### PR TITLE
Support prerelease versions and new branches (major versions) in `dockerupdate`

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -6,6 +6,7 @@
 package buildmodel
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -219,43 +220,84 @@ var NoMajorMinorUpgradeMatchError = errors.New("no match found in existing versi
 // UpdateVersions takes a build asset file containing a list of build outputs and updates a
 // versions.json model to consume the new build.
 func UpdateVersions(assets *buildassets.BuildAssets, versions dockerversions.Versions) error {
+	var v *dockerversions.MajorMinorVersion
+
+	// First, try to update an existing major.minor version in the Docker versions file. If it
+	// doesn't exist, try to find the previous version and create a new Docker versions file entry
+	// based on that. If that doesn't exist either, fail.
 	key := assets.GetDockerRepoVersionsKey()
-	if v, ok := versions[key]; ok {
-		vNew := goversion.New(assets.Version)
-
-		if key == "main" {
-			// We could call this "main.0.0-0", but that makes the Docker tag names complicated.
-			// Stick with simple "main".
-			v.Version = key
-			v.Revision = ""
-		} else {
-			v.Version = vNew.MajorMinorPatch()
-			v.Revision = vNew.Revision
+	v, ok := versions[key]
+	if !ok {
+		// Make a copy of BuildAssets and decrement the minor version to find the previous key.
+		prevKey, err := assets.GetPreviousMinorDockerRepoVersionsKey()
+		if err != nil {
+			return fmt.Errorf("unable to calculate previous version key to use as a basis for the new version: %w", err)
 		}
-
-		// Look through the asset arches, find an arch in the versions file that matches each asset,
-		// and update its info.
-		for _, arch := range assets.Arches {
-			// Special case for arm artifacts: change it to arm32v7. We produce arm32v6 builds of Go
-			// but package them in arm/v7 (armhf) Docker images. The upstream Go official image repo
-			// does this in their versions.json file: there are v6 and v7 Dockerfile arches that
-			// both carry the v6 Go. We only care about arm/v7, so only include that one.
-			if arch.Env.GOARCH == "arm" {
-				arch.Env.GOARM = "7"
-			}
-
-			archKey := arch.Env.GoImageOSArchKey()
-			if match, ok := v.Arches[archKey]; ok {
-				// Copy over the previous value of keys that aren't specific to an asset, but
-				// actually indicate the state of the Dockerfile. All other values come from the new
-				// asset's data.
-				arch.Supported = match.Supported
-			}
-			// Copy the asset data into the versions file whether it's a new arch or not.
-			v.Arches[archKey] = arch
+		v, ok = versions[prevKey]
+		if !ok {
+			return fmt.Errorf(
+				"checked current version %v and previous version %v, however: %w",
+				key, prevKey, NoMajorMinorUpgradeMatchError)
 		}
+		// Create a new Docker versions file entry for the new branch/major.minor version. Copy the
+		// data (such as the list of variants) from the previous version. Use JSON serialization to
+		// do a deep copy and prevent accidentally modifying shared old data in the following code.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("unable to clone/marshal previous Docker versions file entry: %w", err)
+		}
+		// Create fresh struct so json.Unmarshal doesn't reuse the slices/maps.
+		v = new(dockerversions.MajorMinorVersion)
+		if err := json.Unmarshal(b, v); err != nil {
+			return fmt.Errorf("unable to clone/unmarshal previous Docker versions file entry: %w", err)
+		}
+		versions[key] = v
+		// Never prefer the freshly generated new version. If we let these remain 'true', the Docker
+		// tags would overlap with the previous version's tags, where it was also 'true'.
+		v.PreferredMinor = false
+		v.PreferredMajor = false
+		// Clear out the arches. These are always version-specific.
+		v.Arches = nil
+	}
+
+	vNew := goversion.New(assets.Version)
+
+	if key == "main" {
+		// We could call this "main.0.0-0", but that makes the Docker tag names complicated.
+		// Stick with simple "main".
+		v.Version = key
+		v.Revision = ""
 	} else {
-		return fmt.Errorf("%v: %w", key, NoMajorMinorUpgradeMatchError)
+		v.Version = vNew.MajorMinorPatch() + vNew.Prerelease
+		v.Revision = vNew.Revision
+	}
+
+	// Look through the asset arches, find an arch in the versions file that matches each asset,
+	// and update its info.
+	for _, arch := range assets.Arches {
+		// Special case for arm artifacts: change it to arm32v7. We produce arm32v6 builds of Go
+		// but package them in arm/v7 (armhf) Docker images. The upstream Go official image repo
+		// does this in their versions.json file: there are v6 and v7 Dockerfile arches that
+		// both carry the v6 Go. We only care about arm/v7, so only include that one.
+		if arch.Env.GOARCH == "arm" {
+			arch.Env.GOARM = "7"
+		}
+
+		archKey := arch.Env.GoImageOSArchKey()
+		if match, ok := v.Arches[archKey]; ok {
+			// Copy over the previous value of keys that aren't specific to an asset, but
+			// actually indicate the state of the Dockerfile. All other values come from the new
+			// asset's data.
+			arch.Supported = match.Supported
+		} else {
+			// By default, enable builds for new architectures that show up.
+			arch.Supported = true
+		}
+		if v.Arches == nil {
+			v.Arches = make(map[string]*dockerversions.Arch, 1)
+		}
+		// Copy the asset data into the versions file whether it's a new arch or not.
+		v.Arches[archKey] = arch
 	}
 	return nil
 }

--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -220,8 +220,6 @@ var NoMajorMinorUpgradeMatchError = errors.New("no match found in existing versi
 // UpdateVersions takes a build asset file containing a list of build outputs and updates a
 // versions.json model to consume the new build.
 func UpdateVersions(assets *buildassets.BuildAssets, versions dockerversions.Versions) error {
-	var v *dockerversions.MajorMinorVersion
-
 	// First, try to update an existing major.minor version in the Docker versions file. If it
 	// doesn't exist, try to find the previous version and create a new Docker versions file entry
 	// based on that. If that doesn't exist either, fail.

--- a/buildmodel/testdata/UpdateVersions/updatedVersions.golden.json
+++ b/buildmodel/testdata/UpdateVersions/updatedVersions.golden.json
@@ -17,6 +17,7 @@
           "GOOS": "linux"
         },
         "sha256": "7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a",
+        "supported": true,
         "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-armv6l.tar.gz"
       },
       "arm64v8": {
@@ -25,6 +26,7 @@
           "GOOS": "linux"
         },
         "sha256": "7965396729a9efb2d166e9b33eb142629f9c505240c4e373bbd783cf5f8af61a",
+        "supported": true,
         "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.18/20220412.1/go.20220412.1.linux-arm64.tar.gz"
       },
       "windows-amd64": {

--- a/goversion/goversion_test.go
+++ b/goversion/goversion_test.go
@@ -3,77 +3,99 @@
 
 package goversion
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestVersion_parseVersion(t *testing.T) {
+func TestNew(t *testing.T) {
 	tests := []struct {
-		name                                string
-		version                             string
-		major, minor, patch, revision, note string
+		name                                            string
+		version                                         string
+		major, minor, patch, revision, note, prerelease string
 	}{
 		{
 			"Full version",
 			"1.2.3-4",
-			"1", "2", "3", "4", "",
+			"1", "2", "3", "4", "", "",
 		},
 		{
 			"Major only",
 			"1",
-			"1", "0", "0", "1", "",
+			"1", "0", "0", "1", "", "",
 		},
 		{
 			"Major.minor",
 			"1.42",
-			"1", "42", "0", "1", "",
+			"1", "42", "0", "1", "", "",
 		},
 		{
 			"Major.minor-revision",
 			"1.42-6",
-			"1", "42", "0", "6", "",
+			"1", "42", "0", "6", "", "",
 		},
 		{
 			"Too many dotted parts",
 			"1.2.3.4.5.6",
-			"1", "2", "3", "1", "",
+			"1", "2", "3", "1", "", "",
 		},
 		{
 			"Many dashed parts",
 			"1-2-3-4",
-			"1", "0", "0", "2", "3-4",
+			"1", "0", "0", "2", "3-4", "",
 		},
 		{
 			"Note without much else",
 			"1-note",
-			"1", "0", "0", "1", "note",
+			"1", "0", "0", "1", "note", "",
 		},
 		{
 			"Note with revision",
 			"1-2-note",
-			"1", "0", "0", "2", "note",
+			"1", "0", "0", "2", "note", "",
 		},
 		{
 			"Note with number after a dash",
 			"1-note-2",
-			"1", "0", "0", "1", "note-2",
+			"1", "0", "0", "1", "note-2", "",
+		},
+		{
+			"Prerelease version",
+			"1.18rc1",
+			"1", "18", "0", "1", "", "rc1",
+		},
+		{
+			"Major beta version",
+			"2beta1",
+			"2", "0", "0", "1", "", "beta1",
+		},
+		{
+			// This case should never happen, but the current behavior is that the parser removes
+			// all prerelease parts and only preserves the last-specified prerelease identifier.
+			"Pick most minor prerelease part",
+			"2beta1.42rc2",
+			"2", "42", "0", "1", "", "rc2",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := New(tt.version)
 			if got.Major != tt.major {
-				t.Errorf("parseVersion() gotMajor = %q, major %q", got.Major, tt.major)
+				t.Errorf("New() gotMajor = %q, major %q", got.Major, tt.major)
 			}
 			if got.Minor != tt.minor {
-				t.Errorf("parseVersion() gotMinor = %q, minor %q", got.Minor, tt.minor)
+				t.Errorf("New() gotMinor = %q, minor %q", got.Minor, tt.minor)
 			}
 			if got.Patch != tt.patch {
-				t.Errorf("parseVersion() gotPatch = %q, patch %q", got.Patch, tt.patch)
+				t.Errorf("New() gotPatch = %q, patch %q", got.Patch, tt.patch)
 			}
 			if got.Revision != tt.revision {
-				t.Errorf("parseVersion() gotRevision = %q, revision %q", got.Revision, tt.revision)
+				t.Errorf("New() gotRevision = %q, revision %q", got.Revision, tt.revision)
 			}
 			if got.Note != tt.note {
-				t.Errorf("parseVersion() gotNote = %q, note %q", got.Note, tt.note)
+				t.Errorf("New() gotNote = %q, note %q", got.Note, tt.note)
+			}
+			if got.Prerelease != tt.prerelease {
+				t.Errorf("New() gotPrerelease = %q, note %q", got.Prerelease, tt.prerelease)
 			}
 		})
 	}


### PR DESCRIPTION
Adds parsing support for prerelease versions like `1.19beta1` and `1.19rc1`.

Adds support for prerelease versions to `dockerupdate`/`dockerupdatepr`, generally matching how rc releases are maintained in https://github.com/docker-library/golang. I created a PR on go-images nightly as an example: https://github.com/microsoft/go-images/pull/133. With this, we could choose to release beta/rc images on MAR/MCR and ask our users to try them out, or on our nightly ACR. (Currently our release automation would put them on MAR.)

This PR also makes it so instead of having to manually pre-create an entry to receive each new 1.x version in the `src/versions.json` file in go-images, the tool will automatically look for the previous version's entry in the file and copy it to start off the current entry. (The set of supported Linux and Windows variants is the data that needs copying.) This lets the process be more automatic.

So, this PR implements the Docker side of these issues:
* https://github.com/microsoft/go/issues/602
* https://github.com/microsoft/go/issues/601

For review, I recommend enabling "hide whitespace": I changed an indent level in buildmodel/buildassets/buildassets.go 