### PR TITLE
Skip arm32 for CBL-Mariner 2.0 Go Docker images

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -144,11 +144,11 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 				if arch.Env.GOOS != os {
 					continue
 				}
-				// Skip arm (arm32) on CBL-Mariner 1.0. The base image doesn't exist. Excluding it
+				// Skip arm (arm32) on CBL-Mariner. The base image doesn't exist. Excluding it
 				// here is better than excluding the platform from the versions.json file:
 				// specializing versions.json for CBL-Mariner requires a lot of duplication and the
 				// templates would generate Dockerfiles in a different, less clear folder structure.
-				if osVersion == "cbl-mariner1.0" && arch.Env.GOARCH == "arm" {
+				if strings.HasPrefix(osVersion, "cbl-mariner") && arch.Env.GOARCH == "arm" {
 					continue
 				}
 


### PR DESCRIPTION
CBL-Mariner doesn't have arm images, only arm64. This PR takes the check that already existed for Mariner 1.0 and extends that to 2.0 and any future versions.