### PR TITLE
sync: don't use merge-base when commit provided; check mirror in get-upstream-commit

### DIFF
--- a/cmd/releasego/get-upstream-commit.go
+++ b/cmd/releasego/get-upstream-commit.go
@@ -38,6 +38,7 @@ indicate an ordinary release) or "fips" (to indicate the release is based on the
 func handleWaitUpstream(p subcmd.ParseFunc) error {
 	version := flag.String("version", "", "[Required] A full or partial microsoft/go version number (major.minor.patch[-revision[-suffix]]).")
 	upstream := flag.String("upstream", "https://go.googlesource.com/go", "The upstream Git repo to check.")
+	upstreamMirror := flag.String("upstream-mirror", "https://github.com/golang/go", "A mirror of the upstream Git repo that must also have the commit. Optional.")
 	azdoVarName := flag.String("set-azdo-variable", "", "An AzDO variable name to set to the commit hash using a logging command.")
 	keepTemp := flag.Bool("w", false, "Keep the temporary repository used for polling, rather than cleaning it up.")
 	pollDelaySeconds := flag.Int("poll-delay", 5, "Number of seconds to wait between each poll attempt.")
@@ -67,15 +68,17 @@ func handleWaitUpstream(p subcmd.ParseFunc) error {
 	switch v.Note {
 	case "":
 		checker = &tagChecker{
-			GitDir:   repo,
-			Upstream: *upstream,
-			Tag:      v.UpstreamFormatGitTag(),
+			GitDir:         repo,
+			Upstream:       *upstream,
+			UpstreamMirror: *upstreamMirror,
+			Tag:            v.UpstreamFormatGitTag(),
 		}
 	case "fips":
 		checker = &boringChecker{
-			GitDir:   repo,
-			Upstream: *upstream,
-			Version:  v.MajorMinorPatch(),
+			GitDir:         repo,
+			Upstream:       *upstream,
+			UpstreamMirror: *upstreamMirror,
+			Version:        v.MajorMinorPatch(),
 		}
 	default:
 		return fmt.Errorf("unable to check for version with note %q", v.Note)
@@ -90,24 +93,33 @@ func handleWaitUpstream(p subcmd.ParseFunc) error {
 
 // tagChecker checks for an upstream release by looking for a Git tag.
 type tagChecker struct {
-	GitDir   string
-	Upstream string
-	Tag      string
+	GitDir         string
+	Upstream       string
+	UpstreamMirror string
+	Tag            string
 }
 
 func (c *tagChecker) Check() (string, error) {
 	if err := gitcmd.Run(c.GitDir, "fetch", "--depth", "1", c.Upstream, "refs/tags/"+c.Tag+":refs/tags/"+c.Tag); err != nil {
 		return "", err
 	}
-	return gitcmd.RevParse(c.GitDir, c.Tag)
+	commit, err := gitcmd.RevParse(c.GitDir, c.Tag)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureCommitInUpstreamMirror(c.GitDir, c.UpstreamMirror, commit); err != nil {
+		return "", err
+	}
+	return commit, nil
 }
 
 // boringChecker checks for an upstream release by reading the boring releases file and looking for
 // a line that matches the given version.
 type boringChecker struct {
-	GitDir   string
-	Upstream string
-	Version  string
+	GitDir         string
+	Upstream       string
+	UpstreamMirror string
+	Version        string
 }
 
 func (c *boringChecker) Check() (string, error) {
@@ -130,7 +142,14 @@ func (c *boringChecker) Check() (string, error) {
 	if err := gitcmd.Run(c.GitDir, "fetch", c.Upstream, "+refs/heads/dev.boringcrypto*:refs/heads/boring*"); err != nil {
 		return "", err
 	}
-	return gitcmd.RevParse(c.GitDir, shortCommit)
+	commit, err := gitcmd.RevParse(c.GitDir, shortCommit)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureCommitInUpstreamMirror(c.GitDir, c.UpstreamMirror, commit); err != nil {
+		return "", err
+	}
+	return commit, nil
 }
 
 // findBoringReleaseCommit finds a line in the RELEASES file that matches our tag, or returns an
@@ -169,4 +188,13 @@ func (c *boringChecker) findBoringReleaseCommit(content string) (string, error) 
 		return "", err
 	}
 	return "", fmt.Errorf("reached end of boring RELEASES file without finding target release %v", c.Version)
+}
+
+func ensureCommitInUpstreamMirror(gitDir, upstreamMirror, commit string) error {
+	if upstreamMirror != "" {
+		if err := gitcmd.Run(gitDir, "fetch", "--depth", "1", upstreamMirror, commit); err != nil {
+			return fmt.Errorf("commit %v not found in upstream mirror: %w", commit, err)
+		}
+	}
+	return nil
 }

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -119,9 +119,9 @@ func CombinedOutput(dir string, args ...string) (string, error) {
 	return executil.CombinedOutput(executil.Dir(dir, "git", args...))
 }
 
-// RevParse runs "git rev-parse <rev>" and returns the result.
+// RevParse runs "git rev-parse <rev>" and returns the result with whitespace trimmed.
 func RevParse(dir, rev string) (string, error) {
-	return CombinedOutput(dir, "rev-parse", rev)
+	return executil.SpaceTrimmedCombinedOutput(executil.Dir(dir, "git", "rev-parse", rev))
 }
 
 // Show runs "git show <spec>" and returns the content.

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -408,14 +408,20 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 			}
 
 			// This update uses a submodule, so find the target version of upstream and update the
-			// submodule to point at it.
+			// submodule to point at it. UpstreamLocalSyncTarget might be a commit hash, and if so,
+			// this rev-parse is simply checking that the commit actually exists.
 			newCommit, err := getTrimmedCmdOutput("rev-parse", b.UpstreamLocalSyncTarget())
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to find upstream sync target in local repo after fetching: %w", err)
 			}
 
-			// Limit the commit to one that's available in every known official repository.
-			if entry.UpstreamMirror != "" {
+			// If we're updating to the latest upstream commit, not a specific upstream commit, find
+			// the latest commit available in both upstream and the upstream mirror.
+			//
+			// If we're updating to a specific commit, the caller of the sync command should have
+			// already validated that it's available in both places. At worst, a missing commit will
+			// cause a failure in the PR validation check.
+			if entry.UpstreamMirror != "" && b.Commit == "" {
 				upstreamMirrorCommit, err := getTrimmedCmdOutput("rev-parse", b.UpstreamMirrorLocalBranch())
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/640

This is what happened in 1.18.4:

1. `releasego get-upstream-commit` started polling https://go.googlesource.com/go to find `go1.18.4`.
2. Upstream pushed the tag/commit to https://go.googlesource.com/go. It's not in https://github.com/golang/go yet.
3. `get-upstream-commit` found it: 88a06f40.
4. `releasego sync` noticed that the latest commit on the mirror https://github.com/golang/go, fb979a50, doesn't match the latest commit on https://go.googlesource.com/go, 88a06f40, and logged a message about it. 
5. The sync infra ran a merge-base between the target branch/commit and upstream mirror's latest: fb979a50.
    * The intent is that if we're syncing to latest, we don't go too far and end up with our submodule pointing to a commit that doesn't exist on GitHub.
7. Sync updated our submodule to the latest available commit in both places, fb979a50.
    * The submodule URL points at https://github.com/golang/go so that GitHub formats it nicely as a clickable link and shows the submodule's file diff in PRs, etc. Our CI therefore also gets the commit from https://github.com/golang/go. This is why we care at all whether the commit is available in both places.

This PR fixes the bad update by skipping the merge-base step when we're trying to update to a specific commit like fb979a50.

The PR also adds a check into `get-upstream-commit` that the commit we find is available in both places. This way, 
 if Go's mirroring process has a delay, our release automation will wait until that's resolved, and then automation continues without manual intervention on our part.
