### PR TITLE
Update Go toolset used in CI to 1.18

### DIFF
--- a/eng/pipelines/steps/init-go.yml
+++ b/eng/pipelines/steps/init-go.yml
@@ -6,4 +6,4 @@
 steps:
   - task: GoTool@0
     inputs:
-      version: 1.17.2
+      version: 1.18


### PR DESCRIPTION
I'm curious if this will work, so we can potentially start using 1.18 features.

---

I also noticed an issue open on `GoTool@0` not being able to get 1.18, and I'm curious if it will repro here:

* https://github.com/microsoft/azure-pipelines-tasks/issues/16043

(Edit: It doesn't repro, you have to specify 1.18.0 for it to repro.)