### PR TITLE
Make README field flexible in manifest.json model

### DIFF
--- a/buildmodel/dockermanifest/dockermanifest.go
+++ b/buildmodel/dockermanifest/dockermanifest.go
@@ -12,7 +12,10 @@ package dockermanifest
 
 // Manifest is the root object of a 'manifest.json' file.
 type Manifest struct {
-	Readme    string                 `json:"readme"`
+	// Readme can be an object with more details, or a string path. This was recently changed from a
+	// string to an object in the .NET Docker infra's model. For now, be flexible in the go-images
+	// model: we only need to persist the value, not manipulate it.
+	Readme    interface{}            `json:"readme"`
 	Registry  string                 `json:"registry"`
 	Variables map[string]interface{} `json:"variables"`
 	Includes  []string               `json:"includes"`


### PR DESCRIPTION
This PR made `dockerupdate` start failing in the nightly branch:

* https://github.com/microsoft/go-images/pull/126

The model change from `"readme": "README.md"` to `"readme": { "path": "README.md" }` made `dockerupdate` stop being able to marshal the JSON. Simple fix: model it as `interface{}` rather than `string`.

In the future, this kind of break will be caught by running `dockerupdate` during go-images CI to ensure repeatability:
* https://github.com/microsoft/go-images/pull/98