### PR TITLE
Add submodule sync for main and imminent release branches

### DIFF
--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -3,11 +3,8 @@
     "Upstream": "https://go.googlesource.com/go",
     "Target": "https://github.com/microsoft/go",
     "BranchMap": {
-      "master": "microsoft/main",
       "release-branch.go1.15": "microsoft/?",
-      "release-branch.go1.16": "microsoft/?",
-      "release-branch.go1.17": "microsoft/?",
-      "dev.boringcrypto.go1.17": "microsoft/?"
+      "release-branch.go1.16": "microsoft/?"
     },
     "AutoResolveTarget": [
       ".gitattributes",
@@ -17,6 +14,18 @@
       "SECURITY.md",
       "SUPPORT.md"
     ]
+  },
+  {
+    "Upstream": "https://go.googlesource.com/go",
+    "UpstreamMirror": "https://github.com/golang/go",
+    "Target": "https://github.com/microsoft/go",
+    "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
+    "BranchMap": {
+      "master": "microsoft/main",
+      "release-branch.go1.17": "microsoft/?",
+      "dev.boringcrypto.go1.17": "microsoft/?"
+    },
+    "SubmoduleTarget": "go"
   },
   {
     "Upstream": "https://github.com/microsoft/go",


### PR DESCRIPTION
Now that https://github.com/microsoft/go/pull/345 is merged, `microsoft/main` is on submodules and needs to switch to a submodule update configuration.

I included `release-branch.go1.17` and `dev.boringcrypto.go1.17` too, because they'll be switching soon. (https://github.com/microsoft/go/pull/379 for `release-branch.go1.17`.) Deleting the old configuration helps avoid merge conflicts while submodule migration PRs are in progress. When the submodule sync pipeline attempts to update `release-branch.go1.17` before the PR is complete, it will fail harmlessly: the tool fails because there's no submodule yet and skips onto the next sync entry.

Based on the model introduced in https://github.com/microsoft/go-infra/pull/19.