### PR TITLE
Add "git go-patch extract" patch renumbering

### DIFF
--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -7,7 +7,8 @@ package gitcmd
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/microsoft/go-infra/stringutil"
 )
 
 const githubPrefix = "https://github.com/"
@@ -26,7 +27,7 @@ type URLAuther interface {
 type GitHubSSHAuther struct{}
 
 func (GitHubSSHAuther) InsertAuth(url string) string {
-	if after, found := cutPrefix(url, githubPrefix); found {
+	if after, found := stringutil.CutPrefix(url, githubPrefix); found {
 		return fmt.Sprintf("git@github.com:%v", after)
 	}
 	return url
@@ -41,7 +42,7 @@ func (a GitHubPATAuther) InsertAuth(url string) string {
 	if a.User == "" || a.PAT == "" {
 		return url
 	}
-	if after, found := cutPrefix(url, githubPrefix); found {
+	if after, found := stringutil.CutPrefix(url, githubPrefix); found {
 		return fmt.Sprintf("https://%v:%v@github.com/%v", a.User, a.PAT, after)
 	}
 	return url
@@ -56,7 +57,7 @@ func (a AzDOPATAuther) InsertAuth(url string) string {
 	if a.PAT == "" {
 		return url
 	}
-	if after, found := cutPrefix(url, azdoDncengPrefix); found {
+	if after, found := stringutil.CutPrefix(url, azdoDncengPrefix); found {
 		url = fmt.Sprintf(
 			// Username doesn't matter. PAT is identity.
 			"https://arbitraryusername:%v@dev.azure.com%v",
@@ -85,11 +86,4 @@ func (m MultiAuther) InsertAuth(url string) string {
 		}
 	}
 	return url
-}
-
-func cutPrefix(s, prefix string) (after string, found bool) {
-	if strings.HasPrefix(s, prefix) {
-		return s[len(prefix):], true
-	}
-	return s, false
 }

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -52,7 +52,7 @@ func Apply(rootDir string, mode ApplyMode) error {
 	// too late to cause noisy warnings because of them.
 	cmd.Args = append(cmd.Args, "--whitespace=nowarn")
 
-	err := WalkPatches(rootDir, func(file string) error {
+	err := WalkGoPatches(rootDir, func(file string) error {
 		cmd.Args = append(cmd.Args, file)
 		return nil
 	})
@@ -63,10 +63,16 @@ func Apply(rootDir string, mode ApplyMode) error {
 	return executil.Run(cmd)
 }
 
-// WalkPatches finds patches in the given Microsoft Go repository root directory and runs fn once
+// WalkGoPatches finds patches in the given Microsoft Go repository root directory and runs fn once
 // per patch file path. If fn returns an error, walking terminates and the error is returned.
-func WalkPatches(rootDir string, fn func(string) error) error {
-	matches, err := filepath.Glob(filepath.Join(rootDir, "patches", "*.patch"))
+func WalkGoPatches(rootDir string, fn func(string) error) error {
+	return WalkPatches(filepath.Join(rootDir, "patches"), fn)
+}
+
+// WalkPatches finds patches in the given directory and runs fn once per patch file path. If fn
+// returns an error, walking terminates and the error is returned.
+func WalkPatches(dir string, fn func(string) error) error {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.patch"))
 	if err != nil {
 		return err
 	}

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package stringutil
+
+import "strings"
+
+// CutPrefix behaves like strings.Cut, but only cuts a prefix, not anywhere in the string.
+func CutPrefix(s, prefix string) (after string, found bool) {
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):], true
+	}
+	return s, false
+}


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/505

Example usage in a patch file (leading `0` optional, just matches 4-digit convention):

```
Subject: [PATCH] Add vendored go-crypto-openssl module

github.com/microsoft/go-infra/cmd/git-go-patch command: patch number 0100
---
```

That prefix hopefully makes it at least a little traceable if the message ends up somewhere we don't expect. I made it so it'll be easy to add another command with that prefix later, if any reasons for it come up.

I think it would make sense for `git go-patch apply` to get a flag that makes it strip out these lines (for submission to upstream). But, we don't need that for the FIPS patches, so filing an issue for that as followup:

* https://github.com/microsoft/go/issues/512