### PR TITLE
Add microsoft/go release-build automation

### DIFF
--- a/azdo/azdo.go
+++ b/azdo/azdo.go
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package azdo
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
+)
+
+// ClientFlags is a set of command-line flags always used in go-infra to access the AzDO APIs.
+type ClientFlags struct {
+	// Org is the base URL of the organization, such as 'https://dev.azure.com/dnceng/'
+	Org *string
+	// Proj is the project, such as 'public' or 'internal'.
+	Proj *string
+	// PAT is the Personal Access Token to use.
+	PAT *string
+}
+
+// BindClientFlags creates a ClientFlags struct where each field is set up as a flag.
+func BindClientFlags() *ClientFlags {
+	return &ClientFlags{
+		Org:  flag.String("org", "", "[Required] The AzDO organization URL."),
+		Proj: flag.String("proj", "", "[Required] The AzDO project URL."),
+		PAT:  flag.String("azdopat", "", "[Required] The Azure DevOps PAT to use."),
+	}
+}
+
+// EnsureAssigned can be called after "flag.Parse()" to ensure all required flags were specified.
+func (c *ClientFlags) EnsureAssigned() error {
+	if *c.Org == "" {
+		return errors.New("no AzDO org specified")
+	}
+	if *c.Proj == "" {
+		return errors.New("no AzDO project URL specified")
+	}
+	if *c.PAT == "" {
+		return errors.New("no AzDO PAT specified")
+	}
+	return nil
+}
+
+// NewConnection creates an AzDO connection based on the given flags.
+func (c *ClientFlags) NewConnection() *azuredevops.Connection {
+	return azuredevops.NewPatConnection(*c.Org, *c.PAT)
+}
+
+// GetBuildWebURL finds the web/UI URL (not API endpoint URL) in the given AzDO Build, if it exists.
+func GetBuildWebURL(b *build.Build) (string, bool) {
+	links, ok := b.Links.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	web, ok := links["web"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	href, ok := web["href"]
+	if !ok {
+		return "", false
+	}
+	s, ok := href.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// SetPipelineVariable uses an AzDO logging command to set a variable in the pipeline.
+// https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
+func SetPipelineVariable(name, value string) {
+	fmt.Printf("##vso[task.setvariable variable=%v]%v\n", name, value)
+}

--- a/buildmodel/commands.go
+++ b/buildmodel/commands.go
@@ -211,7 +211,7 @@ func SubmitUpdatePR(f *PRFlags) error {
 
 		if parsedOrigin != nil {
 			fmt.Println("---- Checking for an existing PR for this base branch and origin...")
-			existingPR, err = gitpr.FindExistingPR(
+			pr, err := gitpr.FindExistingPR(
 				request,
 				parsedPRHeadRemote,
 				parsedOrigin,
@@ -221,6 +221,7 @@ func SubmitUpdatePR(f *PRFlags) error {
 			if err != nil {
 				return err
 			}
+			existingPR = pr.ID
 			if existingPR != "" {
 				fmt.Printf("---- Found PR ID: %v\n", existingPR)
 			} else {

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -129,6 +129,7 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 	if err != nil {
 		return err
 	}
+        defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -12,7 +13,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/go-infra/azdo"
@@ -113,7 +113,7 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(bodyJSON)))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyJSON))
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 	if err != nil {
 		return err
 	}
-        defer resp.Body.Close()
+	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "build-pipeline",
+		Summary: "Queue an AzDO build pipeline.",
+		Description: `
+
+Takes extra args: parameters and variables to queue the build with. Pass a parameter by passing
+three args 'p <name> <value>', or pass a variable with 'v <name> <value>'.
+`,
+		TakeArgsReason: "Parameters and variables to pass to the build.",
+		Handle:         handleBuildPipeline,
+	})
+}
+
+func handleBuildPipeline(p subcmd.ParseFunc) error {
+	id := flag.String("id", "", "[Required] The ID of the AzDO pipeline to queue.")
+	commit := flag.String("commit", "", "A specific commit to build.")
+	branch := flag.String("branch", "", "The branch that contains commit. Only necessary if the repo's default branch doesn't contain commit.")
+	setVariable := flag.String("set-azdo-variable", "", "An AzDO variable name to set to the ID of the queued build.")
+	azdoFlags := azdo.BindClientFlags()
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *id == "" {
+		flag.Usage()
+		log.Fatalln("No pipeline ID specified.")
+	}
+	if err := azdoFlags.EnsureAssigned(); err != nil {
+		flag.Usage()
+		return err
+	}
+
+	var parameters = make(map[string]string)
+	var variables = make(map[string]string)
+
+	if url := getEnvBuildURL(); url != "" {
+		variables["DebugGoReleaseQueuePipelineOriginURL"] = getEnvBuildURL()
+	}
+
+	for i := 0; i < len(flag.Args()); i++ {
+		a := flag.Args()[i]
+		remaining := flag.Args()[i:]
+		switch a {
+		case "p":
+			if len(remaining) < 3 {
+				return fmt.Errorf("not enough args remaining for 'p': %v", remaining)
+			}
+			parameters[remaining[1]] = remaining[2]
+			i += 2
+
+		case "v":
+			if len(remaining) < 3 {
+				return fmt.Errorf("not enough args remaining for 'v': %v", remaining)
+			}
+			variables[remaining[1]] = remaining[2]
+			i += 2
+
+		default:
+			flag.Usage()
+			log.Fatalf("Unrecognized arg: %v\n", a)
+		}
+	}
+
+	ctx := context.Background()
+
+	// Make our own client. The AzDO library doesn't support the 7.1 API needed to pass parameters:
+	// https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-7.1
+	client := new(http.Client)
+
+	variablesJSON, err := json.Marshal(variables)
+	if err != nil {
+		return err
+	}
+
+	url := *azdoFlags.Org + *azdoFlags.Proj + "/_apis/build/builds?definitionId=" + *id + "&api-version=7.1-preview.7"
+	body := map[string]interface{}{
+		"definition": map[string]interface{}{
+			"id": *id,
+		},
+		"sourceBranch":       *branch,
+		"sourceVersion":      *commit,
+		"templateParameters": parameters,
+		// Variables is a JSON string of a map[string]string. "parameters" is a legacy name in the
+		// AzDO UI--this is unrelated to the template parameters.
+		"parameters": string(variablesJSON),
+	}
+
+	bodyJSON, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(string(bodyJSON)))
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Sending body:\n%v\n", string(bodyJSON))
+
+	// Based on https://github.com/microsoft/azure-devops-go-api/blob/00dac5c867394a3c5ca4e12b6965d7625a1588c6/azuredevops/client.go#L172-L181
+	req.Header.Add("Authorization", azdoFlags.NewConnection().AuthorizationString)
+	req.Header.Add("Accept", "application/json;api-version=7.1-preview.7")
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		return fmt.Errorf("non-success status code: %#v\nresponse data: %v", resp, string(bodyBytes))
+	}
+
+	var b build.Build
+	if err := json.Unmarshal(bodyBytes, &b); err != nil {
+		return err
+	}
+
+	log.Printf("Queued build id %v\n", *b.Id)
+	if *setVariable != "" {
+		azdo.SetPipelineVariable(*setVariable, strconv.Itoa(*b.Id))
+	}
+
+	if url, ok := azdo.GetBuildWebURL(&b); ok {
+		log.Printf("Web build URL: %v\n", url)
+	} else {
+		log.Printf("Unable to find web URL in API response: %v\n", b.Links)
+	}
+
+	return nil
+}

--- a/cmd/releasego/check-limits.go
+++ b/cmd/releasego/check-limits.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/subcmd"
 )
 
@@ -20,19 +21,19 @@ func init() {
 }
 
 func handleCheckLimits(p subcmd.ParseFunc) error {
-	pat := githubPATFlag()
+	pat := githubutil.BindPATFlag()
 
 	if err := p(); err != nil {
 		return err
 	}
 
 	ctx := context.Background()
-	client, err := githubClient(ctx, *pat)
+	client, err := githubutil.NewClient(ctx, *pat)
 	if err != nil {
 		return err
 	}
 
-	return retry(func() error {
+	return githubutil.Retry(func() error {
 		limits, _, err := client.RateLimits(ctx)
 		if err != nil {
 			return err

--- a/cmd/releasego/get-merged-pr-commit.go
+++ b/cmd/releasego/get-merged-pr-commit.go
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/google/go-github/github"
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "get-merged-pr-commit",
+		Summary: "Get the commit that merging the given PR created, or poll if the PR is not yet merged.",
+		Description: `
+
+If the PR is not on track to be merged automatically, prints an error and return exit code 1. For
+example, fail if auto-merge is not enabled or CI failed. This lets release automation continue and
+alert a dev that the process is not proceeding smoothly.
+`,
+		Handle: handleGetMergedPRCommit,
+	})
+}
+
+func handleGetMergedPRCommit(p subcmd.ParseFunc) error {
+	repo := githubutil.BindRepoFlag()
+	pat := githubutil.BindPATFlag()
+	prNumber := flag.Int("pr", 0, "[Required] The PR number to check.")
+	pollDelaySeconds := flag.Int("poll-delay", 5, "Number of seconds to wait between each poll attempt.")
+	setVariable := flag.String("set-azdo-variable", "", "An AzDO variable name to set.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	owner, name, err := githubutil.ParseRepoFlag(repo)
+	if err != nil {
+		return err
+	}
+	if *prNumber == 0 {
+		return errors.New("no pr number specified")
+	}
+	pollDelay := time.Duration(*pollDelaySeconds) * time.Second
+
+	ctx := context.Background()
+	client, err := githubutil.NewClient(ctx, *pat)
+	if err != nil {
+		return err
+	}
+
+	var commit string
+	for {
+		// Use retry to fetch the PR info: handles rate limit and other temporary errors.
+		var pr *github.PullRequest
+		if err := githubutil.Retry(func() error {
+			pr, _, err = client.PullRequests.Get(ctx, owner, name, *prNumber)
+			return err
+		}); err != nil {
+			return err
+		}
+
+		commit, err = checkPRCompleteMergeCommit(pr)
+		if err != nil {
+			return err
+		}
+
+		if commit != "" {
+			break
+		}
+
+		headCommit := pr.Head.GetSHA()
+
+		log.Printf(
+			"Examining CI checks on commit %v from PR %v to determine if PR still has a chance to be merged...",
+			headCommit, pr.GetHTMLURL())
+
+		var checks []*github.CheckRun
+		if err := githubutil.FetchEachPage(func(options github.ListOptions) (*github.Response, error) {
+			completed := "completed"
+			result, resp, err := client.Checks.ListCheckRunsForRef(
+				ctx, owner, name, headCommit,
+				&github.ListCheckRunsOptions{
+					Status:      &completed,
+					ListOptions: options,
+				})
+			if err != nil {
+				return nil, err
+			}
+			checks = append(checks, result.CheckRuns...)
+			return resp, nil
+		}); err != nil {
+			return err
+		}
+
+		log.Printf("Found %v complete check runs.\n", len(checks))
+		for _, c := range checks {
+			if c.GetConclusion() == "failure" {
+				return fmt.Errorf("failed check detected: %v PR most likely won't auto-merge", c.GetHTMLURL())
+			}
+		}
+
+		log.Printf("It looks like this PR might merge in the future. Will check again in after %v...\n", pollDelay)
+		time.Sleep(pollDelay)
+	}
+
+	if *setVariable != "" {
+		azdo.SetPipelineVariable(*setVariable, commit)
+	}
+	log.Printf("Found merged commit hash: %v\n", commit)
+	return nil
+}
+
+func checkPRCompleteMergeCommit(pr *github.PullRequest) (string, error) {
+	if pr.GetMerged() {
+		return pr.GetMergeCommitSHA(), nil
+	}
+	if pr.GetState() == "closed" {
+		return "", fmt.Errorf("pull request is closed without being merged: %v", pr.GetHTMLURL())
+	}
+	return "", nil
+}

--- a/cmd/releasego/get-target-branch.go
+++ b/cmd/releasego/get-target-branch.go
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"log"
+
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "get-target-branch",
+		Summary: "Calculate the target branch for a given release version.",
+		Handle:  handleGetTargetBranch,
+	})
+}
+
+func handleGetTargetBranch(p subcmd.ParseFunc) error {
+	version := flag.String(
+		"version", "",
+		"[Required] A full microsoft/goversion number (major.minor.patch-revision[-suffix]).\n"+
+			"The configuration file is filtered to a single entry and branch using this info.")
+
+	setVariableBranchName := flag.String(
+		"set-azdo-variable-branch-name", "",
+		"An AzDO variable name to set to the name of the branch that the sync PR is based on.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *version == "" {
+		return errors.New("no version specified")
+	}
+
+	v := goversion.New(*version)
+	versionUpstream := versionBranch(v)
+
+	log.Printf("Target branch name: %v\n", versionUpstream)
+	if *setVariableBranchName != "" {
+		azdo.SetPipelineVariable(*setVariableBranchName, versionUpstream)
+	}
+
+	return nil
+}

--- a/cmd/releasego/get-upstream-commit.go
+++ b/cmd/releasego/get-upstream-commit.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/microsoft/go-infra/azdo"
 	"github.com/microsoft/go-infra/executil"
 	"github.com/microsoft/go-infra/goversion"
 	"github.com/microsoft/go-infra/subcmd"
@@ -95,7 +96,7 @@ func handleWaitUpstream(p subcmd.ParseFunc) error {
 
 	result := poll(checker, pollDelay)
 	if *azdoVarName != "" {
-		setAzDOPipelineVariable(*azdoVarName, result)
+		azdo.SetPipelineVariable(*azdoVarName, result)
 	}
 	return nil
 }

--- a/cmd/releasego/sync.go
+++ b/cmd/releasego/sync.go
@@ -54,7 +54,7 @@ func handleSync(p subcmd.ParseFunc) error {
 		"An AzDO variable name to set to the sync PR number, or nil if no sync PR is created.")
 	setVariableUpToDateCommit := flag.String(
 		"set-azdo-variable-up-to-date-commit", "",
-		"An AzDO variable name to set to the sync PR number, or nil if no sync PR is created.")
+		"An AzDO variable name to set to nil if a sync PR is created, otherwise the full commit hash that was found to be already up to date.")
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -160,13 +160,4 @@ func findTarget(entries []sync.ConfigEntry, repo string, upstream string) (*sync
 		}
 	}
 	return foundEntry, foundTarget, nil
-}
-
-// versionBranch determines the upstream branch that a given release version belongs to.
-func versionBranch(v *goversion.GoVersion) string {
-	branchBase := "release-branch.go"
-	if v.Note == "fips" {
-		branchBase = "dev.boringcrypto.go"
-	}
-	return branchBase + v.MajorMinor()
 }

--- a/cmd/releasego/sync.go
+++ b/cmd/releasego/sync.go
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/subcmd"
+	"github.com/microsoft/go-infra/sync"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "sync",
+		Summary: "Sync the right branch to the specified release.",
+		Description: `
+
+This command ensures the repository either has a commit that will build the specified upstream
+release, or creates an open PR that updates a branch's submodule to the correct commit.
+
+The command reports the result by setting AzDO variables named by each '-set-*' flag.
+
+If opening a PR is necessary, uses the upstream sync infrastructure:
+github.com/microsoft/go-infra/cmd/sync.
+
+If using the default temp directory for sync PR generation, run this command inside the root of a
+Git clone of the go-infra repository. The default directory is stored in 'eng/artifacts'.
+`,
+		Handle: handleSync,
+	})
+}
+
+func handleSync(p subcmd.ParseFunc) error {
+	repo := githubutil.BindRepoFlag()
+	version := flag.String(
+		"version", "",
+		"[Required] A full microsoft/goversion number (major.minor.patch-revision[-suffix]).\n"+
+			"The configuration file is filtered to a single entry and branch using this info.")
+
+	commit := flag.String("commit", "", "The upstream commit to update to.")
+
+	setVariablePRNumber := flag.String(
+		"set-azdo-variable-pr-number", "",
+		"An AzDO variable name to set to the sync PR number, or nil if no sync PR is created.")
+	setVariableUpToDateCommit := flag.String(
+		"set-azdo-variable-up-to-date-commit", "",
+		"An AzDO variable name to set to the sync PR number, or nil if no sync PR is created.")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	syncFlags := sync.BindFlags(wd)
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *version == "" {
+		return errors.New("no version specified")
+	}
+
+	entries, err := syncFlags.ReadConfig()
+	if err != nil {
+		return err
+	}
+	v := goversion.New(*version)
+	versionUpstream := versionBranch(v)
+
+	foundEntry, foundTarget, err := findTarget(entries, *repo, versionUpstream)
+	if err != nil {
+		return err
+	}
+
+	if foundEntry == nil {
+		return fmt.Errorf("unable to find config entry matching %q for version %q", versionUpstream, v.Full())
+	}
+
+	// Remove all branch mappings other than the one we want to sync.
+	foundEntry.BranchMap = map[string]string{versionUpstream: foundTarget}
+	if *commit != "" {
+		// Use the target commit, not just what happens to be the latest.
+		foundEntry.SourceBranchLatestCommit = map[string]string{versionUpstream: *commit}
+	}
+
+	dir, err := syncFlags.MakeGitWorkDir()
+	if err != nil {
+		return err
+	}
+
+	results, err := sync.MakeBranchPRs(syncFlags, dir, foundEntry)
+	if err != nil {
+		return err
+	}
+
+	if len(results) != 1 {
+		return fmt.Errorf("expected one result, got %v: %v", len(results), results)
+	}
+
+	r := results[0]
+
+	if r.Commit == "" {
+		return fmt.Errorf("commit string empty in sync result %v", r)
+	}
+
+	if r.PR == nil {
+		log.Printf("No PR created for commit: %v\n", r.Commit)
+		if *setVariablePRNumber != "" {
+			azdo.SetPipelineVariable(*setVariablePRNumber, "nil")
+		}
+		if *setVariableUpToDateCommit != "" {
+			azdo.SetPipelineVariable(*setVariableUpToDateCommit, r.Commit)
+		}
+	} else {
+		log.Printf("Created PR: %v\n", r.PR.Number)
+		if *setVariablePRNumber != "" {
+			azdo.SetPipelineVariable(*setVariablePRNumber, strconv.Itoa(r.PR.Number))
+		}
+		if *setVariableUpToDateCommit != "" {
+			azdo.SetPipelineVariable(*setVariableUpToDateCommit, "nil")
+		}
+	}
+
+	return nil
+}
+
+// findTarget searches through entries to find a config entry matching the given repo and upstream
+// branch. Returns the found config entry and the target branch, nil if none is found, or an error
+// if multiple matches are found.
+func findTarget(entries []sync.ConfigEntry, repo string, upstream string) (*sync.ConfigEntry, string, error) {
+	var foundEntry *sync.ConfigEntry
+	var foundTarget string
+	for i := range entries {
+		entry := &entries[i]
+		if !strings.HasSuffix(entry.Target, repo) {
+			continue
+		}
+		for u, target := range entry.BranchMap {
+			if u != upstream {
+				continue
+			}
+			if foundEntry != nil {
+				return nil, "", fmt.Errorf(
+					"found entry matching target repo and upstream branch %q %q targeting %q, but already found %q targeting %q",
+					entry.Target, u, target,
+					foundEntry.Target, foundTarget)
+			}
+			foundEntry = entry
+			foundTarget = target
+		}
+	}
+	return foundEntry, foundTarget, nil
+}
+
+// versionBranch determines the upstream branch that a given release version belongs to.
+func versionBranch(v *goversion.GoVersion) string {
+	branchBase := "release-branch.go"
+	if v.Note == "fips" {
+		branchBase = "dev.boringcrypto.go"
+	}
+	return branchBase + v.MajorMinor()
+}

--- a/cmd/releasego/wait-azdo-commit.go
+++ b/cmd/releasego/wait-azdo-commit.go
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "wait-azdo-commit",
+		Summary: "Wait until the commit is available in the specified AzDO repo.",
+		Handle:  handleWaitAzDOCommit,
+	})
+}
+
+func handleWaitAzDOCommit(p subcmd.ParseFunc) error {
+	commit := flag.String("commit", "", "[Required] The commit to check for.")
+	name := flag.String("name", "", "[Required] The AzDO repo name to query.")
+	pollDelaySeconds := flag.Int("poll-delay", 5, "Number of seconds to wait between each poll attempt.")
+	azdoFlags := azdo.BindClientFlags()
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *commit == "" {
+		flag.Usage()
+		log.Fatalln("No commit specified.")
+	}
+	if *name == "" {
+		flag.Usage()
+		log.Fatalln("No repo name specified.")
+	}
+	if err := azdoFlags.EnsureAssigned(); err != nil {
+		flag.Usage()
+		return err
+	}
+
+	pollDelay := time.Duration(*pollDelaySeconds) * time.Second
+
+	ctx := context.Background()
+
+	c, err := git.NewClient(ctx, azdoFlags.NewConnection())
+	if err != nil {
+		return err
+	}
+
+	for {
+		_, err := c.GetCommit(ctx, git.GetCommitArgs{
+			CommitId:     commit,
+			RepositoryId: name,
+			Project:      azdoFlags.Proj,
+		})
+		if err == nil {
+			log.Println("Found commit.")
+			break
+		}
+		log.Printf("Unable to find commit: %v, next poll in %v...", err, pollDelay)
+		time.Sleep(pollDelay)
+	}
+
+	return nil
+}

--- a/cmd/releasego/wait-build.go
+++ b/cmd/releasego/wait-build.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "wait-build",
+		Summary: "Wait until the AzDO Pipeline build is complete and successful.",
+		Handle:  handleWaitBuild,
+	})
+}
+
+func handleWaitBuild(p subcmd.ParseFunc) error {
+	id := flag.Int("id", 0, "[Required] The AzDO build ID (not build number) to query.")
+	pollDelaySeconds := flag.Int("poll-delay", 5, "Number of seconds to wait between each poll attempt.")
+	azdoFlags := azdo.BindClientFlags()
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *id == 0 {
+		flag.Usage()
+		log.Fatalln("No ID specified.")
+	}
+	if err := azdoFlags.EnsureAssigned(); err != nil {
+		flag.Usage()
+		return err
+	}
+
+	pollDelay := time.Duration(*pollDelaySeconds) * time.Second
+
+	ctx := context.Background()
+
+	c, err := build.NewClient(ctx, azdoFlags.NewConnection())
+	if err != nil {
+		return err
+	}
+
+	for {
+		b, err := c.GetBuild(ctx, build.GetBuildArgs{
+			BuildId: id,
+			Project: azdoFlags.Proj,
+		})
+		if err != nil {
+			return err
+		}
+
+		url, _ := azdo.GetBuildWebURL(b)
+
+		if *b.Status != build.BuildStatusValues.Completed {
+			log.Printf("Build status: %v, next poll in %v... %v\n", *b.Status, pollDelay, url)
+			time.Sleep(pollDelay)
+			continue
+		}
+
+		if *b.Result != build.BuildResultValues.Succeeded &&
+			*b.Result != build.BuildResultValues.PartiallySucceeded {
+
+			return fmt.Errorf("build completed, but was not successful: result %q %v", *b.Result, url)
+		}
+
+		log.Printf("Build completed! %v", url)
+		log.Printf("Success. Result: %q\n", *b.Result)
+		break
+	}
+
+	return nil
+}

--- a/cmd/sync/main.go
+++ b/cmd/sync/main.go
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/microsoft/go-infra/buildmodel"
+	"github.com/microsoft/go-infra/sync"
+)
+
+const description = `
+Example: A sync operation dry run:
+
+  go run ./cmd/sync -n
+
+Sync runs a "merge from upstream" and submits it as a PR. This means fetching commits from an
+upstream repo and merging them into corresponding branches in a target repo. This is configured in a
+config file, by default 'eng/sync-config.json'. For each entry in the configuration:
+
+1. Fetch each SourceBranch 'branch' from 'Upstream' to a local temp repository.
+2. Fetch each 'microsoft/{branch}' from 'Target'.
+3. Merge each upstream branch 'b' into corresponding 'microsoft/b'.
+4. Push each merge commit to 'Head' (or 'Target' if 'Head' isn't specified) with a name that follows
+   the pattern 'dev/auto-merge/microsoft/{branch}'.
+5. Create a PR in 'Target' that merges the auto-merge branch. If the PR already exists, overwrite.
+   (Force push.)
+
+This script creates the temporary repository in 'eng/artifacts/' by default.
+
+To run a subset of the syncs specified in the config file, or to swap out URLs for development
+purposes, create a copy of the configuration file and point at it using a '-c' argument.
+`
+
+func main() {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Panic(err)
+	}
+	f := sync.BindFlags(wd)
+
+	buildmodel.ParseBoundFlags(description)
+
+	if err := sync.MakePRs(f); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("\nSuccess.")
+}

--- a/docs/release-process/README.md
+++ b/docs/release-process/README.md
@@ -12,6 +12,9 @@ This doc describes the plan to create Azure Pipelines that run the release steps
 
 The overall effort is tracked by <https://github.com/microsoft/go/issues/423>.
 
+* (2) release-build
+    * ✅ microsoft/go upstream sync, build, and release-go trigger
+    * ⌚ go-images Docker update
 * (3) release-go
     * ✅ aka.ms link generation <https://github.com/microsoft/go/issues/453>
     * ✅ GitHub release generation

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -1,0 +1,249 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Use runtime parameters to define these selections in YML. This also makes them
+# show up in the "Run" popup directly. This makes them much easier to set
+# manually, vs. digging into the Variables submenu with many clicks.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters
+parameters:
+  - name: releaseVersion
+    displayName: Version to release, including Microsoft revision suffix (-1) and boring/FIPS suffix (-fips) if they apply.
+    type: string
+
+  - name: releaseIssue
+    displayName: microsoft/go issue number to comment on once complete, or nil.
+    type: string
+    default: 'nil'
+
+  # Allow retrying a build starting at any of these points.
+  - name: poll1MicrosoftGoPRNumber
+    displayName: '1: microsoft/go PR number to poll for merge.'
+    type: string
+    default: nil
+  - name: poll2MicrosoftGoCommitHash
+    displayName: '2: microsoft/go commit hash to poll for build.'
+    type: string
+    default: nil
+  - name: poll3MicrosoftGoBuildID
+    displayName: '3: internal build ID to poll for completion.'
+    type: string
+    default: nil
+  - name: poll4MicrosoftGoImagesPRNumber
+    displayName: '4: microsoft/go-images PR number to poll for merge.'
+    type: string
+    default: nil
+
+  # This parameter intentionally has no default: see release-go-pipeline.yml
+  - name: goReleaseConfigVariableGroup
+    displayName: '[Use "go-release-config" for a real release] Variable group that specifies release target locations and auth.'
+    type: string
+
+trigger: none
+pr: none
+
+variables:
+  - group: go-akams-config
+  - group: go-akams-auth
+  - group: Microsoft-GoLang-bot
+  - group: DotNet-VSTS-Infra-Access
+  # Import config group. This may direct the build to use secrets from the other groups.
+  - group: ${{ parameters.goReleaseConfigVariableGroup }}
+
+jobs:
+  - job: Release
+    # Let the job overall continue 9 hours before failing. The job time has to account for upstream
+    # availability, sync PR validation jobs, mirroring time, and internal build time. Each waiting
+    # step should specify its own timeout that's just long enough for that particular step, so we
+    # don't need to wait 8 hours to get notified about any particular step taking too long.
+    timeoutInMinutes: 540
+    workspace:
+      clean: all
+    pool:
+      # This is a utility job: use generic recent LTS.
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    variables:
+      assetsDir: $(Pipeline.Workspace)/BuildAssets
+      buildAssetJsonFile: $(assetsDir)/assets.json
+      artifactsDir: $(Pipeline.Workspace)/Artifacts
+      microsoftGoInternalPipeline: 958
+      # Set a variable for each polling parameter. If a variable starts off with 'nil', it will be
+      # overridden with a logging command as the pipeline moves on.
+      MicrosoftGoPRNumber: ${{ parameters.poll1MicrosoftGoPRNumber }}
+      MicrosoftGoCommitHash: ${{ parameters.poll2MicrosoftGoCommitHash }}
+      MicrosoftGoBuildID: ${{ parameters.poll3MicrosoftGoBuildID }}
+      MicrosoftGoImagesPRNumber: ${{ parameters.poll4MicrosoftGoImagesPRNumber }}
+    steps:
+      - script: |
+          # Catch and prevent whole-job retries. Retrying the whole job after a
+          # failure would repeat steps that are already completed.
+          echo 'The "retry" button on this pipeline is forbidden.'
+          echo 'Instead, follow the instructions printed by the "Print Retry Instructions" step in the first attempt of this job.'
+          exit 1
+        displayName: Forbid Retry
+        condition: ne(variables['System.JobAttempt'], 1)
+
+      - template: steps/checkout-unix-task.yml
+
+      - template: steps/init-pwsh-task.yml
+      - template: steps/init-go.yml
+      - template: steps/set-bot-git-author.yml
+
+      - script: |
+          go install ./cmd/releasego
+          echo "##vso[task.prependpath]$(go env GOPATH)/bin"
+        displayName: Install releasego
+
+      - script: releasego check-limits -pat '$(GitHubPAT)'
+        displayName: Check GitHub rate limit
+
+      # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
+      # retry build will have a non-nil value in one of these parameters. Only the value of the last
+      # step's parameter matters.
+      - ${{ if eq(parameters.poll4MicrosoftGoImagesPRNumber, 'nil') }}:
+        - ${{ if eq(parameters.poll3MicrosoftGoBuildID, 'nil') }}:
+          - ${{ if eq(parameters.poll2MicrosoftGoCommitHash, 'nil') }}:
+            - ${{ if eq(parameters.poll1MicrosoftGoPRNumber, 'nil') }}:
+              # Poll for the right commit to use for this release.
+              - script: |
+                  releasego get-upstream-commit \
+                    -version '${{ parameters.releaseVersion }}' \
+                    -set-azdo-variable upstreamReleasedCommit
+                displayName: ⌚ Get upstream commit for release
+                # 6 hours. This step may take an arbitrarily long time while if we ran the release
+                # job preemptively. But at some point, a dev needs to check that the tool is working
+                # properly and the upstream release is progressing as expected.
+                timeoutInMinutes: 360
+              # Either make sure the microsoft/go branch has the correct commit as its submodule, or
+              # submit a PR that sets the submodule commit.
+              - script: |
+                  releasego sync \
+                    -c '$(ReleaseSyncConfigPath)' \
+                    -commit '$(upstreamReleasedCommit)' \
+                    -version '${{ parameters.releaseVersion }}' \
+                    -git-auth pat \
+                    -github-user '$(GitHubUser)' \
+                    -github-pat '$(GitHubPAT)' \
+                    -github-pat-reviewer '$(GitHubPATReviewer)' \
+                    -azdo-dnceng-pat '$(AzDODncengPAT)' \
+                    -set-azdo-variable-pr-number MicrosoftGoPRNumber \
+                    -set-azdo-variable-up-to-date-commit MicrosoftGoCommitHash
+                displayName: Sync to upstream commit
+
+            # Now we have MicrosoftGoPRNumber
+            - script: |
+                releasego get-merged-pr-commit \
+                  -repo '$(TargetGitHubRepo)' \
+                  -pr '$(MicrosoftGoPRNumber)' \
+                  -pat '$(GitHubPAT)' \
+                  -set-azdo-variable MicrosoftGoCommitHash
+              displayName: ⌚ Get sync PR merged commit hash
+              timeoutInMinutes: 60
+              condition: and(succeeded(), ne(variables.MicrosoftGoPRNumber, 'nil'))
+
+          # Now we have MicrosoftGoCommitHash
+          - script: |
+              releasego wait-azdo-commit \
+                -commit '$(MicrosoftGoCommitHash)' \
+                -name '$(TargetAzDORepo)' \
+                -org 'https://dev.azure.com/dnceng/' \
+                -proj 'internal' \
+                -azdopat '$(System.AccessToken)'
+            displayName: ⌚ Wait for internal mirror
+            timeoutInMinutes: 15 # This should be very quick, and a dev can easily fix it.
+          # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
+          # default Branch is "microsoft/main". So, we need to figure out the release branch name
+          # and save it as a variable to pass it to AzDO.
+          #
+          # Testing adds a complication: testing commits won't be found in the actual release
+          # branches, so we need a way to override. This is done using BuildPipelineFullBranchName
+          # from the variable group. For actual releases, it should have the value
+          # "refs/heads/microsoft/$(UpstreamTargetBranchName)". But in a testing variable group, it
+          # can point at any ordinary dev branch that has the sync commit.
+          - script: |
+              releasego get-target-branch \
+                -version '${{ parameters.releaseVersion }}' \
+                -set-azdo-variable-branch-name UpstreamTargetBranchName
+            displayName: Get target branch containing commit
+          - script: |
+              releasego build-pipeline \
+                -commit '$(MicrosoftGoCommitHash)' \
+                -branch '$(BuildPipelineFullBranchName)' \
+                -id '$(GoPipelineID)' \
+                -org 'https://dev.azure.com/dnceng/' \
+                -proj 'internal' \
+                -azdopat '$(System.AccessToken)' \
+                -set-azdo-variable MicrosoftGoBuildID
+            displayName: Run microsoft/go internal build
+
+        # Now we have MicrosoftGoBuildID
+        - script: |
+            releasego wait-build \
+              -id '$(MicrosoftGoBuildID)' \
+              -org 'https://dev.azure.com/dnceng/' \
+              -proj 'internal' \
+              -azdopat '$(System.AccessToken)'
+          displayName: ⌚ Wait for internal build
+          timeoutInMinutes: 120
+        - script: |
+            releasego build-pipeline \
+              -id '$(GoReleasePipelineID)' \
+              -org 'https://dev.azure.com/dnceng/' \
+              -proj 'internal' \
+              -azdopat '$(System.AccessToken)' \
+              p releaseVersion '${{ parameters.releaseVersion }}' \
+              p releaseGoBuildId '$(MicrosoftGoBuildID)' \
+              p releaseIssue '${{ parameters.releaseIssue }}' \
+              p goReleaseConfigVariableGroup '${{ parameters.goReleaseConfigVariableGroup }}'
+          displayName: Run microsoft/go release pipeline
+
+        # Planned work: after microsoft-go is built (without waiting for the  microsoft/go release
+        # pipeline to complete), start running Docker update (microsoft/go-images) and wait for the
+        # Docker update PR to be merged. This may be done by sharing a AzDO YAML template with
+        # update-images-pipeline.yml but pull the build asset JSON file from MicrosoftGoBuildID.
+        #
+        # Until this is done, MicrosoftGoImagesPRNumber will always be 'nil' so the next step will
+        # be skipped.
+        #
+        # docs\release-process\README.md
+
+      # Now we have MicrosoftGoImagesPRNumber if a Docker release is associated with this version.
+      - script: |
+          releasego get-merged-pr-commit \
+            -repo '$(TargetGoImagesGitHubRepo)' \
+            -pr '$(MicrosoftGoImagesPRNumber)' \
+            -pat '$(GitHubPAT)'
+        displayName: ⌚ Wait for go-images update PR merge
+        timeoutInMinutes: 120
+        condition: and(succeeded(), ne(variables.MicrosoftGoImagesPRNumber, 'nil'))
+
+      - script: releasego check-limits -pat $(GitHubPAT)
+        displayName: Check GitHub rate limit
+
+      - ${{ if ne(parameters.releaseIssue, 'nil') }}:
+        - script: |
+            releasego report \
+              -i '${{ parameters.releaseIssue }}' \
+              -m ':white_check_mark: Successfully ran microsoft/go build prep steps for ${{ parameters.releaseVersion }}.' \
+              -repo '$(TargetGitHubRepo)' \
+              -pat '$(GitHubPAT)'
+          displayName: Report Success
+          condition: succeeded()
+        - script: |
+            releasego report \
+              -i '${{ parameters.releaseIssue }}' \
+              -m ':rotating_light: Failed to run microsoft/go build prep steps for ${{ parameters.releaseVersion }}.' \
+              -repo '$(TargetGitHubRepo)' \
+              -pat '$(GitHubPAT)'
+          displayName: Report Failure
+          condition: failed()
+
+      - script: |
+          echo 'To retry, press "Run new" from the build main page and copy the last defined value below into the matching parameter input:'
+          echo ''
+          echo '1: $(MicrosoftGoPRNumber)'
+          echo '2: $(MicrosoftGoCommitHash)'
+          echo '3: $(MicrosoftGoBuildID)'
+          echo '4: $(MicrosoftGoImagesPRNumber)'
+        displayName: 🔁 Print Retry Instructions
+        condition: failed()

--- a/githubutil/githubutil.go
+++ b/githubutil/githubutil.go
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package githubutil
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// NewClient creates a GitHub client using the given personal access token.
+func NewClient(ctx context.Context, pat string) (*github.Client, error) {
+	if pat == "" {
+		return nil, errors.New("no GitHub PAT specified")
+	}
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: pat})
+	tokenClient := oauth2.NewClient(ctx, tokenSource)
+	return github.NewClient(tokenClient), nil
+}
+
+// BindPATFlag returns a flag to specify the personal access token.
+func BindPATFlag() *string {
+	return flag.String("pat", "", "[Required] The GitHub PAT to use.")
+}
+
+// BindRepoFlag returns a flag to specify a GitHub repo to target. Parse it with ParseRepoFlag.
+func BindRepoFlag() *string {
+	return flag.String("repo", "", "[Required] The target repo, in '{owner}/{repo}' form.")
+}
+
+// ParseRepoFlag splits a given repo (owner/name) into owner and name, or returns an error.
+func ParseRepoFlag(repo *string) (owner, name string, err error) {
+	if *repo == "" {
+		return "", "", errors.New("repo not specified")
+	}
+	var found bool
+	owner, name, found = strings.Cut(*repo, "/")
+	if !found {
+		return "", "", fmt.Errorf("unable to split repo into owner and name: %v", repo)
+	}
+	return
+}
+
+const retryAttempts = 5
+const maxRateLimitResetWait = time.Minute * 15
+const rateLimitResetWaitSlack = time.Second * 5
+
+// Retry runs f up to 'retryAttempts' times, printing the error if one is encountered. Handles
+// GitHub rate limit exceeded errors by waiting, if the reset will happen reasonably soon.
+func Retry(f func() error) error {
+	var i = 0
+	for ; i < retryAttempts; i++ {
+		log.Printf("   attempt %v/%v...\n", i+1, retryAttempts)
+		err := f()
+		if err != nil {
+			log.Printf("...attempt %v/%v failed with error: %v\n", i+1, retryAttempts, err)
+			if i+1 < retryAttempts {
+				var rateErr *github.RateLimitError
+				if errors.As(err, &rateErr) {
+					resetDuration := rateErr.Rate.Reset.Sub(time.Now())
+
+					log.Printf("...rate limit exceeded. Reset at %v, %v from now.\n", rateErr.Rate.Reset, resetDuration)
+					if resetDuration > maxRateLimitResetWait {
+						log.Printf("...rate limit reset is too far away to reasonably wait. Aborting.")
+						return err
+					}
+
+					// Sleep until the reset, plus some extra in case our clocks aren't synchronized.
+					wait := resetDuration + rateLimitResetWaitSlack
+					log.Printf("...waiting %v before next retry.\n", wait)
+					time.Sleep(wait)
+				}
+				continue
+			}
+			log.Printf("...no retries remaining.\n")
+			return err
+		}
+		break
+	}
+	log.Printf("...attempt %v/%v successful.\n", i+1, retryAttempts)
+	return nil
+}
+
+// FetchEachPage helps fetch all data from a GitHub API call that may or may not span multiple
+// pages. FetchEachPage initially calls f with no paging parameters, then inspects the GitHub
+// response to see if there are more pages to fetch. If so, it constructs paging parameters that
+// will fetch the next page and calls f again. This repeats until there aren't any more pages.
+//
+// Note that FetchEachPage doesn't process any of the result data, and doesn't actually call the
+// GitHub API. f must do this itself. This allows FetchEachPage to work with any GitHub API.
+func FetchEachPage(f func(options github.ListOptions) (*github.Response, error)) error {
+	var options github.ListOptions
+	for {
+		log.Printf("Fetching page %v...\n", options.Page)
+		resp, err := f(options)
+		if err != nil {
+			return err
+		}
+		if resp.NextPage == 0 {
+			return nil
+		}
+		options.Page = resp.NextPage
+	}
+}

--- a/sync/model.go
+++ b/sync/model.go
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package main
+package sync
 
-// SyncConfigEntry is one entry in a sync config file. The file contains a JSON list of objects that
+// ConfigEntry is one entry in a sync config file. The file contains a JSON list of objects that
 // match this struct.
-type SyncConfigEntry struct {
+type ConfigEntry struct {
 	// Upstream is the upstream Git repository to take updates from.
 	Upstream string
 	// UpstreamMirror is an optional upstream-maintained mirror of the Upstream repository.
@@ -42,6 +42,12 @@ type SyncConfigEntry struct {
 	// replaced with the upstream branch name.
 	BranchMap map[string]string
 
+	// SourceBranchLatestCommit is a map of source branch names in Upstream (keys) and a full commit
+	// hash to treat as the latest commit for that source branch, no matter what the upstream
+	// repository says at the time of merge. This map can be used to avoid a race between the sync
+	// infrastructure and upstream merge flow.
+	SourceBranchLatestCommit map[string]string
+
 	// AutoResolveTarget lists files and dirs that Upstream may have modified, but we want to keep
 	// the contents as they are in Target. Normally files that are modified in our fork repos are
 	// all in the 'eng/' directory to avoid merge conflicts (and keep the repository tidy), but in
@@ -53,4 +59,12 @@ type SyncConfigEntry struct {
 	// (default), that indicates the entire Upstream repository should be merged into the Target
 	// repository.
 	SubmoduleTarget string
+}
+
+// PRBranchStorageRepo returns the repo to store the PR branch on.
+func (c *ConfigEntry) PRBranchStorageRepo() string {
+	if c.Head != "" {
+		return c.Head
+	}
+	return c.Target
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package main
+package sync
 
 import (
 	"strings"


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/423

There's more work to do in the future for this pipeline:
* Docker images
* https://github.com/microsoft/go/issues/470
* https://github.com/microsoft/go/issues/542
* https://github.com/microsoft/go/issues/575

---

Add almost all of the release-build section of https://github.com/microsoft/go-infra/blob/main/docs/release-process/README.md#2-release-build. (This PR updates the doc with the specifics.) 

Adds a handful of new tools to `releasego`:

* `build-pipeline` - Run a build of an AzDO pipeline. Used to trigger a microsoft/go build and other release steps.
  * Doesn't wait--see `wait-build`.
* `get-merged-pr-commit` - Get the commit that resulted from merging the given GitHub PR.
  * If the PR hasn't been merged, wait. (Poll.) If something other than merging happens, fail.
  * It also checks if the PR is still will definitely not merge without human intervention and fail immediately to let a human know. This way it doesn't wait around forever for something that will never happen.
*  `get-target-branch` - Gets the target microsoft/go branch for the targeted version number.
* `sync` - Runs the ordinary upstream-sync process and submits a PR, but specialized for the release process.
  * See command desc for more info.
  * I pulled out a lot of old `cmd/sync` functionality into a `sync` package to share between `cmd/sync` and `cmd/releasego/sync.go`. I changed `gitpr.FindExistingPR` to return more data about the PR so that the release pipeline can run further steps on it.
* `wait-azdo-commit` - Wait for a commit (the result of merging the `sync` PR) to show up in the internal mirror of the GitHub repo.
* `wait-build` - Wait for an AzDO build to complete.

`eng/pipelines/release-build-pipeline.yml` combines these to run the release steps.

[Link to the `go-release-config` variable group.](https://dev.azure.com/dnceng/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=156&path=go-release-config)

This PR uses the dependencies I added to the `go.mod` in my last PR:

https://github.com/microsoft/go-infra/blob/850c558938dd65b867bf76b1cb44027ad5606bf8/go.mod#L10-L12

---

Example successful run from the top: https://dev.azure.com/dnceng/internal/_build/results?buildId=1780270&view=results
Uses a temp testing repo on GitHub where I manually merged the sync PR and pushed it to a dev branch in AzDO to keep the run going.

Example run that (intentionally) ran out of time waiting for the AzDO mirror to sync: https://dev.azure.com/dnceng/internal/_build/results?buildId=1780032&view=results. 

