### PR TITLE
Update version files during release automation

### DIFF
--- a/cmd/releasego/sync.go
+++ b/cmd/releasego/sync.go
@@ -93,6 +93,10 @@ func handleSync(p subcmd.ParseFunc) error {
 		foundEntry.SourceBranchLatestCommit = map[string]string{versionUpstream: *commit}
 	}
 
+	// Configure the sync to update the VERSION and MICROSOFT_REVISION files.
+	foundEntry.GoVersionFileContent = v.UpstreamFormatGitTag()
+	foundEntry.GoMicrosoftRevisionFileContent = v.Revision
+
 	dir, err := syncFlags.MakeGitWorkDir()
 	if err != nil {
 		return err

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - template: steps/checkout-unix-task.yml
       - template: steps/init-go.yml
+      - template: steps/set-bot-git-author.yml
 
       # Install the version of gotestsum specified in the ci-tools module.
       - script: |

--- a/sync/model.go
+++ b/sync/model.go
@@ -59,6 +59,17 @@ type ConfigEntry struct {
 	// (default), that indicates the entire Upstream repository should be merged into the Target
 	// repository.
 	SubmoduleTarget string
+
+	// GoVersionFileContent	is empty, or the Go version that the microsoft/go build should use
+	// after the sync. Should be in the upstream format, e.g. go1.17.10 and go1.18. Sync examines
+	// VERSION in the submodule, and if it doesn't match the expected value, creates/updates VERSION
+	// in the outer repo (microsoft/go) to specify it. Otherwise, cleans up the outer VERSION file.
+	GoVersionFileContent string
+
+	// GoMicrosoftRevisionFileContent is empty, or the Microsoft revision (1, 2, ...) that the
+	// microsoft/go build should use after the sync. If 1, removes the MICROSOFT_REVISION file if
+	// one exists. If 2 or more, creates a MICROSOFT_REVISION file to specify it.
+	GoMicrosoftRevisionFileContent string
 }
 
 // PRBranchStorageRepo returns the repo to store the PR branch on.

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -4,6 +4,10 @@
 package sync
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -47,4 +51,194 @@ func Test_createCommitMessageSnippet(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_MakeBranchPRs_VersionUpdate(t *testing.T) {
+	trueBool := true
+	none := "none"
+	f := &Flags{
+		DryRun:        &trueBool,
+		GitAuthString: &none,
+	}
+
+	tests := []struct {
+		name                                               string
+		initialVersion, initialRevision, initialSubVersion string
+		version, revision                                  string
+		wantVersionContent, wantRevisionContent            string
+	}{
+		{
+			"matching version",
+			"", "", "go1.18",
+			"go1.18", "",
+			"", "",
+		},
+		{
+			"create rev2 version (boring branch)",
+			"", "", "",
+			"go1.18", "2",
+			"go1.18", "2",
+		},
+		{
+			"update rev1 version (boring branch)",
+			"go1.18", "2", "",
+			"go1.18.2", "1",
+			"go1.18.2", "",
+		},
+		{
+			"remove version",
+			"go1.18.2", "", "go1.18.3",
+			"go1.18.3", "",
+			"", "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := t.TempDir()
+			// Make sure the path ends in "/<owner>/<repo>" so this part of our mock repository
+			// paths can be parsed as if they're GitHub repository URLs.
+			target := filepath.Join(d, "target") + "/microsoft/go"
+			upstream := filepath.Join(d, "upstream") + "/golang/go"
+
+			workDir := filepath.Join(d, "work")
+
+			// Set up upstream, simulated golang/go.
+			if err := setupMockRepo(upstream, "main"); err != nil {
+				t.Fatal(err)
+			}
+			if tt.initialSubVersion != "" {
+				if err := addMockFile(upstream, "VERSION", tt.initialSubVersion); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Set up target, simulated microsoft/go.
+			if err := setupMockRepo(target, "microsoft/main"); err != nil {
+				t.Fatal(err)
+			}
+			if err := addMockSubmodule(target, upstream); err != nil {
+				t.Fatal(err)
+			}
+			if tt.initialVersion != "" {
+				if err := addMockFile(target, "VERSION", tt.initialVersion); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.initialRevision != "" {
+				if err := addMockFile(target, "MICROSOFT_REVISION", tt.initialRevision); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Simulate an upstream change that needs to be synced.
+			if err := addMockFile(upstream, "release-notes.md", "Bug has been fixed"); err != nil {
+				t.Fatal(err)
+			}
+
+			c := &ConfigEntry{
+				Upstream: upstream,
+				Target:   target,
+				BranchMap: map[string]string{
+					"main": "microsoft/main",
+				},
+				SubmoduleTarget:                "go",
+				GoVersionFileContent:           tt.version,
+				GoMicrosoftRevisionFileContent: tt.revision,
+			}
+
+			_, err := MakeBranchPRs(f, workDir, c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wVersion := filepath.Join(workDir, "VERSION")
+			if tt.wantVersionContent == "" {
+				ensureMissing(t, wVersion)
+			} else {
+				ensureFileContent(t, wVersion, tt.wantVersionContent)
+			}
+
+			wRevision := filepath.Join(workDir, "MICROSOFT_REVISION")
+			if tt.wantRevisionContent == "" {
+				ensureMissing(t, wRevision)
+			} else {
+				ensureFileContent(t, wRevision, tt.wantRevisionContent)
+			}
+		})
+	}
+}
+
+func ensureMissing(t *testing.T, path string) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		t.Fatalf("unknown error while ensuring file %#q is missing: %v", path, err)
+	}
+	t.Errorf("file exists, but shouldn't: %v", path)
+}
+
+func ensureFileContent(t *testing.T, path, want string) {
+	s, err := readFileString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != want {
+		t.Errorf("content wanted: %#q, got: %#q in file %#q", want, s, path)
+	}
+}
+
+func readFileString(path string) (string, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func setupMockRepo(dir, branch string) error {
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+	if err := runGit(dir, "init"); err != nil {
+		return err
+	}
+	if err := runGit(dir, "checkout", "-b", branch); err != nil {
+		return err
+	}
+	// Initial commit, to make sure the branch exists.
+	if err := addMockFile(dir, "README.md", "Hello"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addMockSubmodule(dir, upstream string) error {
+	if err := runGit(dir, "submodule", "add", upstream, "go"); err != nil {
+		return err
+	}
+	if err := runGit(dir, "commit", "-m", "Add submodule"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addMockFile(dir, relativePath, content string) error {
+	if err := os.WriteFile(filepath.Join(dir, relativePath), []byte(content), 0666); err != nil {
+		return err
+	}
+	if err := runGit(dir, "add", "."); err != nil {
+		return err
+	}
+	if err := runGit(dir, "commit", "-m", "Add "+relativePath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return run(cmd)
 }


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/423
* Fixes https://github.com/microsoft/go/issues/575
* Fixes https://github.com/microsoft/go/issues/470

This removes the need to manually set `VERSION` and `MICROSOFT_REVISION` with a dev PR in the middle of a release. Ordinary `sync` can't tell what version it's syncing, but `releasego sync` has the info it needs to set the proper values, and this PR threads it through.

I finally added some high-level `sync` tests to validate this. 😄 We can extend it later to test more parts of `sync`.