### PR TITLE
build asset JSON: handle `go.*.src.tar.gz` files, improve errors

### DIFF
--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -55,6 +55,7 @@ func (b BuildAssets) GetDockerRepoTargetBranch() string {
 // less likely to unintentionally break, so some of that information is duplicated here.
 var archiveSuffixes = []string{".tar.gz", ".zip"}
 var checksumSuffix = ".sha256"
+var sourceArchiveSuffix = ".tar.gz"
 
 // BuildResultsDirectoryInfo points to locations in the filesystem that contain a Go build from
 // source, and includes extra information that helps make sense of the build results.
@@ -122,8 +123,13 @@ func (b BuildResultsDirectoryInfo) CreateSummary() (*BuildAssets, error) {
 			fullPath := path.Join(b.ArtifactsDir, e.Name())
 
 			// Is it a source archive file?
-			if strings.HasSuffix(e.Name(), ".src.tar.gz") {
+			if strings.HasSuffix(e.Name(), sourceArchiveSuffix) {
 				goSrcURL = b.DestinationURL + "/" + e.Name()
+				continue
+			}
+			// Is it a source archive file checksum?
+			if strings.HasSuffix(e.Name(), sourceArchiveSuffix+checksumSuffix) {
+				// The build asset JSON doesn't keep track of this info.
 				continue
 			}
 			// Is it a checksum file?

--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -55,7 +55,7 @@ func (b BuildAssets) GetDockerRepoTargetBranch() string {
 // less likely to unintentionally break, so some of that information is duplicated here.
 var archiveSuffixes = []string{".tar.gz", ".zip"}
 var checksumSuffix = ".sha256"
-var sourceArchiveSuffix = ".tar.gz"
+var sourceArchiveSuffix = ".src.tar.gz"
 
 // BuildResultsDirectoryInfo points to locations in the filesystem that contain a Go build from
 // source, and includes extra information that helps make sense of the build results.


### PR DESCRIPTION
* Fix issue found in testing build for https://github.com/microsoft/go/pull/408
* For https://github.com/microsoft/go/issues/398

Check for `.src.tar.gz` and avoid trying to parse it as a binary build, because it will fail. Also improve the error message in case of failure, and store the source tarball URL in the build asset JSON to make the file more complete.