### PR TITLE
Add initial release-go pipeline for aka.ms links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+## microsoft/go-infra gitignore
+
+# Ignore Arcade C# project artifacts and intermediate output.
+*.binlog
+obj/
+bin/
+
 ## Go gitignore from https://raw.githubusercontent.com/github/gitignore/master/Go.gitignore
 
 # Binaries for programs and plugins

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file. -->
+<!-- This NuGet.config is required in this location by the Arcade SDK, or auto-updates throw errors. -->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -66,9 +66,9 @@ func (b BuildAssets) GetDockerRepoVersionsKey() string {
 	return key
 }
 
-// GetGoVersion parses Version in the format that Microsoft builds of Go use. The BuildAssets file
+// GoVersion parses Version in the format that Microsoft builds of Go use. The BuildAssets file
 // doesn't include the Note (-fips), so this is added based on the branch.
-func (b BuildAssets) GetGoVersion() *goversion.GoVersion {
+func (b BuildAssets) GoVersion() *goversion.GoVersion {
 	v := b.Version
 	if strings.HasPrefix(b.Branch, "dev.boringcrypto") {
 		v += "-fips"

--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/go-infra/buildmodel/dockerversions"
+	"github.com/microsoft/go-infra/goversion"
 )
 
 // BuildAssets is the root object of a build asset JSON file.
@@ -27,7 +28,7 @@ type BuildAssets struct {
 	// BuildID is a link to the build that produced these assets. It is not used for auto-update.
 	BuildID string `json:"buildId"`
 
-	// Version of the build, as 'major.minor.patch-revision'.
+	// Version of the build, as 'major.minor.patch-revision'. Doesn't include version note (-fips).
 	Version string `json:"version"`
 	// Arches is the list of artifacts that was produced for this version, typically one per target
 	// os/architecture. The name "Arches" is shared with the versions.json format.
@@ -56,13 +57,23 @@ func (b BuildAssets) GetDockerRepoTargetBranch() string {
 // GetDockerRepoVersionsKey gets the Docker Versions key that should be updated with new builds
 // listed in this BuildAssets file.
 func (b BuildAssets) GetDockerRepoVersionsKey() string {
-	major, minor, _, _ := ParseVersion(b.Version)
+	v := goversion.New(b.Version)
 
-	key := major + "." + minor
+	key := v.Major + "." + v.Minor
 	if strings.HasPrefix(b.Branch, "dev.boringcrypto") {
 		key = key + "-fips"
 	}
 	return key
+}
+
+// GetGoVersion parses Version in the format that Microsoft builds of Go use. The BuildAssets file
+// doesn't include the Note (-fips), so this is added based on the branch.
+func (b BuildAssets) GetGoVersion() *goversion.GoVersion {
+	v := b.Version
+	if strings.HasPrefix(b.Branch, "dev.boringcrypto") {
+		v += "-fips"
+	}
+	return goversion.New(v)
 }
 
 // Basic information about how the build output assets are formatted by Microsoft builds of Go. The
@@ -224,30 +235,6 @@ func (b BuildResultsDirectoryInfo) CreateSummary() (*BuildAssets, error) {
 		Arches:   arches,
 		GoSrcURL: goSrcURL,
 	}, nil
-}
-
-// ParseVersion parses a "major.minor.patch-revision" version string into each part. If a part
-// doesn't exist, it defaults to "0".
-func ParseVersion(v string) (string, string, string, string) {
-	dashParts := strings.Split(v, "-")
-	majorMinorPatch := dashParts[0]
-	revision := "0"
-	if len(dashParts) > 1 {
-		revision = dashParts[1]
-	}
-
-	dotParts := strings.Split(majorMinorPatch, ".")
-	major := dotParts[0]
-	minor := "0"
-	if len(dotParts) > 1 {
-		minor = dotParts[1]
-	}
-	patch := "0"
-	if len(dotParts) > 2 {
-		patch = dotParts[2]
-	}
-
-	return major, minor, patch, revision
 }
 
 // getVersion reads the file at path, if it exists. If it doesn't exist, returns the default

--- a/buildmodel/buildassets/buildassets_test.go
+++ b/buildmodel/buildassets/buildassets_test.go
@@ -49,62 +49,6 @@ func TestBuildResultsDirectoryInfo_CreateSummary(t *testing.T) {
 	}
 }
 
-func TestBuildAssets_parseVersion(t *testing.T) {
-	tests := []struct {
-		name                          string
-		version                       string
-		major, minor, patch, revision string
-	}{
-		{
-			"Full version",
-			"1.2.3-4",
-			"1", "2", "3", "4",
-		},
-		{
-			"Major only",
-			"1",
-			"1", "0", "0", "0",
-		},
-		{
-			"Major.minor",
-			"1.42",
-			"1", "42", "0", "0",
-		},
-		{
-			"Major.minor-revision",
-			"1.42-6",
-			"1", "42", "0", "6",
-		},
-		{
-			"Too many dotted parts",
-			"1.2.3.4.5.6",
-			"1", "2", "3", "0",
-		},
-		{
-			"Too many dashed parts",
-			"1-2-3-4",
-			"1", "0", "0", "2",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotMajor, gotMinor, gotPatch, gotRevision := ParseVersion(tt.version)
-			if gotMajor != tt.major {
-				t.Errorf("parseVersion() gotMajor = %v, major %v", gotMajor, tt.major)
-			}
-			if gotMinor != tt.minor {
-				t.Errorf("parseVersion() gotMinor = %v, minor %v", gotMinor, tt.minor)
-			}
-			if gotPatch != tt.patch {
-				t.Errorf("parseVersion() gotPatch = %v, patch %v", gotPatch, tt.patch)
-			}
-			if gotRevision != tt.revision {
-				t.Errorf("parseVersion() gotRevision = %v, revision %v", gotRevision, tt.revision)
-			}
-		})
-	}
-}
-
 func Test_getVersion(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoft/go-infra/buildmodel/buildassets"
 	"github.com/microsoft/go-infra/buildmodel/dockermanifest"
 	"github.com/microsoft/go-infra/buildmodel/dockerversions"
+	"github.com/microsoft/go-infra/goversion"
 )
 
 // ReadJSONFile reads one JSON value from the specified file.
@@ -79,7 +80,7 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 		}
 
 		// The key always contains a major.minor version. Split out the major part.
-		major, _, _, _ := buildassets.ParseVersion(majorMinor)
+		major := goversion.New(majorMinor).Major
 
 		majorMinorPatchRevision := v.Version + "-" + v.Revision
 
@@ -210,10 +211,10 @@ var NoMajorMinorUpgradeMatchError = errors.New("no match found in existing versi
 func UpdateVersions(assets *buildassets.BuildAssets, versions dockerversions.Versions) error {
 	key := assets.GetDockerRepoVersionsKey()
 	if v, ok := versions[key]; ok {
-		major, minor, patch, revision := buildassets.ParseVersion(assets.Version)
+		vNew := goversion.New(assets.Version)
 
-		v.Version = major + "." + minor + "." + patch
-		v.Revision = revision
+		v.Version = vNew.MajorMinorPatch()
+		v.Revision = vNew.Revision
 
 		// Look through the asset arches, find an arch in the versions file that matches each asset,
 		// and update its info.

--- a/cmd/update-aka-ms/update-aka-ms.go
+++ b/cmd/update-aka-ms/update-aka-ms.go
@@ -107,18 +107,18 @@ func createAkaMSLinks(assetFilePath string) error {
 		return err
 	}
 
-	propsFileContent, err := propsFileContent(linkPairs)
+	content, err := propsFileContent(linkPairs)
 	if err != nil {
 		return err
 	}
 
 	projectPath := filepath.Join(wd, "eng", "publishing", "UpdateAkaMSLinks", "UpdateAkaMSLinks.csproj")
 	propsPath := filepath.Join(akaMSDir, "AkaMSLinks.props")
-	if err := os.WriteFile(propsPath, []byte(propsFileContent), 0666); err != nil {
+	if err := os.WriteFile(propsPath, []byte(content), 0666); err != nil {
 		return err
 	}
 
-	log.Printf("---- File content for generated file %v\n%v\n", propsPath, propsFileContent)
+	log.Printf("---- File content for generated file %v\n%v\n", propsPath, content)
 
 	cmd := exec.Command(
 		"dotnet", "build", projectPath,

--- a/cmd/update-aka-ms/update-aka-ms.go
+++ b/cmd/update-aka-ms/update-aka-ms.go
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/go-infra/buildmodel"
+	"github.com/microsoft/go-infra/buildmodel/buildassets"
+	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/goversion"
+)
+
+const description = `
+update-aka-ms creates aka.ms links based on a given build asset JSON file. This command uses an
+MSBuild task supplied by .NET Arcade to carry out the communication with aka.ms services. Therefore,
+it must be executed within the go-infra repository, where it can use the eng directory that sets up
+the Arcade task. The .NET SDK must also be installed on the machine, and 'dotnet' on PATH.
+
+Example:
+
+  go run ./cmd/update-aka-ms -build-asset-json /downloads/assets.json -version 1.17.8-1
+
+All non-flag args are passed through to the MSBuild project. Use this to configure the link
+ownership information and to add authentication. Keep in mind that because this command uses the
+standard flag library, all flag args must be passed before the first non-flag arg.
+
+See UpdateAkaMSLinks.csproj for information about the MSBuild properties that must be set.
+`
+
+var latestShortLinkPrefix = flag.String(
+	"prefix", "golang/release/dev/latest/",
+	"The shortened URL prefix to use, including '/'. The default value includes 'dev' and is not intended for production use.")
+
+var validateVersionFlag = flag.String(
+	"version", "",
+	"A Microsoft-built Go version, in 1.2.3-1[-fips] format.\n"+
+		"If specified, must match the build asset JSON's version or this command will fail.\n"+
+		"The string 'nil' is treated as the same as not setting the value, for use in CI.\n"+
+		"Optionally use this to validate expectations.")
+
+func main() {
+	help := flag.Bool("h", false, "Print this help message.")
+	buildAssetJSON := flag.String("build-asset-json", "", "[Required] The path of a build asset JSON file describing the Go build to update to.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "\nUsage:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "%s\n\n", description)
+	}
+	flag.Parse()
+
+	if *help {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	if *buildAssetJSON == "" {
+		flag.Usage()
+		log.Fatal("No build asset JSON specified.\n")
+	}
+	if *validateVersionFlag == "nil" {
+		*validateVersionFlag = ""
+	}
+
+	if err := createAkaMSLinks(*buildAssetJSON); err != nil {
+		log.Fatalf("error: %v\n", err)
+	}
+
+	log.Println("\nSuccess.")
+}
+
+func createAkaMSLinks(assetFilePath string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	akaMSDir := filepath.Join(wd, "eng", "artifacts", "akams")
+	if err := os.MkdirAll(akaMSDir, os.ModeDir|os.ModePerm); err != nil {
+		return err
+	}
+
+	var b buildassets.BuildAssets
+	if err := buildmodel.ReadJSONFile(assetFilePath, &b); err != nil {
+		return err
+	}
+
+	if *validateVersionFlag != "" {
+		assetVersion := b.GetGoVersion().Full()
+		inputVersion := goversion.New(*validateVersionFlag).Full()
+		if assetVersion != inputVersion {
+			return fmt.Errorf("build asset JSON version %q doesn't match input version %q", assetVersion, inputVersion)
+		}
+	}
+
+	linkPairs, err := createLinkPairs(b)
+	if err != nil {
+		return err
+	}
+
+	propsFileContent, err := getPropsFileContent(linkPairs)
+	if err != nil {
+		return err
+	}
+
+	projectPath := filepath.Join(wd, "eng", "publishing", "UpdateAkaMSLinks", "UpdateAkaMSLinks.csproj")
+	propsPath := filepath.Join(akaMSDir, "AkaMSLinks.props")
+	if err := os.WriteFile(propsPath, []byte(propsFileContent), 0666); err != nil {
+		return err
+	}
+
+	log.Printf("---- File content for generated file %v\n%v\n", propsPath, propsFileContent)
+
+	cmd := exec.Command(
+		"dotnet", "build", projectPath,
+		fmt.Sprintf("/p:LinkItemPropsFile=\"%v\"", propsPath))
+	// Pass any additional args through. Likely /p:Key=Value and /bl:Something.binlog
+	cmd.Args = append(cmd.Args, flag.Args()...)
+	return executil.Run(cmd)
+}
+
+type akaMSLinkPair struct {
+	short, target string
+}
+
+func (p *akaMSLinkPair) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	s := xml.StartElement{
+		Name: xml.Name{Local: "AkaMSLink"},
+		Attr: []xml.Attr{
+			{Name: xml.Name{Local: "Include"}, Value: p.short},
+			{Name: xml.Name{Local: "TargetUrl"}, Value: p.target},
+		},
+	}
+	err := e.EncodeToken(s)
+	if err != nil {
+		return err
+	}
+	return e.EncodeToken(s.End())
+}
+
+func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
+	v := assets.GetGoVersion()
+	// The partial versions that we want to link to a specific build.
+	// For example, 1.18-fips -> 1.18.2-1-fips.
+	partial := []string{
+		v.MajorMinor() + v.NoteWithPrefix(),
+		v.MajorMinorPatch() + v.NoteWithPrefix(),
+		// Also include the fully specified version. This lets people use a pretty link even if they
+		// do need to pin to a specific version.
+		v.Full(),
+	}
+
+	goSrcURLParts := strings.Split(assets.GoSrcURL, "/")
+	if len(goSrcURLParts) < 3 {
+		return nil, fmt.Errorf("unable to determine build number from %#q: not enough '/' segments to be an asset URL", assets.GoSrcURL)
+	}
+	buildNumber := goSrcURLParts[len(goSrcURLParts)-2]
+
+	urls := make([]string, 0, 3*(len(assets.Arches)+1))
+	for _, a := range assets.Arches {
+		urls = appendURLAndVerificationURLs(urls, a.URL)
+	}
+	urls = appendURLAndVerificationURLs(urls, assets.GoSrcURL)
+
+	pairs := make([]akaMSLinkPair, 0, len(urls)*len(partial))
+
+	for _, p := range partial {
+		for _, u := range urls {
+			urlParts := strings.Split(u, "/")
+			if len(urlParts) < 3 {
+				return nil, fmt.Errorf("unable to determine short link for %#q: not enough '/' segments to be an asset URL", u)
+			}
+			filename := urlParts[len(urlParts)-1]
+			// Make our aka.ms links more like official Go links: remove '.' between first parts.
+			if strings.HasPrefix(filename, "go.") {
+				filename = "go" + strings.TrimPrefix(filename, "go.")
+			}
+			f, err := makeFloatingFilename(filename, buildNumber, p)
+			if err != nil {
+				return nil, fmt.Errorf("unable to process URL %#q: %w", u, err)
+			}
+
+			pairs = append(pairs, akaMSLinkPair{
+				*latestShortLinkPrefix + f,
+				u,
+			})
+		}
+	}
+
+	return pairs, nil
+}
+
+func appendURLAndVerificationURLs(u []string, url string) []string {
+	u = append(u, url, url+".sha256")
+	if strings.HasSuffix(url, ".tar.gz") {
+		u = append(u, url+".sig")
+	}
+	return u
+}
+
+func makeFloatingFilename(filename, buildNumber, floatVersion string) (string, error) {
+	f := strings.ReplaceAll(filename, buildNumber, floatVersion)
+	if f == filename {
+		return "", fmt.Errorf("unable to find buildNumber %#q in filename %#q", buildNumber, filename)
+	}
+	return f, nil
+}
+
+func getPropsFileContent(pairs []akaMSLinkPair) (string, error) {
+	var b strings.Builder
+	b.WriteString("<Project>\n")
+	b.WriteString("  <ItemGroup>\n")
+
+	marshal, err := xml.MarshalIndent(pairs, "    ", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	_, err = b.Write(marshal)
+	if err != nil {
+		return "", err
+	}
+	b.WriteString("\n")
+
+	b.WriteString("  </ItemGroup>\n")
+	b.WriteString("</Project>\n")
+	return b.String(), nil
+}

--- a/cmd/update-aka-ms/update-aka-ms_test.go
+++ b/cmd/update-aka-ms/update-aka-ms_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/go-infra/buildmodel/buildassets"
+	"github.com/microsoft/go-infra/buildmodel/dockerversions"
+)
+
+func Test_createLinkPairs(t *testing.T) {
+	*latestShortLinkPrefix = "testing/"
+	input := buildassets.BuildAssets{
+		Branch:  "release-branch.go1.18",
+		BuildID: "123456",
+		Version: "1.17.7-1",
+		Arches: []*dockerversions.Arch{
+			{
+				URL: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz",
+			},
+		},
+		GoSrcURL: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz",
+	}
+	want := []akaMSLinkPair{
+		{short: "testing/go1.17.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{short: "testing/go1.17.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{short: "testing/go1.17.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{short: "testing/go1.17.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{short: "testing/go1.17.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{short: "testing/go1.17.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{short: "testing/go1.17.7.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{short: "testing/go1.17.7.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{short: "testing/go1.17.7.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{short: "testing/go1.17.7.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{short: "testing/go1.17.7.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{short: "testing/go1.17.7.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{short: "testing/go1.17.7-1.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{short: "testing/go1.17.7-1.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{short: "testing/go1.17.7-1.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{short: "testing/go1.17.7-1.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{short: "testing/go1.17.7-1.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{short: "testing/go1.17.7-1.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+	}
+	got, err := createLinkPairs(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("createLinkPairs() got %#v, want %#v", got, want)
+	}
+}
+
+func Test_getPropsFileContent(t *testing.T) {
+	pairs := []akaMSLinkPair{
+		{
+			short: "from", target: "to",
+		},
+		{
+			short:  "release/latest/go1.18.2-linux-amd64.tar.gz",
+			target: "https://example.org/go/go1.18.s-linux-amd64.tar.gz",
+		},
+	}
+	want := `<Project>
+  <ItemGroup>
+    <AkaMSLink Include="from" TargetUrl="to"></AkaMSLink>
+    <AkaMSLink Include="release/latest/go1.18.2-linux-amd64.tar.gz" TargetUrl="https://example.org/go/go1.18.s-linux-amd64.tar.gz"></AkaMSLink>
+  </ItemGroup>
+</Project>
+`
+
+	got, err := getPropsFileContent(pairs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("getPropsFileContent() got %v, want %v", got, want)
+	}
+}

--- a/cmd/update-aka-ms/update-aka-ms_test.go
+++ b/cmd/update-aka-ms/update-aka-ms_test.go
@@ -25,24 +25,24 @@ func Test_createLinkPairs(t *testing.T) {
 		GoSrcURL: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz",
 	}
 	want := []akaMSLinkPair{
-		{short: "testing/go1.17.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
-		{short: "testing/go1.17.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
-		{short: "testing/go1.17.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
-		{short: "testing/go1.17.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
-		{short: "testing/go1.17.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
-		{short: "testing/go1.17.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
-		{short: "testing/go1.17.7.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
-		{short: "testing/go1.17.7.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
-		{short: "testing/go1.17.7.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
-		{short: "testing/go1.17.7.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
-		{short: "testing/go1.17.7.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
-		{short: "testing/go1.17.7.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
-		{short: "testing/go1.17.7-1.linux-amd64.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
-		{short: "testing/go1.17.7-1.linux-amd64.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
-		{short: "testing/go1.17.7-1.linux-amd64.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
-		{short: "testing/go1.17.7-1.src.tar.gz", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
-		{short: "testing/go1.17.7-1.src.tar.gz.sha256", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
-		{short: "testing/go1.17.7-1.src.tar.gz.sig", target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.linux-amd64.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{Short: "testing/go1.17.linux-amd64.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{Short: "testing/go1.17.linux-amd64.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{Short: "testing/go1.17.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{Short: "testing/go1.17.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{Short: "testing/go1.17.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.7.linux-amd64.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{Short: "testing/go1.17.7.linux-amd64.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{Short: "testing/go1.17.7.linux-amd64.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{Short: "testing/go1.17.7.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{Short: "testing/go1.17.7.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{Short: "testing/go1.17.7.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
+		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
+		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
+		{Short: "testing/go1.17.7-1.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
+		{Short: "testing/go1.17.7-1.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
+		{Short: "testing/go1.17.7-1.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
 	}
 	got, err := createLinkPairs(input)
 	if err != nil {
@@ -53,14 +53,14 @@ func Test_createLinkPairs(t *testing.T) {
 	}
 }
 
-func Test_getPropsFileContent(t *testing.T) {
+func Test_propsFileContent(t *testing.T) {
 	pairs := []akaMSLinkPair{
 		{
-			short: "from", target: "to",
+			Short: "from", Target: "to",
 		},
 		{
-			short:  "release/latest/go1.18.2-linux-amd64.tar.gz",
-			target: "https://example.org/go/go1.18.s-linux-amd64.tar.gz",
+			Short:  "release/latest/go1.18.2-linux-amd64.tar.gz",
+			Target: "https://example.org/go/go1.18.s-linux-amd64.tar.gz",
 		},
 	}
 	want := `<Project>
@@ -71,11 +71,11 @@ func Test_getPropsFileContent(t *testing.T) {
 </Project>
 `
 
-	got, err := getPropsFileContent(pairs)
+	got, err := propsFileContent(pairs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != want {
-		t.Errorf("getPropsFileContent() got %v, want %v", got, want)
+		t.Errorf("propsFileContent() got %v, want %v", got, want)
 	}
 }

--- a/docs/release-process/README.md
+++ b/docs/release-process/README.md
@@ -1,0 +1,107 @@
+# Release process
+
+We have a handful of pipelines to manage the steps creating a release.
+
+The goal is to have this system handle the easy stuff that's easy to mistype or forget, and that's annoying to copy-paste.
+
+All steps written below are performed by the release pipeline (not by the dev) unless stated otherwise.
+
+## Status
+
+This doc describes the plan to create Azure Pipelines that run the release steps for the Microsoft build of Go. The doc and the plan are works in progress. The doc is written so that it describes the final state of the pipelines, and this status section can simply be removed once the entire doc is implemented.
+
+The overall effort is tracked by <https://github.com/microsoft/go/issues/423>.
+
+* (3) release-go
+    * ✅ aka.ms link generation <https://github.com/microsoft/go/issues/453>
+
+# Pipelines
+
+## (1) release-start
+
+Inputs:
+* A list of `major.minor.patch-release[-note]` release numbers.
+    * Example: 1.17.8-1, 1.17.8-1-fips, 1.18.0-1, 1.18.0-1-fips
+
+Steps:
+1. Create a tracking issue for the release event, and one for each release version number.
+1. Launch a "(2) release-build" for each release/issue.
+1. Launch one "(4) release-go-images" that includes all release version numbers.
+    * This pipeline has to wait for (2) to finish. We just launch it now while we have all the info necessary to kick it off.
+
+## (2) release-build
+
+Inputs:
+* microsoft/go release issue number.
+* A single `major.minor.patch-revision[-note]` release number.
+    * The note determines whether this is a boring/FIPS release.
+* (Optional) One or more IDs to start polling.
+    1. microsoft/go PR number.
+    1. microsoft/go commit hash created by PR merge.
+    1. AzDO Go pipeline build id.
+    1. microsoft/go-images PR number.
+    * The last one defined "wins", and the job starts by polling that. This means if the dev needs to re-trigger this job after a failure, they can simply fill in the last parameter the build was stuck on.
+
+Steps:
+1. Poll the upstream Go repository for the release availability.
+    * If a normal release branch, fail immediately if the tag isn't available.
+    * If boring/FIPS, poll the RELEASES file.
+1. Create an auto-update PR updating to the specific commit released by upstream.
+1. Poll CI and merge status for a green merge.
+1. Poll the official Go pipeline to check for an official build triggered by the auto-update commit being mirrored.
+1. Poll the build for successful completion.
+1. Launch "(3) release-go" on the result.
+1. If this branch has an associated go-images Dockerfile:
+    1. Create an auto-update PR for go-images based on the build.
+    1. Poll CI and merge status for a green merge.
+
+If any polling steps fail (or time out), the pipeline notifies the dev handling the release by commenting on the release issue.
+
+## (3) release-go
+
+Inputs:
+* microsoft/go release issue number.
+* A single `major.minor.patch-revision[-note]` release number.
+* AzDO build ID: the microsoft/go build to release.
+    * If running this job manually, note: this is the id in the URL, not the build number.
+
+Steps:
+1. Check that results match the expected Go version.
+    * VERSION file, commit hashes. Goal: prevent the wrong build from being passed into this pipeline.
+1. Tag the commit on GitHub.
+1. Add a GitHub release on the tag. Attach the source archive files and assets json.
+1. Update aka.ms links.
+1. Add a comment to the release issue alerting the dev that the process has completed.
+
+## (4) release-go-images
+
+Inputs:
+* A list of major.minor.patch release numbers.
+
+Steps:
+1. Poll the latest `microsoft/main` go-images commit in AzDO to ensure its set of versions matches all target versions.
+1. Run the go-images internal build pipeline in "build" mode.
+1. Manual approval step: check the set of tags that were built.
+    * The dev should check to make sure the image build filter is set up properly and built the right set of tags. Not every image in go-images is necessarily built during a given servicing release.
+1. Run the go-images internal build pipeline in "publish" mode.
+
+# Considerations for improvement
+
+## Polling
+
+This plan has a lot of polling, and that's bad! It keeps an agent busy while it does effectively nothing. With sufficiently large pools, this may not end up causing problems, but it's a waste in any case. If this ends up being a problem, we have some workarounds in mind:
+
+* (Bad) Add "user approval" steps on a server-side job to let the pipeline stop without using up a VM.
+    * This means we don't keep a machine busy polling. However, it puts a burden on the dev running the release.
+* (Best) Move the polling to an external system that doesn't rely on an AzDO build pool.
+    * We can have the pipeline call out to Azure Functions (potentially Durable Functions) to have it start polling and report back later.
+    * This could be implemented using an [agentless/server job](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#server-jobs), with:
+        * [AzureFunction@1](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/azure-function?view=azure-devops) - Kick off the polling function.
+        * [ManualValidation@0](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/manual-validation?view=azure-devops&tabs=yaml) - Receive the callback in the form of a service account pressing the approve button.
+* (Incredible) Add or discover some Azure Pipelines functionality that enables some way to poll without a constantly reserved agent.
+
+## Release notes
+
+We should consider where release notes should go that are specific to the Microsoft build of Go. In particular, FIPS-related changes.
+
+It would be reasonable to have a place where release notes can be checked in: doc/go1.18-fips.html? Inside patch file descriptions with conventions to extract relevant info? Then the release-go pipeline can detect the notes, format them, and put them into e.g. the GitHub release.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,0 +1,13 @@
+<!-- Copyright (c) Microsoft Corporation. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file. -->
+<Dependencies>
+  <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.22171.1">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>fa981934d2c05c4ef309864f940efa3cca641183</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.Deployment.Tasks.Links" Version="7.0.0-beta.22171.1">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>fa981934d2c05c4ef309864f940efa3cca641183</Sha>
+    </Dependency>
+  </ToolsetDependencies>
+</Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,0 +1,6 @@
+<!-- Copyright (c) Microsoft Corporation. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file. -->
+<Project>
+  <PropertyGroup>
+    <MicrosoftDotNetDeploymentTasksLinksVersion>7.0.0-beta.22171.1</MicrosoftDotNetDeploymentTasksLinksVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -11,3 +11,8 @@ Pipeline definitions currently using each YAML file are:
       options in the "Run pipeline" dialog.
     * To see where an update came from, click the "X consumed" button:
       ![](img/consumed-artifacts.png)
+
+Release pipelines (see [release process docs](/docs/release-process)):
+
+* [`release-go.yml`](release-go.yml)
+  * [`microsoft-go-infra-release-go`](https://dev.azure.com/dnceng/internal/_build?definitionId=1123)

--- a/eng/pipelines/release-go.yml
+++ b/eng/pipelines/release-go.yml
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Use runtime parameters to define these selections in YML. This also makes them
+# show up in the "Run" popup directly. This makes them much easier to set
+# manually, vs. digging into the Variables submenu with many clicks.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters
+parameters:
+  - name: releaseVersion
+    displayName: Version being release, including Microsoft revision suffix (-1) and boring/FIPS suffix (-fips) if they apply.
+    type: string
+
+  - name: releaseGoBuildId
+    displayName: Build ID to release. Copy the ID from the build page's URL.
+    type: string
+
+  - name: vanityUrlPrefix
+    displayName: Prefix for the vanity URLs.
+    type: string
+    default: 'golang/release/latest/'
+
+trigger: none
+pr: none
+
+variables:
+  - group: go-akams-config
+  - group: go-akams-auth
+
+jobs:
+  - job: Release
+    workspace:
+      clean: all
+    pool:
+      # This is a utility job: use generic recent LTS.
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    variables:
+      assetsDir: $(Pipeline.Workspace)/BuildAssets
+      buildAssetJsonFile: $(assetsDir)/assets.json
+    steps:
+      - template: steps/checkout-unix-task.yml
+
+      - template: steps/init-go.yml
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK'
+        inputs:
+          version: 6.x
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          source: specific
+          artifact: BuildAssets
+          project: internal
+          pipeline: 958
+          runVersion: specific
+          runId: ${{ parameters.releaseGoBuildId }}
+          path: $(assetsDir)
+
+      - script: |
+          # Pass owners through environment. (Contains semicolons.)
+          export AkaMSOwners="$(AkaMSOwners)"
+
+          go run ./cmd/update-aka-ms \
+            -build-asset-json "$(buildAssetJsonFile)" \
+            -version "${{ parameters.releaseVersion }}" \
+            -prefix "${{ parameters.vanityUrlPrefix }}" \
+            /p:AkaMSClientId="$(akams-client-id)" \
+            /p:AkaMSClientSecret="$(akams-client-secret)" \
+            /p:AkaMSTenant="$(AkaMSTenant)" \
+            /p:AkaMSCreatedBy="$(AkaMSCreatedBy)" \
+            /p:AkaMSGroupOwner="$(AkaMSGroupOwner)"
+        displayName: Update aka.ms links

--- a/eng/publishing/UpdateAkaMSLinks/UpdateAkaMSLinks.csproj
+++ b/eng/publishing/UpdateAkaMSLinks/UpdateAkaMSLinks.csproj
@@ -1,0 +1,32 @@
+<!-- Copyright (c) Microsoft Corporation. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file. -->
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <!--
+    Import a user-specified props file that defines the aka.ms links to create. The
+    ./cmd/update-aka-ms program generates a props file and runs this project to evaluate/execute it.
+  -->
+  <Import Project="$(LinkItemPropsFile)" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Versions.props))" />
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Deployment.Tasks.Links" Version="$(MicrosoftDotNetDeploymentTasksLinksVersion)" />
+  </ItemGroup>
+
+  <Target Name="UpdateAkaMSLinks" BeforeTargets="Build">
+    <Message Text="%0A@(AkaMSLink -> 'https://aka.ms/%(Identity) -> %(TargetUrl)', '%0A')%0A" Importance="high" />
+    <CreateAkaMSLinks
+      Links="@(AkaMSLink)"
+      ClientId="$(AkaMSClientId)"
+      ClientSecret="$(AkaMSClientSecret)"
+      Tenant="$(AkaMSTenant)"
+      Owners="$(AkaMSOwners)"
+      CreatedBy="$(AkaMSCreatedBy)"
+      GroupOwner="$(AkaMSGroupOwner)" />
+  </Target>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,10 @@
+{
+  "__comment__": "This .NET global.json file is required to be in this location by the Arcade SDK and is otherwise unused. If it isn't present, attempting to auto-update the Arcade SDK throws errors.",
+  "tools": {
+    "dotnet": "6.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22171.1",
+    "Microsoft.Build.NoTargets": "3.3.0"
+  }
+}

--- a/goversion/goversion.go
+++ b/goversion/goversion.go
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package goversion contains utilities to parse and store a Go toolset version. It also handles
+// extra parts that are used by the Microsoft build of Go to describe how it was built.
+package goversion
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// GoVersion is the parsed representation of a Microsoft-built Go toolset version.
+type GoVersion struct {
+	// Original is the source data, without any defaults filled in.
+	Original string
+
+	// Major is the major version in semver terms, as in "Go 1".
+	Major string
+	// Minor is the minor version, referred to by Go as "major releases". Default: 0
+	Minor string
+	// Patch is the patch version, referred to by Go as "minor revisions". Default: 0.
+	Patch string
+	// Revision is an integer immediately after the first '-' (if any). These are revisions of the
+	// Microsoft build and aren't associated with official Go releases. Default: 1.
+	Revision string
+	// Note is a non-integer string after a '-' separator, or not included. Common use is to
+	// specify 'fips'. Default: empty string, indicating not provided.
+	Note string
+}
+
+// New parses a version string. Any parts left blank are filled in with default values.
+func New(v string) *GoVersion {
+	dashParts := strings.Split(v, "-")
+	majorMinorPatch := dashParts[0]
+
+	revision := "1"
+	note := ""
+	// If we have a "-", we need to determine if the remaining text is a revision (-1), revision and
+	// note (-1-fips), or just note (-fips). This is done by consuming the first part if it's an
+	// int, then the rest must be a note (if anything's left). This only works because a revision
+	// must be an int, and a note must not start with an int part.
+	if len(dashParts) > 1 {
+		noteBegin := 1
+		if isInt(dashParts[1]) {
+			revision = dashParts[1]
+			noteBegin = 2
+		}
+		note = strings.Join(dashParts[noteBegin:], "-")
+	}
+
+	dotParts := strings.Split(majorMinorPatch, ".")
+	major := dotParts[0]
+	minor := "0"
+	if len(dotParts) > 1 {
+		minor = dotParts[1]
+	}
+	patch := "0"
+	if len(dotParts) > 2 {
+		patch = dotParts[2]
+	}
+
+	return &GoVersion{
+		v,
+		major, minor, patch,
+		revision,
+		note,
+	}
+}
+
+func (v *GoVersion) String() string {
+	return fmt.Sprintf("%v (%v)", v.Original, v.Full())
+}
+
+func (v *GoVersion) MajorMinor() string {
+	return v.Major + "." + v.Minor
+}
+
+func (v *GoVersion) MajorMinorPatch() string {
+	return v.MajorMinor() + "." + v.Patch
+}
+
+func (v *GoVersion) MajorMinorPatchRevision() string {
+	return v.MajorMinorPatch() + "-" + v.Revision
+}
+
+// Full returns the full normalized version string, including Note if specified.
+func (v *GoVersion) Full() string {
+	return v.MajorMinorPatchRevision() + v.NoteWithPrefix()
+}
+
+// NoteWithPrefix is a utility to help with version string construction. Returns Note with a "-"
+// prefix, or empty string if Note isn't specified.
+func (v *GoVersion) NoteWithPrefix() string {
+	if v.Note == "" {
+		return ""
+	}
+	return "-" + v.Note
+}
+
+func isInt(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}

--- a/goversion/goversion_test.go
+++ b/goversion/goversion_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package goversion
+
+import "testing"
+
+func TestVersion_parseVersion(t *testing.T) {
+	tests := []struct {
+		name                                string
+		version                             string
+		major, minor, patch, revision, note string
+	}{
+		{
+			"Full version",
+			"1.2.3-4",
+			"1", "2", "3", "4", "",
+		},
+		{
+			"Major only",
+			"1",
+			"1", "0", "0", "1", "",
+		},
+		{
+			"Major.minor",
+			"1.42",
+			"1", "42", "0", "1", "",
+		},
+		{
+			"Major.minor-revision",
+			"1.42-6",
+			"1", "42", "0", "6", "",
+		},
+		{
+			"Too many dotted parts",
+			"1.2.3.4.5.6",
+			"1", "2", "3", "1", "",
+		},
+		{
+			"Many dashed parts",
+			"1-2-3-4",
+			"1", "0", "0", "2", "3-4",
+		},
+		{
+			"Note without much else",
+			"1-note",
+			"1", "0", "0", "1", "note",
+		},
+		{
+			"Note with revision",
+			"1-2-note",
+			"1", "0", "0", "2", "note",
+		},
+		{
+			"Note with number after a dash",
+			"1-note-2",
+			"1", "0", "0", "1", "note-2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := New(tt.version)
+			if got.Major != tt.major {
+				t.Errorf("parseVersion() gotMajor = %q, major %q", got.Major, tt.major)
+			}
+			if got.Minor != tt.minor {
+				t.Errorf("parseVersion() gotMinor = %q, minor %q", got.Minor, tt.minor)
+			}
+			if got.Patch != tt.patch {
+				t.Errorf("parseVersion() gotPatch = %q, patch %q", got.Patch, tt.patch)
+			}
+			if got.Revision != tt.revision {
+				t.Errorf("parseVersion() gotRevision = %q, revision %q", got.Revision, tt.revision)
+			}
+			if got.Note != tt.note {
+				t.Errorf("parseVersion() gotNote = %q, note %q", got.Note, tt.note)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add "release-go" pipeline that can, so far, create aka.ms links for a given Microsoft build of Go.

This adds the Arcade SDK basics to go-infra so we will be able to use Arcade's auto-update infrastructure for the links package.

Rendered release pipeline design/planning doc: https://github.com/dagood/go-infra/tree/dev/dagood/release-pipeline/docs/release-process

Example test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1678529&view=results
(Click "Run new" to see the UI, and the parameter values I queued it with, which are saved.)

I ran the build with the prefix changed from the default `golang/release/latest/` to `golang/release/dev/latest/`, so it created these aka.ms links:

```
  https://aka.ms/golang/release/dev/latest/go1.18-fips.linux-amd64.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18-fips.linux-amd64.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18-fips.linux-amd64.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sig
  https://aka.ms/golang/release/dev/latest/go1.18-fips.windows-amd64.zip -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip
  https://aka.ms/golang/release/dev/latest/go1.18-fips.windows-amd64.zip.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip.sha256
  https://aka.ms/golang/release/dev/latest/go1.18-fips.src.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18-fips.src.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18-fips.src.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sig
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.linux-amd64.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.linux-amd64.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.linux-amd64.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sig
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.windows-amd64.zip -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.windows-amd64.zip.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.src.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.src.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-fips.src.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sig
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.linux-amd64.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.linux-amd64.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.linux-amd64.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.linux-amd64.tar.gz.sig
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.windows-amd64.zip -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.windows-amd64.zip.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.windows-amd64.zip.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.src.tar.gz -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.src.tar.gz.sha256 -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sha256
  https://aka.ms/golang/release/dev/latest/go1.18.0-1-fips.src.tar.gz.sig -> https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220316.2/go.20220316.2.src.tar.gz.sig
```

Note that the least specific (most floating) links are `go1.18`. The pipeline doesn't currently generate links that let you automatically grab the latest major version. Two reasons for this:
* This pipeline will be run on both 1.17 and 1.18 builds, and currently it has no way to tell which one is latest because they don't know about each other.
* I don't think anyone has asked for links like `go1-fips.linux-amd64.tar.gz` and `go1.linux-amd64.tar.gz`. Requests so far have either not had clear/strict requirements, or want specific version Go version URLs (1.16.3, 1.17[.0]).

Also note: the URLs of different versions are in the same "directory", which keeps things simple:
* `https://aka.ms/golang/release/latest/go1.18.0-1-fips.linux-amd64.tar.gz`
* `https://aka.ms/golang/release/latest/go1.17.8-1-fips.linux-amd64.tar.gz`

I made up the `golang/release/latest/` prefix--think about it and let me know if you think of something better. 😄 

For more info about the aka.ms infra and the variable groups that I'm using in the pipeline, see [our aka.ms link generation OneNote page](https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FGoLang%20Team&wd=target%28Main.one%7C62B655D4-14E7-41D6-A063-0869C28D63FC%2Faka.ms%20link%20generation%3A%20%22get%20latest%20build%22%7C69202A3E-FF61-44DF-AE37-23F375AC5221%2F%29).