### PR TITLE
Handle nil when no build asset JSON was passed

### DIFF
--- a/buildmodel/commands.go
+++ b/buildmodel/commands.go
@@ -237,7 +237,12 @@ func SubmitUpdatePR(f *PRFlags) error {
 		return nil
 	}
 
-	runOrPanic(newGitCmd("commit", "-a", "-m", "Update "+b.Name+" to "+r.buildAssets.Version))
+	commitMessage := "Update " + b.Name
+	if r.buildAssets != nil {
+		commitMessage += " to " + r.buildAssets.Version
+	}
+
+	runOrPanic(newGitCmd("commit", "-a", "-m", commitMessage))
 
 	// Push the commit.
 	args := []string{"push", *f.origin, b.PRPushRefspec()}


### PR DESCRIPTION
The `dockerupdatepr` command accepts `-build-assets-json`, but it's also intended to work without one and simply do an update in place. (Regenerate the manifest JSON and Dockerfiles.) But, `r.buildAssets` will be `nil` if there is no build assets JSON, causing a panic at `"Update "+b.Name+" to "+r.buildAssets.Version`. This PR fixes it by handling `nil`.

The `nil` access only exists in `SubmitUpdatePR`, so it's not necessary for local updates (once PR https://github.com/microsoft/go-infra/pull/6 goes in) but it seems like a reasonable fix for parity between the two.