### PR TITLE
go-patch extract repeatability: consistent `--abbrev=14`

### DIFF
--- a/cmd/git-go-patch/extract.go
+++ b/cmd/git-go-patch/extract.go
@@ -99,6 +99,9 @@ func handleExtract(p subcmd.ParseFunc) error {
 		"git",
 		"format-patch",
 
+		// Set the minimum abbreviation level to a certain value to avoid user-specific defaults,
+		// which may change due to Git version or user configuration.
+		"--abbrev=14",
 		// Remove default signature, which includes the Git version.
 		"--signature=",
 		// Use "From 0000000" instead of "From abc123f" in the patch file. A new commit hash is


### PR DESCRIPTION
Fix go-patch extract repeatability issue @chsienki noticed here:

* https://github.com/microsoft/go/pull/597#pullrequestreview-1013943230

The default abbrev length is indeed settable by `git config` and has changed over time:
https://public-inbox.org/git/CA+55aFy0_pwtFOYS1Tmnxipw9ZkRNCQHmoYyegO00pjMiZQfbg@mail.gmail.com/
https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892

@qmuntal and I have different default abbrev values, which causes thrashing in these patch file lines:

```
index 00000000000..c2c06d3bff8
index 0000000000..c2c06d3bff
```

Choosing 14 here just because it's larger than either of our settings. 😄 As far as I know, there's no big reason to keep them small in this situation.

```
index 00000000000000..c2c06d3bff8c74
```