### PR TITLE
Fix missing "/" in AzDO auth and false success in sync pipeline

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -184,6 +184,7 @@ func main() {
 		fmt.Println("Completed successfully.")
 	} else {
 		fmt.Println("Completed with errors.")
+		os.Exit(1)
 	}
 }
 

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -60,7 +60,7 @@ func (a AzDOPATAuther) InsertAuth(url string) string {
 	if after, found := stringutil.CutPrefix(url, azdoDncengPrefix); found {
 		url = fmt.Sprintf(
 			// Username doesn't matter. PAT is identity.
-			"https://arbitraryusername:%v@dev.azure.com%v",
+			"https://arbitraryusername:%v@dev.azure.com/%v",
 			a.PAT, after)
 	}
 	return url


### PR DESCRIPTION
Fix a missing `/` in AzDO URL secret injection. The `/` is removed as part of the prefix wasn't being added back in properly. (Regression in https://github.com/microsoft/go-infra/pull/30.)

Add `os.Exit(1)` so a failure shows up as a failure in the pipeline. I looked at the sync pipeline after https://github.com/microsoft/go-infra/pull/30 to make sure it was working, but the jobs were green even though they contained failures.

Failure showing up with the exit code fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=1713027&view=results
Successful build with the URL fix: https://dev.azure.com/dnceng/internal/_build/results?buildId=1713029&view=results

(This isn't blocking the 1.17/1.18 update--the manual run above did the update. I'm just fixing along the way.)