### PR TITLE
Add sync support for dev branches and tune PR description

### DIFF
--- a/cmd/sync/model.go
+++ b/cmd/sync/model.go
@@ -16,12 +16,19 @@ type SyncConfigEntry struct {
 	// the value of Target. This can be used to run the PR from a GitHub fork.
 	Head string
 
-	// SourceBranches is the list of branches in Upstream to merge into Target.
-	SourceBranches []string
+	// UpstreamMergeBranches is the list of branches in Upstream to merge into Target, where Target
+	// is a fork repo of Upstream. The branch name in Target associated with each Upstream branch is
+	// determined automatically, including a "microsoft/" prefix to distinguish it.
+	UpstreamMergeBranches []string
+	// MergeMap is a map of source branch name in Upstream to target branch name in Target. This map
+	// should only be used by the configuration file when there is no reasonable way to determine
+	// the target branch name automatically, like UpstreamMergeBranches.
+	MergeMap map[string]string
 
-	// AutoResolveOurs contains files and dirs that upstream may modify, but we want to ignore those
-	// modifications and keep our changes to them. Normally our files are all in the 'eng/'
-	// directory, but some files are required by GitHub to be in the root of the repo or in the
-	// '.github' directory. In those cases, we must modify them in place and auto-resolve conflicts.
-	AutoResolveOurs []string
+	// AutoResolveTarget lists files and dirs that Upstream may have modified, but we want to keep
+	// the contents as they are in Target. Normally files that are modified in our fork repos are
+	// all in the 'eng/' directory to avoid merge conflicts (and keep the repository tidy), but in
+	// some cases this isn't possible. In these cases, Target has in-place modifications that must
+	// be auto-resolved during the sync process.
+	AutoResolveTarget []string
 }

--- a/docs/automation/sync.md
+++ b/docs/automation/sync.md
@@ -1,0 +1,8 @@
+# Automated branch sync
+
+microsoft/go-infra implements branch sync infrastructure for the Microsoft Go repositories. Sync is used to keep Microsoft's repos up to date with upstream repos, and to update dev branches with the latest changes from their upstream branches. This sometimes involves automatically resolving merge conflicts, so the infra is implemented here rather than relying on existing infra that assumes clean merges.
+
+* [/eng/sync-config.json](/eng/sync-config.json) configures the list of branches to sync.
+* [/cmd/sync/model.go](/cmd/sync/model.go) documents the configuration file format.
+* [/cmd/sync/sync.go](/cmd/sync/sync.go) contains the sync command entrypoint.
+* [/eng/pipelines/sync-pipeline.yml](/eng/pipelines/sync-pipeline.yml) is the pipeline that periodically runs sync, and it defines the schedule shared by all configurations.

--- a/eng/pipelines/sync-pipeline.yml
+++ b/eng/pipelines/sync-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - pwsh: |
           go run ./cmd/sync `
-            -git-auth-pat `
+            -git-auth pat `
             -github-user microsoft-golang-bot `
             -github-pat $(BotAccount-microsoft-golang-bot-PAT) `
             -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT)

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -2,13 +2,13 @@
   {
     "Upstream": "https://go.googlesource.com/go",
     "Target": "https://github.com/microsoft/go",
-    "SourceBranches": [
+    "UpstreamMergeBranches": [
       "master",
       "release-branch.go1.15",
       "release-branch.go1.16",
       "release-branch.go1.17"
     ],
-    "AutoResolveOurs": [
+    "AutoResolveTarget": [
       ".gitattributes",
       ".github",
       "CODE_OF_CONDUCT.md",
@@ -18,12 +18,19 @@
     ]
   },
   {
+    "Upstream": "https://github.com/microsoft/go",
+    "Target": "https://github.com/microsoft/go",
+    "MergeMap": {
+      "microsoft/release-branch.go1.17": "dev/official/go1.17-openssl-fips"
+    }
+  },
+  {
     "Upstream": "https://github.com/docker-library/golang",
     "Target": "https://github.com/microsoft/go-images",
-    "SourceBranches": [
+    "UpstreamMergeBranches": [
       "master"
     ],
-    "AutoResolveOurs": [
+    "AutoResolveTarget": [
       ".gitattributes",
       ".github",
       ".gitignore",

--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -66,18 +66,6 @@ type SyncPRRefSet struct {
 	PRRefSet
 }
 
-// NewSyncPRRefSet creates a SyncPRRefSet based on the name of an upstream branch. Mapping from
-// upstream branch name to "microsoft/"-prefixed branch name happens here.
-func NewSyncPRRefSet(upstreamName string) *SyncPRRefSet {
-	return &SyncPRRefSet{
-		upstreamName,
-		PRRefSet{
-			Name:    "microsoft/" + strings.ReplaceAll(upstreamName, "master", "main"),
-			Purpose: "auto-merge",
-		},
-	}
-}
-
 // UpstreamLocalBranch is the name of the upstream ref after it has been fetched locally.
 func (b SyncPRRefSet) UpstreamLocalBranch() string {
 	return "fetched-upstream/" + b.UpstreamName


### PR DESCRIPTION
This PR adds automatic merges from `microsoft/release-branch.go1.17` into `dev/official/go1.17-openssl-fips`.

I touched up the PR description a bit. The main change was to truncate the diff after 200 lines to avoid potential issues with unbounded output. (See code comment.) I went after this right now because with dev branches, the diff could get very large depending on what's being worked on. While I was there, added a couple more things:
* A link to a doc that points at the sync config and entrypoint.
* A collapsible section for the file diff, because usually when you look at one of these PRs, it's because it failed, and this diff isn't useful.

Example PR: https://github.com/dagood/go/pull/9