### PR TITLE
Skip unsupported arches in manifest.json

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -161,6 +161,10 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 			// Add one Platform for each OS/ARCH this variant supports.
 			platforms := make([]*dockermanifest.Platform, 0, 3)
 			for _, arch := range v.Arches {
+				// Skip unsupported arches/platforms.
+				if !arch.Supported {
+					continue
+				}
 				// Skip platforms that don't match the current variant. v.Arches is actually a list
 				// of OS/ARCHes, not just architectures.
 				if arch.Env.GOOS != os {

--- a/buildmodel/testdata/UpdateManifest/versions.json
+++ b/buildmodel/testdata/UpdateManifest/versions.json
@@ -59,6 +59,15 @@
         "sha256": "7b28ca61502d7034c32e0a03ecde15847db4ad323c2be88a14f3f6ffc065bff7",
         "supported": true,
         "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-amd64.tar.gz"
+      },
+      "arm32v7": {
+        "env": {
+          "GOARCH": "arm",
+          "GOARM": "7",
+          "GOOS": "linux"
+        },
+        "sha256": "5e4387af9f38e1092abcdefghijklmnop9922bd3d7ade60560884e0dd75ba50e",
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/dev.boringcrypto.go1.18/20220414.3/go.20220414.3.linux-armv6l.tar.gz"
       }
     },
     "variants": [


### PR DESCRIPTION
Fixes a mismatch that manifest.json has vs. Dockerfile generation: https://github.com/microsoft/go-images/pull/107#discussion_r855521895.

This PR adds an unsupported armv7 versions.json entry in the buildmodel test asset without changing the golden file to make sure the unsupported skip behaves as expected. I also tried `dockerupdate -f` on https://github.com/microsoft/go-images/pull/107, and it works there.