### PR TITLE
Support multiple go-images architectures

### DIFF
--- a/buildmodel/dockermanifest/dockermanifest.go
+++ b/buildmodel/dockermanifest/dockermanifest.go
@@ -38,6 +38,13 @@ type Image struct {
 type Platform struct {
 	BuildArgs map[string]string `json:"buildArgs,omitempty"`
 
+	// Architecture	is the processor/os architecture the image should build for. This follows
+	// .NET Docker tooling values, which in turn follows GOARCH:
+	// https://go.dev/doc/install/source#environment
+	Architecture string `json:"architecture,omitempty"`
+	// Variant is a string used to further specify architecture. For example: "v8", for ARM.
+	Variant string `json:"variant,omitempty"`
+
 	Dockerfile string `json:"dockerfile"`
 	OS         string `json:"os"`
 	OSVersion  string `json:"osVersion"`

--- a/buildmodel/dockerversions/dockerversions.go
+++ b/buildmodel/dockerversions/dockerversions.go
@@ -66,5 +66,32 @@ type Arch struct {
 
 type ArchEnv struct {
 	GOARCH string
+	GOARM  string `json:"GOARM,omitempty"`
 	GOOS   string
+}
+
+// GoImageArchSuffix is the string used in docker-library/golang to specify an arch's version
+// suffix, if one is necessary.
+func (a ArchEnv) GoImageArchSuffix() string {
+	// If arch is arm/arm64, need a version suffix.
+	if a.GOARCH == "arm" {
+		// arm always has a GOARM version.
+		return a.GOARM
+	}
+	if a.GOARCH == "arm64" {
+		// arm64 is always v8. GOARM is no longer specified.
+		return "v8"
+	}
+	return ""
+}
+
+// GoImageOSArchKey creates the string used by docker-library/golang to identify this OS/arch in its
+// versions.json file. This is upstream behavior we are conforming to.
+func (a ArchEnv) GoImageOSArchKey() string {
+	var s = a.GOARCH + a.GoImageArchSuffix()
+	// OSes other than Linux need a prefix.
+	if a.GOOS != "linux" {
+		s = a.GOOS + "-" + s
+	}
+	return s
 }


### PR DESCRIPTION
* https://github.com/microsoft/go/issues/173

Add support for linux-arm64 (along with linux-amd64) in go-images. The generated `manifest.json` for .NET Docker tooling supports Docker manifests: getting the appropriate Go image from the registry based on Docker host architecture.

I've been mainly using https://hub.docker.com/r/tonistiigi/binfmt to try things out on arm64, but I wasn't able to get `docker build --platform linux/arm64` to work very consistently. `docker run` and `docker pull` seem more reliable. The build infra (actual arm64) doesn't seem to have any problems building our arm64 images: https://dev.azure.com/dnceng/internal/_build/results?buildId=1703646&view=results.

```
$ docker run --rm --platform linux/arm64 golangpublicimages.azurecr.io/build-staging/1703646/oss/go/microsoft/golang:1.18.0-2-fips-cbl-mariner1.0-arm64 go version
go version devel go1.18-0622ea4d Tue Mar 15 12:16:46 2022 -0400 linux/arm64
```

Related changes:

* Add "force submodule reset" flag for dockerupdate.
  * `dockerupdate` uses index-mode (not commit-mode) patching, which puts the submodule into a unknown state and running `dockerupdate` again fails. Without `-f`, you have to either manually clean up the submodule or use a fresh clone. The `-f` feature is particularly useful when testing out new changes like this!
* Centralize some arch versioning logic.
* Extract makeOsArchPlatform and test.