### PR TITLE
Move credentials into gitcmd.GitURLAuther

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/go-infra/buildmodel"
+	"github.com/microsoft/go-infra/gitcmd"
 	"github.com/microsoft/go-infra/gitpr"
 )
 
@@ -78,6 +79,8 @@ const (
 	GitAuthPAT  GitAuthOption = "pat"
 )
 
+var auther gitcmd.GitURLAuther
+
 func main() {
 	var syncConfig = flag.String("c", "eng/sync-config.json", "The sync configuration file to run.")
 	var tempGitDir = flag.String(
@@ -89,7 +92,7 @@ func main() {
 		"git-auth",
 		string(GitAuthNone),
 		// List valid options. Indent one space, to line up with the automatic ' (default "none")'.
-		"The type of Git auth to inject into upstream and target GitHub URLs for fetch/push access. String options:\n"+
+		"The type of Git auth to inject into URLs for fetch/push access. String options:\n"+
 			" none - Leave GitHub URLs as they are. Git may use HTTPS authentication in this case.\n"+
 			" ssh - Change the GitHub URL to SSH format.\n"+
 			" pat - Add the 'github-user' and 'github-pat' values into the URL.\n")
@@ -98,15 +101,15 @@ func main() {
 
 	gitAuth := GitAuthOption(*gitAuthString)
 	switch gitAuth {
-	case GitAuthNone, GitAuthSSH, GitAuthPAT:
+	case GitAuthNone:
+		auther = gitcmd.NoAuther{}
 		break
-	default:
-		fmt.Printf("Error: git-auth value %q is not an accepted value.\n", *gitAuthString)
-		flag.Usage()
-		os.Exit(1)
-	}
 
-	if gitAuth == GitAuthPAT {
+	case GitAuthSSH:
+		auther = gitcmd.GitHubSSHAuther{}
+		break
+
+	case GitAuthPAT:
 		missingArgs := false
 		if *githubUser == "" {
 			fmt.Printf("Error: git-auth pat is specified but github-user is not.")
@@ -119,6 +122,23 @@ func main() {
 		if missingArgs {
 			os.Exit(1)
 		}
+		auther = gitcmd.MultiAuther{
+			Authers: []gitcmd.GitURLAuther{
+				gitcmd.GitHubPATAuther{
+					User: *githubUser,
+					PAT:  *githubPAT,
+				},
+				gitcmd.AzDOPATAuther{
+					PAT: *azdoDncengPAT,
+				},
+			},
+		}
+		break
+
+	default:
+		fmt.Printf("Error: git-auth value %q is not an accepted value.\n", *gitAuthString)
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	var entries []SyncConfigEntry
@@ -140,12 +160,6 @@ func main() {
 	for i, entry := range entries {
 		syncNum := fmt.Sprintf("%v/%v", i+1, len(entries))
 		fmt.Printf("=== Beginning sync %v, from %v -> %v\n", syncNum, entry.Upstream, entry.Target)
-
-		// Add authentication to Target and Upstream URLs if necessary.
-		entry.Target = createAuthorizedGitUrl(entry.Target, gitAuth)
-		entry.Upstream = createAuthorizedGitUrl(entry.Upstream, gitAuth)
-		entry.UpstreamMirror = createAuthorizedGitUrl(entry.UpstreamMirror, gitAuth)
-		entry.MirrorTarget = createAuthorizedGitUrl(entry.MirrorTarget, gitAuth)
 
 		if entry.Head == "" {
 			entry.Head = entry.Target
@@ -169,33 +183,6 @@ func main() {
 	} else {
 		fmt.Println("Completed with errors.")
 	}
-}
-
-// createAuthorizedGitUrl takes a URL, auth options, and returns an authorized URL. The authorized
-// URL may be the same as the original URL, depending on the options given and the URL content.
-func createAuthorizedGitUrl(url string, gitAuth GitAuthOption) string {
-	const githubPrefix = "https://github.com"
-	if strings.HasPrefix(url, githubPrefix) {
-		targetRepoOwnerSlashName := strings.TrimPrefix(url, githubPrefix)
-
-		switch gitAuth {
-		case GitAuthSSH:
-			url = fmt.Sprintf("git@github.com:%v", targetRepoOwnerSlashName)
-			break
-		case GitAuthPAT:
-			url = fmt.Sprintf("https://%v:%v@github.com/%v", *githubUser, *githubPAT, targetRepoOwnerSlashName)
-			break
-		}
-	}
-	const azdoDncengPrefix = "https://dnceng@dev.azure.com"
-	if strings.HasPrefix(url, azdoDncengPrefix) {
-		url = fmt.Sprintf(
-			// Username doesn't matter. PAT is identity.
-			"https://arbitraryusername:%v@dev.azure.com%v",
-			*azdoDncengPAT, strings.TrimPrefix(url, azdoDncengPrefix),
-		)
-	}
-	return url
 }
 
 // changedBranch stores the refs that have changes that need to be submitted in a PR, and the diff
@@ -236,8 +223,8 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 	//
 	// For an overview of the sequence of Git commands below, see the command description.
 
-	fetchUpstream := newGitCmd("fetch", "--no-tags", entry.Upstream)
-	fetchOrigin := newGitCmd("fetch", "--no-tags", entry.Target)
+	fetchUpstream := newGitCmd("fetch", "--no-tags", auther.InsertAuth(entry.Upstream))
+	fetchOrigin := newGitCmd("fetch", "--no-tags", auther.InsertAuth(entry.Target))
 	for _, b := range branches {
 		fetchUpstream.Args = append(fetchUpstream.Args, b.UpstreamFetchRefspec())
 		fetchOrigin.Args = append(fetchOrigin.Args, b.BaseBranchFetchRefspec())
@@ -252,7 +239,7 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 	// Fetch the state of the official/upstream-maintained mirror (if specified) so we can check
 	// against it later.
 	if entry.UpstreamMirror != "" {
-		fetchUpstreamMirror := newGitCmd("fetch", "--no-tags", entry.UpstreamMirror)
+		fetchUpstreamMirror := newGitCmd("fetch", "--no-tags", auther.InsertAuth(entry.UpstreamMirror))
 		for _, b := range branches {
 			fetchUpstreamMirror.Args = append(fetchUpstreamMirror.Args, b.UpstreamMirrorFetchRefspec())
 		}
@@ -264,7 +251,7 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 	// Before attempting any update, mirror everything (if specified). Only continue once this is
 	// complete, to avoid a potentially broken internal build state.
 	if entry.MirrorTarget != "" {
-		mirror := newGitCmd("push", entry.MirrorTarget)
+		mirror := newGitCmd("push", auther.InsertAuth(entry.MirrorTarget))
 		for _, b := range branches {
 			mirror.Args = append(mirror.Args, b.UpstreamMirrorRefspec())
 		}
@@ -441,7 +428,7 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 		if force {
 			c.Args = append(c.Args, "--force")
 		}
-		c.Args = append(c.Args, remote)
+		c.Args = append(c.Args, auther.InsertAuth(remote))
 		for _, r := range refspecs {
 			c.Args = append(c.Args, r)
 		}

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package gitcmd contains utilities for common Git operations in a local repository, including
+// authentication with a remote repository.
+package gitcmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+const githubPrefix = "https://github.com/"
+const azdoDncengPrefix = "https://dnceng@dev.azure.com/"
+
+// GitURLAuther manipulates a Git repository URL (GitHub, AzDO, ...) such that Git commands taking a
+// remote will work with the URL. This is intentionally vague: it could add an access token into the
+// URL, or it could simply make the URL compatible with environmental auth on the machine (SSH).
+type GitURLAuther interface {
+	// InsertAuth inserts authentication into the URL and returns it, or if the auther doesn't
+	// apply, returns the url without any modifications.
+	InsertAuth(url string) string
+}
+
+// GitHubSSHAuther turns an https-style GitHub URL into an SSH-style GitHub URL.
+type GitHubSSHAuther struct{}
+
+func (a GitHubSSHAuther) InsertAuth(url string) string {
+	if strings.HasPrefix(url, githubPrefix) {
+		return fmt.Sprintf("git@github.com:%v", strings.TrimPrefix(url, githubPrefix))
+	}
+	return url
+}
+
+// GitHubPATAuther adds a username and password into the https-style GitHub URL.
+type GitHubPATAuther struct {
+	User, PAT string
+}
+
+func (a GitHubPATAuther) InsertAuth(url string) string {
+	if a.User != "" && a.PAT != "" && strings.HasPrefix(url, githubPrefix) {
+		return fmt.Sprintf(
+			"https://%v:%v@github.com/%v",
+			a.User, a.PAT, strings.TrimPrefix(url, githubPrefix))
+	}
+	return url
+}
+
+// AzDOPATAuther adds a PAT into the https-style Azure DevOps repository URL.
+type AzDOPATAuther struct {
+	PAT string
+}
+
+func (a AzDOPATAuther) InsertAuth(url string) string {
+	if a.PAT != "" && strings.HasPrefix(url, azdoDncengPrefix) {
+		url = fmt.Sprintf(
+			// Username doesn't matter. PAT is identity.
+			"https://arbitraryusername:%v@dev.azure.com%v",
+			a.PAT, strings.TrimPrefix(url, azdoDncengPrefix))
+	}
+	return url
+}
+
+// NoAuther does nothing to URLs.
+type NoAuther struct{}
+
+func (a NoAuther) InsertAuth(url string) string {
+	return url
+}
+
+// MultiAuther tries multiple authers in sequence. Stops and returns the result when any auther
+// makes a change to the URL.
+type MultiAuther struct {
+	Authers []GitURLAuther
+}
+
+func (m MultiAuther) InsertAuth(url string) string {
+	for _, a := range m.Authers {
+		if authUrl := a.InsertAuth(url); authUrl != url {
+			return authUrl
+		}
+	}
+	return url
+}


### PR DESCRIPTION
The `gitcmd.GitURLAuther` stores credentials, and the `./cmd/sync` code uses it to inject auth data into URLs at the last moment. The short lifetime of the authed URLs makes it easier to trace which variables could be sensitive.

Also fix a small bug with the resulting authed URLs: the old code caused a double slash in `https://github.com//microsoft/go` and an unusual slash in ssh auth mode with `git@github.com:/microsoft/go` (should be `...com:microsoft/go`). These forms actually do happen to work, but they aren't what you'd expect to see and could be confusing.

I initially planned to wrap the Git commands we're using and handle auth with a "client" struct, but this is a more minimal approach we can go with for now. We might still want to wrap the Git commands, for other reasons, and the wrapper can continue to use these authers.