### PR TITLE
Update upstream sync for 1.18; update go-images rule for submodules; cleanup

### DIFF
--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -6,19 +6,12 @@
     "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
     "BranchMap": {
       "master": "microsoft/main",
+      "release-branch.go1.18": "microsoft/?",
+      "dev.boringcrypto.go1.18": "microsoft/?",
       "release-branch.go1.17": "microsoft/?",
-      "dev.boringcrypto.go1.17": "microsoft/?",
-      "release-branch.go1.16": "microsoft/?",
-      "dev.boringcrypto.go1.16": "microsoft/?"
+      "dev.boringcrypto.go1.17": "microsoft/?"
     },
     "SubmoduleTarget": "go"
-  },
-  {
-    "Upstream": "https://github.com/microsoft/go",
-    "Target": "https://github.com/microsoft/go",
-    "BranchMap": {
-      "microsoft/release-branch.go1.17": "dev/official/go1.17-openssl-fips"
-    }
   },
   {
     "Upstream": "https://github.com/docker-library/golang",
@@ -26,14 +19,6 @@
     "BranchMap": {
       "master": "microsoft/nightly"
     },
-    "AutoResolveTarget": [
-      ".gitattributes",
-      ".github",
-      ".gitignore",
-      "CODE_OF_CONDUCT.md",
-      "README.md",
-      "SECURITY.md",
-      "SUPPORT.md"
-    ]
+    "SubmoduleTarget": "go"
   }
 ]


### PR DESCRIPTION
A few things I noticed around 1.18:
* Add 1.18 branches, remove 1.16.
* Update go-images rule to use submodules.
* Clean up old dev branch rule.