### PR TITLE
Omit archVariant for CBL-Mariner 2.0: same manifest format as CBL-Mariner 1.0

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -263,9 +263,9 @@ func makeOSArchPlatform(os, osVersion string, env *dockerversions.ArchEnv) *dock
 	// to specify more info: a version. .NET Docker infra calls this a "variant". This
 	// is not the same as the Official Go Image "variant" (OS name/version).
 	archVariant := env.GoImageArchVersionSuffix()
-	// CBL-Mariner 1.0 doesn't specify an ARM arch variant (version) in its Docker
-	// manifest, so we must omit it, too: .NET Docker infra checks they match.
-	if osVersion == "cbl-mariner1.0" {
+	// CBL-Mariner 1.0 and 2.0 don't specify an ARM arch variant (version) in the Docker manifest,
+	// so we must omit it, too: .NET Docker infra checks they match.
+	if strings.HasPrefix(osVersion, "cbl-mariner") {
 		archVariant = ""
 	}
 	return &dockermanifest.Platform{

--- a/buildmodel/buildmodel_test.go
+++ b/buildmodel/buildmodel_test.go
@@ -115,6 +115,11 @@ func Test_makeOsArchPlatform(t *testing.T) {
 			args{"linux", "cbl-mariner1.0", "arm64", ""},
 			want{"linux", "cbl-mariner1.0", "arm64", ""},
 		},
+		{
+			"linux-arm64 no version if Mariner 2.0",
+			args{"linux", "cbl-mariner2.0", "arm64", ""},
+			want{"linux", "cbl-mariner2.0", "arm64", ""},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The CBL-Mariner 2.0 image manifest doesn't include the `v8` variant (like 1.0 didn't), so expand the special case from `cbl-mariner1.0` to anything that starts with `cbl-mariner`. This way it includes 2.0 and beyond.

Including the variant in the go-images `manifest.json` file makes the .NET Docker tooling complain that the arch doesn't match:

```
Unhandled exception: System.InvalidOperationException: Platform 'src/microsoft/1.17-fips/cbl-mariner2.0/Dockerfile' is configured with an architecture that is not compatible with the base image 'golangpublicimages.azurecr.io/mirror/cblmariner.azurecr.io/base/core:2.0':
Manifest platform:
	Architecture: ARM64
	Variant: v8
Base image:
	Architecture: ARM64
	Variant: 
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.ValidatePlatformIsCompatibleWithBaseImage(PlatformInfo platform) in /image-builder/src/Commands/BuildCommand.cs:line 417
   at Microsoft.DotNet.ImageBuilder.Commands.BuildCommand.BuildImage(PlatformInfo platform, IEnumerable`1 allTags) in /image-builder/src/Commands/BuildCommand.cs:line 431
...
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=1815952&view=logs&j=1e831885-872d-5776-de5c-f21040121ec9&t=7a04e6f8-48ae-5537-f09d-05931bd02b23&l=212