### PR TITLE
Fix get-build-info: use variable, not parameter

### DIFF
--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -205,7 +205,7 @@ jobs:
 
           - script: |
               releasego get-build-info \
-                -id '${{ parameters.poll3MicrosoftGoBuildID }}' \
+                -id '$(poll3MicrosoftGoBuildID)' \
                 -org 'https://dev.azure.com/dnceng/' \
                 -proj 'internal' \
                 -prefix 'BuildInfo' \


### PR DESCRIPTION
This caused a hiccup in the 1.18.4 build/release: https://dev.azure.com/dnceng/internal/_build/results?buildId=1875873&view=logs&j=8d802004-fbbb-5f17-b73e-f23de0c1dec8&t=995a157e-87d5-56c6-b42a-d8b689a8a0cd&l=71. This bug doesn't block any releases, it just means one redundant re-run is necessary per version.

The _parameter_ is only set if the dev (me) fills it in at the "Run new" dialog. The _variable_ is set in that case *or* if it gets created during the build process (when automation is running as normal).

Here, automation queued the internal build, so it set the `poll3MicrosoftGoBuildID` variable to use in later steps. But `${{ parameters.poll3MicrosoftGoBuildID }}` is still `nil`, so this step failed.

I missed this parameter when I combined the pipelines together (https://github.com/microsoft/go-infra/pull/50). The `poll*` variables should be used when passing an arg to a `releasego` tool, never a `parameters.poll*`.
