### PR TITLE
Print would-be PR content with '-n'

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -289,7 +289,12 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			return err
 		}
 
-		c := changedBranch{Refs: b}
+		c := changedBranch{
+			Refs: b,
+			PRBody: "Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃" +
+				"\n\nAfter submitting the PR, I will attempt to enable auto-merge in the \"merge commit\" configuration." +
+				"\n\nFor more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md).",
+		}
 		var commitMessage string
 
 		if entry.SubmoduleTarget == "" {
@@ -312,6 +317,10 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 				}
 			}
 			c.PRTitle = fmt.Sprintf("Merge upstream %#q into %#q", b.UpstreamName, b.Name)
+			c.PRBody += fmt.Sprintf(
+				"\n\nThis PR merges %#q into %#q.\n\nIf PR validation fails and you need to fix up the PR, make sure to use a merge commit, not a squash or rebase!",
+				c.Refs.UpstreamName, c.Refs.Name,
+			)
 			commitMessage = fmt.Sprintf("Merge upstream branch %q into %v", b.UpstreamName, b.Name)
 		} else {
 			// This is a submodule update. We'll be doing more evaluation to figure out which commit
@@ -368,17 +377,6 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			snippet := createCommitMessageSnippet(upstreamCommitMessage)
 
 			c.PRTitle = fmt.Sprintf("Update submodule to latest %#q in %#q", b.UpstreamName, b.Name)
-			c.PRBody = "Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃" +
-				"\n\nAfter submitting the PR, I will attempt to enable auto-merge in the \"merge commit\" configuration." +
-				"\n\nFor more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md)."
-
-			if entry.SubmoduleTarget == "" {
-				c.PRBody += fmt.Sprintf(
-					"\n\nThis PR merges %#q into %#q.\n\nIf PR validation fails and you need to fix up the PR, make sure to use a merge commit, not a squash or rebase!",
-					c.Refs.UpstreamName, c.Refs.Name,
-				)
-			}
-
 			commitMessage = fmt.Sprintf("Update submodule to latest %v (%v): %v", b.UpstreamName, newCommit[:8], snippet)
 		}
 

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -204,6 +204,7 @@ type changedBranch struct {
 	Refs    *gitpr.SyncPRRefSet
 	Diff    string
 	PRTitle string
+	PRBody  string
 }
 
 func syncRepository(dir string, entry SyncConfigEntry) error {
@@ -367,6 +368,17 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			snippet := createCommitMessageSnippet(upstreamCommitMessage)
 
 			c.PRTitle = fmt.Sprintf("Update submodule to latest %#q in %#q", b.UpstreamName, b.Name)
+			c.PRBody = "Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃" +
+				"\n\nAfter submitting the PR, I will attempt to enable auto-merge in the \"merge commit\" configuration." +
+				"\n\nFor more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md)."
+
+			if entry.SubmoduleTarget == "" {
+				c.PRBody += fmt.Sprintf(
+					"\n\nThis PR merges %#q into %#q.\n\nIf PR validation fails and you need to fix up the PR, make sure to use a merge commit, not a squash or rebase!",
+					c.Refs.UpstreamName, c.Refs.Name,
+				)
+			}
+
 			commitMessage = fmt.Sprintf("Update submodule to latest %v (%v): %v", b.UpstreamName, newCommit[:8], snippet)
 		}
 
@@ -422,9 +434,15 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			}
 			c.Diff = diffLines.String()
 
-			fmt.Printf("---- Files changed from %q to %q ----\n", b.UpstreamName, b.Name)
-			fmt.Print(diff)
-			fmt.Println("--------")
+			if c.Diff != "" {
+				c.PRBody += fmt.Sprintf(
+					"\n\n"+
+						"<details><summary>Click on this text to view the file difference between this branch and upstream.</summary>\n\n"+
+						"```\n%v\n```"+
+						"\n\n</details>",
+					c.Diff,
+				)
+			}
 		}
 
 		changedBranches = append(changedBranches, c)
@@ -482,6 +500,12 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 	}
 
 	for _, b := range changedBranches {
+		prFlowDescription := fmt.Sprintf("%v -> %v", b.Refs.UpstreamName, b.Refs.PRBranch())
+
+		fmt.Printf("---- %s: Checking if PR should be submitted.\n", prFlowDescription)
+		fmt.Printf("---- PR Title: %s\n", b.PRTitle)
+		fmt.Printf("---- PR Body:\n%s\n", b.PRBody)
+
 		var skipReason string
 		switch {
 		case *dryRun:
@@ -499,8 +523,6 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 			skipReason = "github-pat-reviewer not provided"
 		}
 
-		prFlowDescription := fmt.Sprintf("%v -> %v", b.Refs.UpstreamName, b.Refs.PRBranch())
-
 		if skipReason != "" {
 			fmt.Printf("---- %s: skipping submitting PR for %v\n", skipReason, prFlowDescription)
 			continue
@@ -515,26 +537,7 @@ func syncRepository(dir string, entry SyncConfigEntry) error {
 		err := func() error {
 			fmt.Printf("---- PR for %v: Submitting...\n", prFlowDescription)
 
-			body := "Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃" +
-				"\n\nAfter submitting the PR, I will attempt to enable auto-merge in the \"merge commit\" configuration.\n\n" +
-				"\n\nFor more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md)."
-			if entry.SubmoduleTarget == "" {
-				body += fmt.Sprintf(
-					"\n\nThis PR merges %#q into %#q.\n\nIf PR validation fails and you need to fix up the PR, make sure to use a merge commit, not a squash or rebase!",
-					b.Refs.UpstreamName, b.Refs.Name,
-				)
-			}
-			if b.Diff != "" {
-				body += fmt.Sprintf(
-					"\n\n"+
-						"<details><summary>Click on this text to view the file difference between this branch and upstream.</summary>\n\n"+
-						"```\n%v\n```"+
-						"\n\n</details>",
-					b.Diff,
-				)
-			}
-
-			request := b.Refs.CreateGitHubPR(parsedPRHeadRemote.GetOwner(), b.PRTitle, body)
+			request := b.Refs.CreateGitHubPR(parsedPRHeadRemote.GetOwner(), b.PRTitle, b.PRBody)
 
 			// POST the PR. The call returns success if the PR is created or if we receive a
 			// specific error message back from GitHub saying the PR is already created.


### PR DESCRIPTION
Move PR content creation (description, title) earlier in `sync` so it can be printed even when dry run mode (`-n`) is enabled. This makes it easier to try out changes locally that affect the PR description. Shows up like this:

```
---- PR Title: Update submodule to latest `master` in `microsoft/nightly`
---- PR Body:
Hi! I'm a bot, and this is an automatically generated upstream sync PR. 🔃

After submitting the PR, I will attempt to enable auto-merge in the "merge commit" configuration.

For more information, visit [sync documentation in microsoft/go-infra](https://github.com/microsoft/go-infra/tree/main/docs/automation/sync.md).
---- Dry run: skipping submitting PR for master -> dev/auto-sync/microsoft/nightly
```