### PR TITLE
Create submodule sync with mirroring

### DIFF
--- a/cmd/sync/model.go
+++ b/cmd/sync/model.go
@@ -8,6 +8,23 @@ package main
 type SyncConfigEntry struct {
 	// Upstream is the upstream Git repository to take updates from.
 	Upstream string
+
+	// UpstreamMirror is an optional upstream-maintained mirror of the Upstream repository.
+	// Specifically, for Upstream 'https://go.googlesource.com/go', the UpstreamMirror is
+	// 'https://github.com/golang/go'.
+	//
+	// When updating a submodule, sync checks both repos and only updates to a version that is in
+	// both. This ensures our dev process doesn't have a strong dependency on one copy of upstream's
+	// code or the other, and makes it reasonable to point the submodule at the GitHub mirror of Go
+	// by default, which has a better appearance in the GitHub UI for a submodule: a clickable link.
+	//
+	// When merging a fork, the check is skipped. A fork inherently mirrors the upstream code, so
+	// there is no reason to look for a common version and hold back.
+	//
+	// If UpstreamMirror is not defined (default), the update simply uses the latest version of
+	// Upstream.
+	UpstreamMirror string
+
 	// Target is the GitHub repository to merge into, then submit the PR onto. It must be an https
 	// github.com URL. Other arguments passed to the sync tool may transform this URL into a
 	// different URL that works with authentication.
@@ -15,15 +32,16 @@ type SyncConfigEntry struct {
 	// Head is the GitHub repository to store the merged branch on. If not specified, defaults to
 	// the value of Target. This can be used to run the PR from a GitHub fork.
 	Head string
+	// MirrorTarget	is an optional Git repository to push the upstream branch to. All mirroring
+	// operations must succeed before sync continues with this sync config entry. The mirror target
+	// is intended to be an internal repo, for reliability and security purposes.
+	MirrorTarget string
 
-	// UpstreamMergeBranches is the list of branches in Upstream to merge into Target, where Target
-	// is a fork repo of Upstream. The branch name in Target associated with each Upstream branch is
-	// determined automatically, including a "microsoft/" prefix to distinguish it.
-	UpstreamMergeBranches []string
-	// MergeMap is a map of source branch name in Upstream to target branch name in Target. This map
-	// should only be used by the configuration file when there is no reasonable way to determine
-	// the target branch name automatically, like UpstreamMergeBranches.
-	MergeMap map[string]string
+	// BranchMap is a map of source branch names in Upstream (keys) to use to update a corresponding
+	// branch in Target (values), where Target is either a fork repo of Upstream or contains a
+	// submodule of Upstream. If the value contains "?" (not a valid branch character), "?" is
+	// replaced with the upstream branch name.
+	BranchMap map[string]string
 
 	// AutoResolveTarget lists files and dirs that Upstream may have modified, but we want to keep
 	// the contents as they are in Target. Normally files that are modified in our fork repos are
@@ -31,4 +49,9 @@ type SyncConfigEntry struct {
 	// some cases this isn't possible. In these cases, Target has in-place modifications that must
 	// be auto-resolved during the sync process.
 	AutoResolveTarget []string
+	// SubmoduleTarget is the path of a submodule in the Target repo to update with the latest
+	// version of Upstream and UpstreamMirror (if specified). If this option is not specified
+	// (default), that indicates the entire Upstream repository should be merged into the Target
+	// repository.
+	SubmoduleTarget string
 }

--- a/cmd/sync/model.go
+++ b/cmd/sync/model.go
@@ -8,7 +8,6 @@ package main
 type SyncConfigEntry struct {
 	// Upstream is the upstream Git repository to take updates from.
 	Upstream string
-
 	// UpstreamMirror is an optional upstream-maintained mirror of the Upstream repository.
 	// Specifically, for Upstream 'https://go.googlesource.com/go', the UpstreamMirror is
 	// 'https://github.com/golang/go'.

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -48,6 +48,8 @@ var githubUser = flag.String("github-user", "", "Use this github user to submit 
 var githubPAT = flag.String("github-pat", "", "Submit the PR with this GitHub PAT, if specified.")
 var githubPATReviewer = flag.String("github-pat-reviewer", "", "Approve the PR and turn on auto-merge with this PAT, if specified. Required, if github-pat specified.")
 
+var azdoDncengPAT = flag.String("azdo-dnceng-pat", "", "Use this Azure DevOps PAT to authenticate to dnceng project HTTPS Git URLs.")
+
 // maxDiffLinesToDisplay is the number of lines of the file diff to show in the console log and
 // include in the PR description before truncating the remaining lines. A dev branch may have a
 // large number of changes that can cause issues like extremely long email notifications, breaking
@@ -55,6 +57,15 @@ var githubPATReviewer = flag.String("github-pat-reviewer", "", "Approve the PR a
 // to the time it takes to log (in particular on Windows terminals). This infra hasn't hit these
 // issues, but other tools have hit some, and it seems reasonable to set a limit ahead of time.
 const maxDiffLinesToDisplay = 200
+
+var (
+	// maxUpstreamCommitMessageInSnippet is the maximum number of characters to include in the
+	// commit message snippet for a submodule update commit message. The snippet gives context to
+	// the current submodule pointer in a "git log" or when viewed on GitHub.
+	maxUpstreamCommitMessageInSnippet = 40
+	// snippetCutoffIndicator is the text to put at the end of the snippet when it is cut off.
+	snippetCutoffIndicator = "[...]"
+)
 
 // GitAuthOption contains a string value given on the command line to indicate what type of auth to
 // use with GitHub URLs.
@@ -133,6 +144,8 @@ func main() {
 		// Add authentication to Target and Upstream URLs if necessary.
 		entry.Target = createAuthorizedGitUrl(entry.Target, gitAuth)
 		entry.Upstream = createAuthorizedGitUrl(entry.Upstream, gitAuth)
+		entry.UpstreamMirror = createAuthorizedGitUrl(entry.UpstreamMirror, gitAuth)
+		entry.MirrorTarget = createAuthorizedGitUrl(entry.MirrorTarget, gitAuth)
 
 		if entry.Head == "" {
 			entry.Head = entry.Target
@@ -174,14 +187,23 @@ func createAuthorizedGitUrl(url string, gitAuth GitAuthOption) string {
 			break
 		}
 	}
+	const azdoDncengPrefix = "https://dnceng@dev.azure.com"
+	if strings.HasPrefix(url, azdoDncengPrefix) {
+		url = fmt.Sprintf(
+			// Username doesn't matter. PAT is identity.
+			"https://arbitraryusername:%v@dev.azure.com%v",
+			*azdoDncengPAT, strings.TrimPrefix(url, azdoDncengPrefix),
+		)
+	}
 	return url
 }
 
 // changedBranch stores the refs that have changes that need to be submitted in a PR, and the diff
 // of files being changed in the PR for use in the PR body.
 type changedBranch struct {
-	Refs *gitpr.SyncPRRefSet
-	Diff string
+	Refs    *gitpr.SyncPRRefSet
+	Diff    string
+	PRTitle string
 }
 
 func syncRepository(dir string, entry SyncConfigEntry) error {
@@ -196,24 +218,13 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 		return c
 	}
 
-	branches := make([]*gitpr.SyncPRRefSet, 0, len(entry.UpstreamMergeBranches)+len(entry.MergeMap))
-	for _, b := range entry.UpstreamMergeBranches {
-		// Map from upstream branch name to "microsoft/"-prefixed branch name.
-		nb := &gitpr.SyncPRRefSet{
-			UpstreamName: b,
-			PRRefSet: gitpr.PRRefSet{
-				Name:    "microsoft/" + strings.ReplaceAll(b, "master", "main"),
-				Purpose: "auto-merge",
-			},
-		}
-		branches = append(branches, nb)
-	}
-	for upstream, target := range entry.MergeMap {
+	branches := make([]*gitpr.SyncPRRefSet, 0, len(entry.BranchMap))
+	for upstream, target := range entry.BranchMap {
 		nb := &gitpr.SyncPRRefSet{
 			UpstreamName: upstream,
 			PRRefSet: gitpr.PRRefSet{
-				Name:    target,
-				Purpose: "auto-merge",
+				Name:    strings.ReplaceAll(target, "?", upstream),
+				Purpose: "auto-sync",
 			},
 		}
 		branches = append(branches, nb)
@@ -238,6 +249,34 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 		return err
 	}
 
+	// Fetch the state of the official/upstream-maintained mirror (if specified) so we can check
+	// against it later.
+	if entry.UpstreamMirror != "" {
+		fetchUpstreamMirror := newGitCmd("fetch", "--no-tags", entry.UpstreamMirror)
+		for _, b := range branches {
+			fetchUpstreamMirror.Args = append(fetchUpstreamMirror.Args, b.UpstreamMirrorFetchRefspec())
+		}
+		if err := run(fetchUpstreamMirror); err != nil {
+			return err
+		}
+	}
+
+	// Before attempting any update, mirror everything (if specified). Only continue once this is
+	// complete, to avoid a potentially broken internal build state.
+	if entry.MirrorTarget != "" {
+		mirror := newGitCmd("push", entry.MirrorTarget)
+		for _, b := range branches {
+			mirror.Args = append(mirror.Args, b.UpstreamMirrorRefspec())
+		}
+		if *dryRun {
+			mirror.Args = append(mirror.Args, "-n")
+		}
+
+		if err := run(mirror); err != nil {
+			return err
+		}
+	}
+
 	// While looping through the branches and trying to sync, use this slice to keep track of which
 	// branches have changes, so we can push changes and submit PRs later.
 	changedBranches := make([]changedBranch, 0, len(branches))
@@ -249,22 +288,88 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			return err
 		}
 
-		if err := run(newGitCmd("merge", "--no-ff", "--no-commit", b.UpstreamLocalBranch())); err != nil {
-			if exitError, ok := err.(*exec.ExitError); ok {
-				fmt.Printf("---- Merge hit an ExitError: '%v'. A non-zero exit code is expected if there were conflicts. The script will try to resolve them, next.\n", exitError)
-			} else {
-				// Make sure we don't ignore more than we intended.
-				return err
-			}
-		}
+		c := changedBranch{Refs: b}
+		var commitMessage string
 
-		if len(entry.AutoResolveTarget) > 0 {
-			// Automatically resolve conflicts in specific project doc files. Use '--no-overlay' to make
-			// sure we delete new files in e.g. '.github' that are in upstream but don't exist locally.
-			// '--ours' auto-deletes if upstream modifies a file that we deleted in our branch.
-			if err := run(newGitCmd(append([]string{"checkout", "--no-overlay", "--ours", "HEAD", "--"}, entry.AutoResolveTarget...)...)); err != nil {
+		if entry.SubmoduleTarget == "" {
+			// This is not a submodule update, so merge with the upstream repository.
+			if err := run(newGitCmd("merge", "--no-ff", "--no-commit", b.UpstreamLocalBranch())); err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					fmt.Printf("---- Merge hit an ExitError: '%v'. A non-zero exit code is expected if there were conflicts. The script will try to resolve them, next.\n", exitError)
+				} else {
+					// Make sure we don't ignore more than we intended.
+					return err
+				}
+			}
+
+			if len(entry.AutoResolveTarget) > 0 {
+				// Automatically resolve conflicts in specific project doc files. Use '--no-overlay' to make
+				// sure we delete new files in e.g. '.github' that are in upstream but don't exist locally.
+				// '--ours' auto-deletes if upstream modifies a file that we deleted in our branch.
+				if err := run(newGitCmd(append([]string{"checkout", "--no-overlay", "--ours", "HEAD", "--"}, entry.AutoResolveTarget...)...)); err != nil {
+					return err
+				}
+			}
+			c.PRTitle = fmt.Sprintf("Merge upstream `%v` into `%v`", b.UpstreamName, b.Name)
+			commitMessage = fmt.Sprintf("Merge upstream branch '%v' into %v", b.UpstreamName, b.Name)
+		} else {
+			// This is a submodule update. We'll be doing more evaluation to figure out which commit
+			// to update to, so define a helper func with captured context.
+			getTrimmedCmdOutput := func(args ...string) (string, error) {
+				out, err := combinedOutput(newGitCmd(args...))
+				if err != nil {
+					return "", err
+				}
+				return strings.TrimSpace(out), nil
+			}
+
+			// This update uses a submodule, so find the latest version of upstream and update the
+			// submodule to point at it.
+			newCommit, err := getTrimmedCmdOutput("rev-parse", b.UpstreamLocalBranch())
+			if err != nil {
 				return err
 			}
+
+			// Get the latest commit available in every known official location.
+			if entry.UpstreamMirror != "" {
+				upstreamMirrorCommit, err := getTrimmedCmdOutput("rev-parse", b.UpstreamMirrorLocalBranch())
+				if err != nil {
+					return err
+				}
+				if newCommit != upstreamMirrorCommit {
+					// Point out mismatches, so we can keep track of them later by searching logs.
+					// This happening normally isn't a concern: our sync schedule most likely
+					// coincided with the potential time window where a commit has been pushed to
+					// Upstream before being pushed to UpstreamMirror.
+					fmt.Printf("--- Upstream and upstream mirror commits do not match: %v != %v\n", newCommit, upstreamMirrorCommit)
+				}
+
+				commonCommit, err := getTrimmedCmdOutput("merge-base", newCommit, upstreamMirrorCommit)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("---- Common commit of upstream and upstream mirror: %v\n", commonCommit)
+				newCommit = commonCommit
+			}
+
+			// Set the submodule commit directly in the Git index. This avoids the need to
+			// init/clone the submodule, which can be time-consuming. Mode 160000 means the tree
+			// entry is a submodule.
+			cacheInfo := fmt.Sprintf("160000,%v,%v", newCommit, entry.SubmoduleTarget)
+			if err := run(newGitCmd("update-index", "--cacheinfo", cacheInfo)); err != nil {
+				return err
+			}
+
+			upstreamCommitMessage, err := getTrimmedCmdOutput("log", "--format=%B", "-n", "1", newCommit)
+			if err != nil {
+				return err
+			}
+			snippet, err := createCommitMessageSnippet(upstreamCommitMessage)
+			if err != nil {
+				return err
+			}
+			c.PRTitle = fmt.Sprintf("Update submodule to latest `%v` in `%v`", b.UpstreamName, b.Name)
+			commitMessage = fmt.Sprintf("Update submodule to latest %v (%v): %v", b.UpstreamName, newCommit[:8], snippet)
 		}
 
 		// Check if there are any files in the stage. If not, we don't need to process this branch
@@ -284,48 +389,47 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 
 		// If we still have unmerged files, 'git commit' will exit non-zero, causing the script to
 		// exit. This prevents the script from pushing a bad merge.
-		if err := run(newGitCmd("commit", "-m", "Merge upstream branch '"+b.UpstreamName+"' into "+b.Name)); err != nil {
+		if err := run(newGitCmd("commit", "-m", commitMessage)); err != nil {
 			return err
 		}
 
-		// Show a summary of which files are in our branch vs. upstream. This is just informational.
-		// CI is a better place to *enforce* a low diff: it's more visible, can be fixed up more
-		// easily, and doesn't block other branch mirror/merge operations.
-		diff, err := combinedOutput(newGitCmd(
-			"diff",
-			"--name-status",
-			b.UpstreamLocalBranch(),
-			b.PRBranch(),
-		))
-		if err != nil {
-			return err
-		}
-
-		// The diff may be large. Truncate it if it seems unreasonable to show on the console, or to
-		// include in a PR description. The user can use Git to dig deeper if needed.
-		var diffLines strings.Builder
-		diffLineScanner := bufio.NewScanner(strings.NewReader(diff))
-		for lineNumber := 0; diffLineScanner.Scan(); lineNumber++ {
-			if err := diffLineScanner.Err(); err != nil {
+		if entry.SubmoduleTarget == "" {
+			// Show a summary of which files are in our fork branch vs. upstream. This is just
+			// informational. CI is a better place to *enforce* a low diff: it's more visible, can
+			// be fixed up more easily, and doesn't block other branch mirror/merge operations.
+			diff, err := combinedOutput(newGitCmd(
+				"diff",
+				"--name-status",
+				b.UpstreamLocalBranch(),
+				b.PRBranch(),
+			))
+			if err != nil {
 				return err
 			}
-			if lineNumber == maxDiffLinesToDisplay {
-				diffLines.WriteString(fmt.Sprintf("Diff truncated: contains more than %v lines.\n", maxDiffLinesToDisplay))
-				break
+
+			// The diff may be large. Truncate it if it seems unreasonable to show on the console, or to
+			// include in a PR description. The user can use Git to dig deeper if needed.
+			var diffLines strings.Builder
+			diffLineScanner := bufio.NewScanner(strings.NewReader(diff))
+			for lineNumber := 0; diffLineScanner.Scan(); lineNumber++ {
+				if err := diffLineScanner.Err(); err != nil {
+					return err
+				}
+				if lineNumber == maxDiffLinesToDisplay {
+					diffLines.WriteString(fmt.Sprintf("Diff truncated: contains more than %v lines.\n", maxDiffLinesToDisplay))
+					break
+				}
+				diffLines.WriteString(diffLineScanner.Text())
+				diffLines.WriteString("\n")
 			}
-			diffLines.WriteString(diffLineScanner.Text())
-			diffLines.WriteString("\n")
+			c.Diff = diffLines.String()
+
+			fmt.Printf("---- Files changed from '%v' to '%v' ----\n", b.UpstreamName, b.Name)
+			fmt.Print(diff)
+			fmt.Println("--------")
 		}
-		diff = diffLines.String()
 
-		fmt.Printf("---- Files changed from '%v' to '%v' ----\n", b.UpstreamName, b.Name)
-		fmt.Print(diff)
-		fmt.Println("--------")
-
-		changedBranches = append(changedBranches, changedBranch{
-			Refs: b,
-			Diff: diff,
-		})
+		changedBranches = append(changedBranches, c)
 	}
 
 	if len(changedBranches) == 0 {
@@ -413,19 +517,31 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 		err := func() error {
 			fmt.Printf("---- PR for %v: Submitting...\n", prFlowDescription)
 
-			title := fmt.Sprintf("Merge upstream `%v` into `%v`", b.Refs.UpstreamName, b.Refs.Name)
-			body := fmt.Sprintf(
-				"🔃 This is an automatically generated PR merging upstream `%v` into `%v`.\n\n"+
-					"This PR is configured to auto-merge with a merge commit when PR validation passes. If CI fails and you need to make fixups, make sure to use a merge commit, not a squash or rebase!\n\n"+
-					"For more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md).\n\n"+
-					"<details><summary>Click on this text to view the file difference between this branch and upstream.</summary>\n\n"+
-					"```\n%v\n```"+
-					"\n\n</details>",
-				b.Refs.UpstreamName,
-				b.Refs.Name,
-				strings.TrimSpace(b.Diff),
-			)
-			request := b.Refs.CreateGitHubPR(parsedPRHeadRemote.GetOwner(), title, body)
+			body := "Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃" +
+				"\n\nAfter submitting the PR, I will attempt to enable auto-merge in the \"merge commit\" configuration.\n\n" +
+				"\n\nFor more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md)."
+			if entry.SubmoduleTarget != "" {
+				body += fmt.Sprintf(
+					"\n\nThis PR updates the submodule at `%v` to the latest version of `%v` at %v.",
+					entry.SubmoduleTarget, b.Refs.UpstreamName, entry.Upstream,
+				)
+			} else {
+				body += fmt.Sprintf(
+					"\n\nThis PR merges `%v` into `%v`.\n\nIf PR validation fails and you need to fix up the PR, make sure to use a merge commit, not a squash or rebase!",
+					b.Refs.UpstreamName, b.Refs.Name,
+				)
+			}
+			if b.Diff != "" {
+				body += fmt.Sprintf(
+					"\n\n"+
+						"<details><summary>Click on this text to view the file difference between this branch and upstream.</summary>\n\n"+
+						"```\n%v\n```"+
+						"\n\n</details>",
+					b.Diff,
+				)
+			}
+
+			request := b.Refs.CreateGitHubPR(parsedPRHeadRemote.GetOwner(), b.PRTitle, body)
 
 			// POST the PR. The call returns success if the PR is created or if we receive a
 			// specific error message back from GitHub saying the PR is already created.
@@ -517,4 +633,18 @@ func combinedOutput(c *exec.Cmd) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+func createCommitMessageSnippet(message string) (string, error) {
+	s := bufio.NewScanner(strings.NewReader(message))
+	s.Scan()
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+
+	snippet := s.Text()
+	if len(snippet) > maxUpstreamCommitMessageInSnippet {
+		snippet = snippet[:maxUpstreamCommitMessageInSnippet-len(snippetCutoffIndicator)+1] + snippetCutoffIndicator
+	}
+	return snippet, nil
 }

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_createCommitMessageSnippet(t *testing.T) {
+	maxUpstreamCommitMessageInSnippet = 20
+	snippetCutoffIndicator = "[...]"
+
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{"short", "Test message", "Test message"},
+		{
+			"near cutoff",
+			"12345678901234567890",
+			"12345678901234567890",
+		},
+		{
+			"one past cutoff",
+			"12345678901234567890-",
+			"1234567890123456[...]",
+		},
+		{
+			"three past cutoff",
+			"12345678901234567890---",
+			"1234567890123456[...]",
+		},
+		{"long", strings.Repeat("words ", 80), "words words word[...]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := createCommitMessageSnippet(tt.message)
+			if err != nil {
+				t.Errorf("createCommitMessageSnippet() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("createCommitMessageSnippet() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -17,6 +17,7 @@ func Test_createCommitMessageSnippet(t *testing.T) {
 		message string
 		want    string
 	}{
+		// Test snippet truncation.
 		{"short", "Test message", "Test message"},
 		{
 			"near cutoff",
@@ -34,15 +35,14 @@ func Test_createCommitMessageSnippet(t *testing.T) {
 			"1234567890123456[...]",
 		},
 		{"long", strings.Repeat("words ", 80), "words words word[...]"},
+
+		// Test that snippet creation only takes the first line.
+		{"newline", "PR Title\nContent", "PR Title"},
+		{"newline Windows", "PR Title\r\nContent", "PR Title"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := createCommitMessageSnippet(tt.message)
-			if err != nil {
-				t.Errorf("createCommitMessageSnippet() error = %v", err)
-				return
-			}
-			if got != tt.want {
+			if got := createCommitMessageSnippet(tt.message); got != tt.want {
 				t.Errorf("createCommitMessageSnippet() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/eng/pipelines/sync-pipeline.yml
+++ b/eng/pipelines/sync-pipeline.yml
@@ -13,6 +13,7 @@ schedules:
 
 variables:
   - group: Microsoft-GoLang-bot
+  - group: DotNet-VSTS-Infra-Access
 
 jobs:
   - job: Sync
@@ -32,5 +33,6 @@ jobs:
             -git-auth pat `
             -github-user microsoft-golang-bot `
             -github-pat $(BotAccount-microsoft-golang-bot-PAT) `
-            -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT)
+            -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT) `
+            -azdo-dnceng-pat $(dn-bot-dnceng-build-rw-code-rw)
         displayName: Sync

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -19,16 +19,6 @@
     ]
   },
   {
-    "Upstream": "https://go.googlesource.com/go",
-    "UpstreamMirror": "https://github.com/golang/go",
-    "Target": "https://github.com/microsoft/go",
-    "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
-    "BranchMap": {
-      "release-branch.go1.17": "dev/dagood/submodule-1.17"
-    },
-    "SubmoduleTarget": "go"
-  },
-  {
     "Upstream": "https://github.com/microsoft/go",
     "Target": "https://github.com/microsoft/go",
     "BranchMap": {

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -2,13 +2,13 @@
   {
     "Upstream": "https://go.googlesource.com/go",
     "Target": "https://github.com/microsoft/go",
-    "UpstreamMergeBranches": [
-      "master",
-      "release-branch.go1.15",
-      "release-branch.go1.16",
-      "release-branch.go1.17",
-      "dev.boringcrypto.go1.17"
-    ],
+    "BranchMap": {
+      "master": "microsoft/main",
+      "release-branch.go1.15": "microsoft/?",
+      "release-branch.go1.16": "microsoft/?",
+      "release-branch.go1.17": "microsoft/?",
+      "dev.boringcrypto.go1.17": "microsoft/?"
+    },
     "AutoResolveTarget": [
       ".gitattributes",
       ".github",
@@ -19,18 +19,28 @@
     ]
   },
   {
+    "Upstream": "https://go.googlesource.com/go",
+    "UpstreamMirror": "https://github.com/golang/go",
+    "Target": "https://github.com/microsoft/go",
+    "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
+    "BranchMap": {
+      "release-branch.go1.17": "dev/dagood/submodule-1.17"
+    },
+    "SubmoduleTarget": "go"
+  },
+  {
     "Upstream": "https://github.com/microsoft/go",
     "Target": "https://github.com/microsoft/go",
-    "MergeMap": {
+    "BranchMap": {
       "microsoft/release-branch.go1.17": "dev/official/go1.17-openssl-fips"
     }
   },
   {
     "Upstream": "https://github.com/docker-library/golang",
     "Target": "https://github.com/microsoft/go-images",
-    "UpstreamMergeBranches": [
-      "master"
-    ],
+    "BranchMap": {
+      "master": "microsoft/main"
+    },
     "AutoResolveTarget": [
       ".gitattributes",
       ".github",

--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -71,9 +71,27 @@ func (b SyncPRRefSet) UpstreamLocalBranch() string {
 	return "fetched-upstream/" + b.UpstreamName
 }
 
+// UpstreamMirrorLocalBranch is the name of the upstream ref after it has been fetched locally from
+// the mirror of the upstream.
+func (b SyncPRRefSet) UpstreamMirrorLocalBranch() string {
+	return "fetched-upstream-mirror/" + b.UpstreamName
+}
+
 // UpstreamFetchRefspec fetches the current upstream ref into the local branch.
 func (b SyncPRRefSet) UpstreamFetchRefspec() string {
 	return createRefspec(b.UpstreamName, b.UpstreamLocalBranch())
+}
+
+// UpstreamMirrorFetchRefspec fetches the current upstream ref as it is in an upstream mirror into a
+// local branch.
+func (b SyncPRRefSet) UpstreamMirrorFetchRefspec() string {
+	return createRefspec(b.UpstreamName, b.UpstreamMirrorLocalBranch())
+}
+
+// UpstreamMirrorRefspec is the refspec that mirrors the original branch name to the same name in another
+// repo. This can be used with "push" for a mirror operation.
+func (b SyncPRRefSet) UpstreamMirrorRefspec() string {
+	return createRefspec(b.UpstreamLocalBranch(), b.UpstreamName)
 }
 
 // Remote is a parsed version of a Git Remote. It helps determine how to send a GitHub PR.


### PR DESCRIPTION
* Add functionality for submodules, mirroring to AzDO, and considering the official/upstream mirror when deciding what to update the submodule to.

* Submodule update commits include the upstream commit message's first line, for context if you don't have quick access to the upstream repo. The message is trimmed if it hits a length limit. I added a test for this func in particular because it's a little intricate, and it's not easy to quickly run manual tests on various upstream messages with full `sync` runs.

* Keep old functionality with a little simplification to fit new scenarios, too. `UpstreamMergeBranches` and `MergeMap` are now just `BranchMap`, with a new `?` token to make `release.branch-go1.17 -> microsoft/?` mappings easy to maintain.
  * This also moves the `master -> microsoft/main` special case into the config file, where it's more visible.

I recommend reviewing with whitespace changes hidden--I wrapped a few existing blocks in `if`s.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=1561104&view=results

* Example submodule update: https://github.com/microsoft/go/pull/377
* Example fork merge: https://github.com/microsoft/go/pull/374
* Example branch-to-branch merge: https://github.com/microsoft/go/pull/375

Example submodule sync config:
```json
  {
    "Upstream": "https://go.googlesource.com/go",
    "UpstreamMirror": "https://github.com/golang/go",
    "Target": "https://github.com/microsoft/go",
    "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
    "BranchMap": {
      "release-branch.go1.17": "dev/dagood/submodule-1.17"
    },
    "SubmoduleTarget": "go"
  }
```