### PR TITLE
Release automation: create branches if necessary

### DIFF
--- a/cmd/releasego/get-upstream-commit.go
+++ b/cmd/releasego/get-upstream-commit.go
@@ -72,6 +72,11 @@ func handleWaitUpstream(p subcmd.ParseFunc) error {
 			Tag:      v.UpstreamFormatGitTag(),
 		}
 	case "fips":
+		// Don't handle prerelease "-fips" version. In 1.19+, the boring branch is no longer
+		// separate so this should never happen.
+		if v.Prerelease != "" {
+			return fmt.Errorf("prerelease FIPS version %q not supported", v.Original)
+		}
 		checker = &boringChecker{
 			GitDir:   repo,
 			Upstream: *upstream,

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -112,6 +112,7 @@ jobs:
                       -github-pat '$(GitHubPAT)' \
                       -github-pat-reviewer '$(GitHubPATReviewer)' \
                       -azdo-dnceng-pat '$(AzDODncengPAT)' \
+                      -create-branches \
                       -set-azdo-variable-pr-number poll1MicrosoftGoPRNumber \
                       -set-azdo-variable-up-to-date-commit poll2MicrosoftGoCommitHash
                   displayName: Sync to upstream commit

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -6,11 +6,17 @@
     "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
     "BranchMap": {
       "master": "microsoft/main",
-      "release-branch.go1.18": "microsoft/?",
-      "dev.boringcrypto.go1.18": "microsoft/?",
-      "release-branch.go1.17": "microsoft/?",
-      "dev.boringcrypto.go1.17": "microsoft/?"
+      "release-branch.go*": "microsoft/?",
+      "dev.boringcrypto.go*": "microsoft/?"
     },
+    "AutoSyncBranches": [
+      "master",
+      "release-branch.go1.18",
+      "dev.boringcrypto.go1.18",
+      "release-branch.go1.17",
+      "dev.boringcrypto.go1.17"
+    ],
+    "MainBranch": "microsoft/main",
     "SubmoduleTarget": "go"
   },
   {
@@ -19,6 +25,9 @@
     "BranchMap": {
       "master": "microsoft/nightly"
     },
+    "AutoSyncBranches": [
+      "master"
+    ],
     "SubmoduleTarget": "go"
   }
 ]

--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -106,6 +106,11 @@ func (b SyncPRRefSet) UpstreamMirrorRefspec() string {
 	return createRefspec(b.UpstreamLocalBranch(), b.UpstreamName)
 }
 
+// ForkFromMainRefspec fetches the specified main branch on the target repo into the local branch.
+func (b SyncPRRefSet) ForkFromMainRefspec(mainBranch string) string {
+	return createRefspec(mainBranch, b.Name)
+}
+
 // Remote is a parsed version of a Git Remote. It helps determine how to send a GitHub PR.
 type Remote struct {
 	url      string


### PR DESCRIPTION
If release automation runs for a new Go version and it doesn't have an associated release branch yet, create one by forking from the main branch if `-create-branches` is specified.

* https://github.com/microsoft/go/issues/602

Other changes:

* Add "-initial-clone-dir" flag to allow getting upstream data locally for quicker dev workflow. New cases in the test table.
* Run the sync tests in parallel to bring test time from 19s to 5s on my machine. The tests are mostly just Git commands in distinct test dirs, so they're easy to run in parallel without much concern.
* Proactively prevent Boring/FIPS branch prerelease support in get-upstream-commit so we don't accidentally create new FIPS branches with potentially invalid names/contents. With 1.19+ there should never be another Boring branch that we need to create!
* Only enable `-create-branches` in release automation, not scheduled syncs, because scheduled syncs have no reason to be creating new branches. (This helps catch bugs that could otherwise unintentionally cause new branches to be created.)

---

`-create-branches` doesn't set up scheduled syncs for the new branch that it creates, but I think that we should stop doing this kind of scheduled sync in release branches anyway:

* https://github.com/microsoft/go/issues/555