### PR TITLE
Update automation: submodules, nightly go-images

### DIFF
--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -42,7 +42,7 @@ type BuildAssets struct {
 // updated.
 func (b BuildAssets) GetDockerRepoTargetBranch() string {
 	if b.Branch == "main" || strings.HasPrefix(b.Branch, "release-branch.") {
-		return "microsoft/main"
+		return "microsoft/nightly"
 	}
 	if strings.HasPrefix(b.Branch, "dev/official/") {
 		return b.Branch

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -1,29 +1,15 @@
 [
   {
     "Upstream": "https://go.googlesource.com/go",
-    "Target": "https://github.com/microsoft/go",
-    "BranchMap": {
-      "release-branch.go1.15": "microsoft/?",
-      "release-branch.go1.16": "microsoft/?"
-    },
-    "AutoResolveTarget": [
-      ".gitattributes",
-      ".github",
-      "CODE_OF_CONDUCT.md",
-      "README.md",
-      "SECURITY.md",
-      "SUPPORT.md"
-    ]
-  },
-  {
-    "Upstream": "https://go.googlesource.com/go",
     "UpstreamMirror": "https://github.com/golang/go",
     "Target": "https://github.com/microsoft/go",
     "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
     "BranchMap": {
       "master": "microsoft/main",
       "release-branch.go1.17": "microsoft/?",
-      "dev.boringcrypto.go1.17": "microsoft/?"
+      "dev.boringcrypto.go1.17": "microsoft/?",
+      "release-branch.go1.16": "microsoft/?",
+      "dev.boringcrypto.go1.16": "microsoft/?"
     },
     "SubmoduleTarget": "go"
   },
@@ -38,7 +24,7 @@
     "Upstream": "https://github.com/docker-library/golang",
     "Target": "https://github.com/microsoft/go-images",
     "BranchMap": {
-      "master": "microsoft/main"
+      "master": "microsoft/nightly"
     },
     "AutoResolveTarget": [
       ".gitattributes",


### PR DESCRIPTION
Update our automation configuration in two areas:
* Submodules.
  * We haven't created a 1.15 branch using submodules and removed the old 1.15 branch, so remove this auto-merge config entirely.
  * The 1.16 branch now uses a submodule, so move it to the submodule configuration object.
* go-images nightly branch (https://github.com/microsoft/go-images/pull/52)
  * Change the auto-sync infra to merge upstream into the `microsoft/nightly` branch.
  * Change Docker auto-update (new microsoft/go builds) to submit update PRs to the `microsoft/nightly` branch.
