### PR TITLE
Trigger go-images update for boring branches

### DIFF
--- a/eng/pipelines/go-update.yml
+++ b/eng/pipelines/go-update.yml
@@ -17,6 +17,7 @@ resources:
             # microsoft/main because those updates will always fail to generate.
             # - microsoft/main
             - microsoft/release-branch.*
+            - microsoft/dev.boringcrypto.go*
             - dev/official/*
 
 variables:


### PR DESCRIPTION
We have a place for boring 1.17 builds to fit into in the go-images nightly branch, so enable auto-update trigger. I'm triggering this manually, for now.