### PR TITLE
Create necessary parent dirs when making work dir

### DIFF
--- a/buildmodel/commands.go
+++ b/buildmodel/commands.go
@@ -137,7 +137,7 @@ func BindPRFlags() *PRFlags {
 // submits the resulting commit as a GitHub PR, approves with a second account, and enables the
 // GitHub auto-merge feature.
 func SubmitUpdatePR(f *PRFlags) error {
-	gitDir, err := GetWorkPathInDir(*f.tempGitDir)
+	gitDir, err := MakeWorkDir(*f.tempGitDir)
 	if err != nil {
 		return err
 	}
@@ -317,12 +317,15 @@ func SubmitUpdatePR(f *PRFlags) error {
 	return nil
 }
 
-// GetWorkPathInDir creates a unique path inside the given root dir to use as a workspace. The name
+// MakeWorkDir creates a unique path inside the given root dir to use as a workspace. The name
 // starts with the local time in a sortable format to help with browsing multiple workspaces. This
 // function allows a command to run multiple times in sequence without overwriting or deleting the
-// old data, for diagnostic purposes.
-func GetWorkPathInDir(rootDir string) (string, error) {
+// old data, for diagnostic purposes. This function uses os.MkdirAll to ensure the root dir exists.
+func MakeWorkDir(rootDir string) (string, error) {
 	pathDate := time.Now().Format("2006-01-02_15-04-05")
+	if err := os.MkdirAll(rootDir, os.ModePerm); err != nil {
+		return "", err
+	}
 	return os.MkdirTemp(rootDir, fmt.Sprintf("%s_*", pathDate))
 }
 

--- a/buildmodel/commands_test.go
+++ b/buildmodel/commands_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package buildmodel
+
+import (
+	"path"
+	"testing"
+)
+
+func TestMakeWorkDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		rootDir string
+	}{
+		{"InsideExistingDir", t.TempDir()},
+		{"InsideNonexistentDir", path.Join(t.TempDir(), "nonexistent")},
+		{"DeeplyInsideNonexistentDir", path.Join(t.TempDir(), "nonexistent", "a", "b", "c")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := MakeWorkDir(tt.rootDir)
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -83,7 +83,7 @@ func main() {
 		fmt.Printf("No entries found in config file: %v\n", *syncConfig)
 	}
 
-	currentRunGitDir, err := buildmodel.GetWorkPathInDir(*tempGitDir)
+	currentRunGitDir, err := buildmodel.MakeWorkDir(*tempGitDir)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
Also rename func from "GetWorkPathInDir" to "MakeWorkDir" because the func doesn't just get a path, it also creates the directory.

Include a very simple unit test to confirm the parent dir creation behavior.

* Fixes issue with https://github.com/microsoft/go-infra/pull/9
* For https://github.com/microsoft/go/issues/244