### PR TITLE
Add "releasego get-upstream-commit" command

### DIFF
--- a/cmd/releasego/get-upstream-commit.go
+++ b/cmd/releasego/get-upstream-commit.go
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "get-upstream-commit",
+		Summary: "Get the upstream commit for a given release version. Poll if not available.",
+		Description: `
+
+If the given version is an ordinary release, wait for the upstream Git tag. If it's a FIPS release,
+wait until the boring releases file lists this release.
+
+If the version contains a revision, it is ignored. The microsoft/go repository uses revision numbers
+so it can release multiple times per upstream version. The build note must either be unspecified (to
+indicate an ordinary release) or "fips" (to indicate the release is based on the boring branch).
+`,
+		Handle: handleWaitUpstream,
+	})
+}
+
+func handleWaitUpstream(p subcmd.ParseFunc) error {
+	version := flag.String("version", "", "[Required] A full or partial microsoft/go version number (major.minor.patch[-revision[-suffix]]).")
+	upstream := flag.String("upstream", "https://go.googlesource.com/go", "The upstream Git repo to check.")
+	azdoVarName := flag.String("set-azdo-variable", "", "An AzDO variable name to set to the commit hash using a logging command.")
+	keepTemp := flag.Bool("w", false, "Keep the temporary repository used for polling, rather than cleaning it up.")
+	pollDelaySeconds := flag.Int("poll-delay", 5, "Number of seconds to wait between each poll attempt.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *version == "" {
+		return errors.New("no version specified")
+	}
+	if *upstream == "" {
+		return errors.New("no upstream specified")
+	}
+	pollDelay := time.Duration(*pollDelaySeconds) * time.Second
+
+	gitDir, err := os.MkdirTemp("", "releasego-get-upstream-commit-*")
+	if err != nil {
+		return err
+	}
+
+	repo := gitRepo{gitDir, *upstream}
+	v := goversion.New(*version)
+	var checker upstreamChecker
+	switch v.Note {
+	case "":
+		checker = &tagChecker{
+			gitRepo: repo,
+			Tag:     v.UpstreamFormatGitTag(),
+		}
+	case "fips":
+		checker = &boringChecker{
+			gitRepo: repo,
+			Version: v.MajorMinorPatch(),
+		}
+	default:
+		return fmt.Errorf("unable to check for version with note %q", v.Note)
+	}
+
+	if *keepTemp {
+		log.Printf("Created dir %#q to store polling Git repo.\n", gitDir)
+	} else {
+		log.Printf("Created temp dir %#q to store polling Git repo. The dir will be deleted when the command completes.\n", gitDir)
+		defer func() {
+			if err := os.RemoveAll(gitDir); err != nil {
+				log.Printf("Unable to clean up temp directory %#q: %v\n", gitDir, err)
+			}
+		}()
+	}
+
+	if err := executil.Run(exec.Command("git", "init", gitDir)); err != nil {
+		return err
+	}
+
+	result := poll(checker, pollDelay)
+	if *azdoVarName != "" {
+		setAzDOPipelineVariable(*azdoVarName, result)
+	}
+	return nil
+}
+
+func poll(checker upstreamChecker, delay time.Duration) string {
+	for {
+		result, err := checker.Check()
+		if err == nil {
+			log.Printf("Check suceeded, result: %q.\n", result)
+			return result
+		}
+		log.Printf("Failed check: %v, next poll in %v...", err, delay)
+		time.Sleep(delay)
+	}
+}
+
+// gitRepo wraps a Git repository directory and provides a few utility methods. By embedding this
+// struct, a checker is able to use Git.
+type gitRepo struct {
+	GitDir   string
+	Upstream string
+}
+
+func (g *gitRepo) gitCmd(args ...string) *exec.Cmd {
+	c := exec.Command("git", args...)
+	c.Dir = g.GitDir
+	return c
+}
+
+func (g *gitRepo) runGitCmd(args ...string) error {
+	return executil.Run(g.gitCmd(args...))
+}
+
+func (g *gitRepo) revParse(rev string) (string, error) {
+	commit, err := executil.CombinedOutput(g.gitCmd("rev-parse", rev))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(commit), nil
+}
+
+// upstreamChecker checks an upstream repository for a release.
+type upstreamChecker interface {
+	// Check finds the commit associated with a release, or returns an error.
+	Check() (string, error)
+}
+
+// tagChecker checks for an upstream release by looking for a Git tag.
+type tagChecker struct {
+	gitRepo
+	Tag string
+}
+
+func (c *tagChecker) Check() (string, error) {
+	if err := c.runGitCmd("fetch", "--depth", "1", c.Upstream, "refs/tags/"+c.Tag+":refs/tags/"+c.Tag); err != nil {
+		return "", err
+	}
+	return c.revParse(c.Tag)
+}
+
+// boringChecker checks for an upstream release by reading the boring releases file and looking for
+// a line that matches the given version.
+type boringChecker struct {
+	gitRepo
+	Version string
+}
+
+func (c *boringChecker) Check() (string, error) {
+	// Fetch the tip commit of the boring branch to check the RELEASES file.
+	if err := c.runGitCmd("fetch", "--depth", "1", c.Upstream, "+dev.boringcrypto:boring"); err != nil {
+		return "", err
+	}
+
+	// Find the boring release file content and find a matching release.
+	releases, err := executil.CombinedOutput(c.gitCmd("show", "boring:misc/boring/RELEASES"))
+	if err != nil {
+		return "", err
+	}
+	shortCommit, err := c.findBoringReleaseCommit(releases)
+	if err != nil {
+		return "", err
+	}
+
+	// Fill in history to find the full commit hash.
+	if err := c.runGitCmd("fetch", c.Upstream, "+refs/heads/dev.boringcrypto*:refs/heads/boring*"); err != nil {
+		return "", err
+	}
+	return c.revParse(shortCommit)
+}
+
+// findBoringReleaseCommit finds a line in the RELEASES file that matches our tag, or returns an
+// error. This method is lenient with unusual lines, skipping them.
+func (c *boringChecker) findBoringReleaseCommit(content string) (string, error) {
+	s := bufio.NewScanner(strings.NewReader(content))
+	for s.Scan() {
+		// Ignore comments.
+		if strings.HasPrefix(s.Text(), "#") {
+			continue
+		}
+		parts := strings.Fields(s.Text())
+		if len(parts) < 3 {
+			continue
+		}
+		version, shortCommit, platform := parts[0], parts[1], parts[2]
+		// Each release has a "src" and "linux-amd64" line. (And more, in the future?) They're the
+		// same as far as we care, but we're building from source, so might as well stick to src.
+		if platform != "src" {
+			continue
+		}
+		// Take the version part and remove "b7" or similar suffix to correspond to the Go version.
+		i := strings.LastIndex(version, "b")
+		if i == -1 {
+			continue
+		}
+		version = version[0:i]
+
+		if "go"+c.Version != version {
+			continue
+		}
+		log.Printf("Found matching line: %v\n", s.Text())
+		return shortCommit, nil
+	}
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("reached end of boring RELEASES file without finding target release %v", c.Version)
+}

--- a/cmd/releasego/get-upstream-commit_test.go
+++ b/cmd/releasego/get-upstream-commit_test.go
@@ -108,6 +108,12 @@ func newEmptyGitRepo(t *testing.T) *gitRepo {
 
 func newUpstreamGitRepo(t *testing.T) *gitRepo {
 	upstream := newEmptyGitRepo(t)
+	if err := upstream.runGitCmd("config", "--local", "user.name", "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := upstream.runGitCmd("config", "--local", "user.email", "test@example.com"); err != nil {
+		t.Fatal(err)
+	}
 	if err := upstream.runGitCmd("commit", "--allow-empty", "-m", "Initial commit"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/releasego/get-upstream-commit_test.go
+++ b/cmd/releasego/get-upstream-commit_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"testing"
+)
+
+var testTag = "go1.2.3"
+
+func Test_tagChecker_Check_existingTag(t *testing.T) {
+	local, upstream := newFixture(t)
+	commit := addTag(t, upstream)
+
+	c := &tagChecker{
+		gitRepo: *local,
+		Tag:     testTag,
+	}
+
+	got, err := c.Check()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != commit {
+		t.Errorf("Check() got = %v, want %v", got, commit)
+	}
+}
+
+func Test_tagChecker_Check_tagOnSecondCall(t *testing.T) {
+	local, upstream := newFixture(t)
+
+	c := &tagChecker{
+		gitRepo: *local,
+		Tag:     testTag,
+	}
+
+	if _, err := c.Check(); err == nil {
+		t.Error("expected error: Check should fail when tag doesn't exist in upstream")
+	}
+
+	commit := addTag(t, upstream)
+
+	got, err := c.Check()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != commit {
+		t.Errorf("Check() got = %v, want %v", got, commit)
+	}
+}
+
+func Test_boringChecker_findBoringReleaseCommit1(t *testing.T) {
+	// https://github.com/golang/go/blob/dev.boringcrypto/misc/boring/RELEASES
+	content := `# This file lists published Go+BoringCrypto releases.
+# Each line describes a single release: <version> <git commit> <target> <URL> <sha256sum>
+go1.16.14b7 e90b835f3071 linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.16.14b7.linux-amd64.tar.gz 5024e1231d33b9dfffdd7821132dd32eccd42e7415f25618dc8c7304b335edd9
+go1.16.14b7 e90b835f3071 src https://go-boringcrypto.storage.googleapis.com/go1.16.14b7.src.tar.gz caef2ef601bcc588e6bcb511087c9620200723a4c74191b725fbda94c3be884b
+go1.17.8b7 4ea866a9969f linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.17.8b7.linux-amd64.tar.gz 4a1fa2c8d77309e1ef5bafe7e80e75c06e70c0ae1212d9f3d95485017155491d
+go1.17.8b7 4ea866a9969f src https://go-boringcrypto.storage.googleapis.com/go1.17.8b7.src.tar.gz e42ac342c315d33c47434299a24f33137e7099f278ee6669404c4d7e49e17bcf
+go1.16.15b7 649671b08fbd linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.16.15b7.linux-amd64.tar.gz 4d62f517786266019c721c35330e23da123eb184eadb5a79379fe81d31d856db
+go1.16.15b7 649671b08fbd src https://go-boringcrypto.storage.googleapis.com/go1.16.15b7.src.tar.gz 54fc7f2ec0b72b0aaf7726eb5f7f57885252ef46c2c1ca238090cc57850e3ef7
+go1.18b7 0622ea4d9068 linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.18b7.linux-amd64.tar.gz baa33bc66b8df97a3c5a328637b85f04d5629f139dc2df946c09ab7214510c61
+go1.18b7 0622ea4d9068 src https://go-boringcrypto.storage.googleapis.com/go1.18b7.src.tar.gz 6028ffee59903934a3182d45ee3e0c1c9f47fb98f05d9bbb2fabb4771db60792
+go1.18.1b7 d003f0850a7d linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.18.1b7.linux-amd64.tar.gz a5b3985341de6ca54f6a8e13e9ae695f0ee202207e25f082c3895a8fc6f89f64
+go1.18.1b7 d003f0850a7d src https://go-boringcrypto.storage.googleapis.com/go1.18.1b7.src.tar.gz c7f91549b3a197e4a08f64e07546855ca8f82d597f60fd23c7ad2f082640a9fe
+go1.17.9b7 ed86dfc4e441 linux-amd64 https://go-boringcrypto.storage.googleapis.com/go1.17.9b7.linux-amd64.tar.gz 9469d1b4c10f59c921c4666c52baba5f6ca63b1cce0eca95e03b5713ef27577c
+go1.17.9b7 ed86dfc4e441 src https://go-boringcrypto.storage.googleapis.com/go1.17.9b7.src.tar.gz 5d6bfe543a9a2bf6d8749973c771e40127b8020a769ecc5fb41d0dbd7deae9a6`
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{"find existing", "1.16.15", "649671b08fbd", false},
+		{"error if not existing", "1.18.12", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &boringChecker{Version: tt.version}
+			got, err := c.findBoringReleaseCommit(content)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findBoringReleaseCommit() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("findBoringReleaseCommit() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newFixture(t *testing.T) (local, upstream *gitRepo) {
+	local = newEmptyGitRepo(t)
+	upstream = newUpstreamGitRepo(t)
+	local.Upstream = upstream.GitDir
+	return
+}
+
+func newEmptyGitRepo(t *testing.T) *gitRepo {
+	c := &gitRepo{GitDir: t.TempDir()}
+	if err := c.runGitCmd("init"); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func newUpstreamGitRepo(t *testing.T) *gitRepo {
+	upstream := newEmptyGitRepo(t)
+	if err := upstream.runGitCmd("commit", "--allow-empty", "-m", "Initial commit"); err != nil {
+		t.Fatal(err)
+	}
+	return upstream
+}
+
+func addTag(t *testing.T, upstream *gitRepo) string {
+	if err := upstream.runGitCmd("tag", testTag); err != nil {
+		t.Fatal(err)
+	}
+	commit, err := upstream.revParse(testTag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return commit
+}

--- a/cmd/releasego/main.go
+++ b/cmd/releasego/main.go
@@ -118,3 +118,9 @@ func appendPathAndVerificationFilePaths(p []string, path string) []string {
 	}
 	return p
 }
+
+// setAzDOPipelineVariable uses an AzDO logging command to set a variable in the pipeline.
+// https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
+func setAzDOPipelineVariable(name, value string) {
+	fmt.Printf("##vso[task.setvariable variable=%v]%v\n", name, value)
+}

--- a/goversion/goversion.go
+++ b/goversion/goversion.go
@@ -90,6 +90,19 @@ func (v *GoVersion) Full() string {
 	return v.MajorMinorPatchRevision() + v.NoteWithPrefix()
 }
 
+// UpstreamFormatGitTag returns the version in the format upstream uses for Git tags. Specifically,
+// revision, note, and trailing ".0" strings are omitted, and the prefix is "go".
+func (v *GoVersion) UpstreamFormatGitTag() string {
+	n := v.Major
+	if v.Patch != "0" || v.Minor != "0" {
+		n += "." + v.Minor
+	}
+	if v.Patch != "0" {
+		n += "." + v.Patch
+	}
+	return "go" + n
+}
+
 // NoteWithPrefix is a utility to help with version string construction. Returns Note with a "-"
 // prefix, or empty string if Note isn't specified.
 func (v *GoVersion) NoteWithPrefix() string {

--- a/goversion/goversion_test.go
+++ b/goversion/goversion_test.go
@@ -78,3 +78,25 @@ func TestVersion_parseVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGoVersion_UpstreamFormatGitTag(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"drop all zeros", "1.0.0", "go1"},
+		{"do not drop middle zero", "1.0.1", "go1.0.1"},
+		{"drop ending zero", "1.1.0", "go1.1"},
+		{"never drop ones", "1.1.1", "go1.1.1"},
+		{"drop zeroes for v2", "2.0.0", "go2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := New(tt.version)
+			if got := v.UpstreamFormatGitTag(); got != tt.want {
+				t.Errorf("UpstreamFormatGitTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/423

Add `releasego get-upstream-commit` that polls upstream for a release and gets the full commit hash for use by later steps in the release process.

The point is to put it in a pipeline, but this would already be useful. Instead of manually refreshing the RELEASES file in the boring branch: `releasego get-upstream-commit -version 1.17.8-fips ; (New-Object -ComObject Sapi.spvoice).speak("Time for boring!")`