### PR TITLE
Add command to update a local Docker Go repo

### DIFF
--- a/cmd/dockerupdate/dockerupdate.go
+++ b/cmd/dockerupdate/dockerupdate.go
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/microsoft/go-infra/buildmodel"
+)
+
+const description = `
+dockerupdate updates a local Go Docker image repository to build images that contain the build of Go
+specified by the given build asset JSON file.
+
+Example: Update the existing repository in a specified directory to the new build listed in a
+assets.json file that has been downloaded to the local machine:
+
+  go run ./cmd/dockerupdate -d ~/git/go-docker -build-asset-json ~/downloads/assets.json
+
+This command is useful to update the Dockerfile contents e.g. when adding Dockerfiles for a new
+branch or changing the Dockerfile templates. The 'dockerupdatepr' command could be used to do this,
+but it has dev cycle overhead that is good to avoid.
+`
+
+func main() {
+	f := buildmodel.BindUpdateFlags()
+	d := flag.String("d", "", "The directory containing the Go Docker repository to update. If empty, uses the current directory.")
+
+	buildmodel.ParseBoundFlags(description)
+
+	if *d == "" {
+		w, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		d = &w
+	}
+
+	if _, err := buildmodel.RunUpdate(*d, f); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("\nSuccess.")
+}

--- a/cmd/dockerupdatepr/dockerupdatepr.go
+++ b/cmd/dockerupdatepr/dockerupdatepr.go
@@ -11,18 +11,19 @@ import (
 )
 
 const description = `
-Example: Create a temporary repo and create a commit that updates the repo to use the build listed
-in the build asset JSON file:
+dockerupdatepr creates a PR that updates the Go Docker image repository to build images that contain
+the build of Go specified by the given build asset JSON file.
 
-  pwsh eng/run.ps1 dockerupdatepr -build-asset-json /home/me/downloads/assets.json -n
+Example dry run that prepares the update locally:
 
-The example command above includes the "-n" dry run arg. Removing that arg makes the command submit
-the change as a GitHub PR.
+  go run ./cmd/dockerupdatepr -build-asset-json /home/me/downloads/assets.json -n
+
+The "-n" is the dry run arg. Removing that arg makes the command submit the change as a GitHub PR.
+
+This command creates a temporary copy of the Go Docker repository in 'eng/artifacts/' by default.
 
 To run this command locally, it may be useful to specify Git addresses like
 'git@github.com:microsoft/go' to use SSH authentication.
-
-This script creates a temporary copy of the Go Docker repository in 'eng/artifacts/' by default.
 `
 
 func main() {


### PR DESCRIPTION
Adds a `dockerupdate` command alongside `dockerupdatepr`.

`dockerupdatepr` requires you to put your branch on a remote for the `-branch` flag, and runs Git operations in a temporary Git directory. This is not very useful when bringing up a whole new major.minor version of Go, because initial work is done locally, and it will likely be manually worked on and submitted as a dev PR.

`dockerupdate` works on an existing Git repo and doesn't run any Git commands, so it's easier to work with when developing nontrivial changes.

Both commands share `UpdateFlags`.
* For `SubmitUpdatePR`, `PRFlags` embeds `UpdateFlags`.
* For `RunUpdate`, `UpdateFlags` is used, plus one directory arg. (It doesn't seem worthwhile to create a command arg struct to contain the single `dockerupdate`-specific arg.)