### PR TITLE
Boost submodule update commit description length

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -61,8 +61,10 @@ const maxDiffLinesToDisplay = 200
 var (
 	// maxUpstreamCommitMessageInSnippet is the maximum number of characters to include in the
 	// commit message snippet for a submodule update commit message. The snippet gives context to
-	// the current submodule pointer in a "git log" or when viewed on GitHub.
-	maxUpstreamCommitMessageInSnippet = 40
+	// the current submodule pointer in a "git log" or when viewed on GitHub. Because the commit had
+	// to be accepted into upstream to make it here, the message length is almost definitely ok to
+	// include in its entirety. This is only a safeguard, and the character count is arbitrary.
+	maxUpstreamCommitMessageInSnippet = 1000
 	// snippetCutoffIndicator is the text to put at the end of the snippet when it is cut off.
 	snippetCutoffIndicator = "[...]"
 )


### PR DESCRIPTION
In auto-update PRs, sometimes I want to know the submodule commit description, so I click on the `...` but I barely get any more info:

![image](https://user-images.githubusercontent.com/12819531/160172312-7150d17d-b4b1-41ae-9424-1c8c090f87e0.png)

This also applies to `git log`, etc.

The limit is arbitrary, so increase it by a lot. It's just here in case AzDO can't handle quite as many characters as GitHub and we do get a huge commit description at some point.

.NET hit a 4000 char limit with PR descriptions, so staying under that seems safe enough to me: https://github.com/dotnet/arcade/issues/5811.