### PR TITLE
Update go-images auto-update triggers

### DIFF
--- a/eng/pipelines/go-update.yml
+++ b/eng/pipelines/go-update.yml
@@ -11,8 +11,13 @@ resources:
       trigger:
         branches:
           include:
-            - microsoft/main
+            # go-images doesn't currently have a place for updates from microsoft/main to go. This
+            # should be addressed once the repo has a nightly branch:
+            # https://github.com/microsoft/go/issues/169. Until then, don't trigger on
+            # microsoft/main because those updates will always fail to generate.
+            # - microsoft/main
             - microsoft/release-branch.*
+            - dev/official/*
 
 variables:
   - group: Microsoft-GoLang-bot


### PR DESCRIPTION
Add `dev/official/*`: after https://github.com/microsoft/go/pull/316 removed the newline from the `VERSION` file in our current dev branch, this auto-update flow should work. This PR adds the trigger now that it won't constantly result in an error.

Remove `microsoft/main`: it always fails and makes the build status noisy. (See code comment for details.)

Queueing with `dev/official/go1.17-openssl-fips` works: https://dev.azure.com/dnceng/internal/_build/results?buildId=1515243&view=results produced https://github.com/microsoft/go-images/pull/38.