### PR TITLE
Fix sync pipeline trigger branch: main

### DIFF
--- a/eng/pipelines/sync-pipeline.yml
+++ b/eng/pipelines/sync-pipeline.yml
@@ -8,7 +8,7 @@ schedules:
     displayName: Sync from upstream three times a week
     branches:
       include:
-        - microsoft/main
+        - main
     always: true
 
 variables:


### PR DESCRIPTION
Our sync pipeline isn't running on its schedule. I triggered a manual build to get another flow started, and this PR should fix it going forward.

When I merge this, I'll set a calendar appointment to remember to check back and make sure it really triggers now. 😅 