### PR TITLE
goversion: handle Prerelease for Go releases

### DIFF
--- a/cmd/releasego/akams.go
+++ b/cmd/releasego/akams.go
@@ -127,8 +127,8 @@ func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
 	// The partial versions that we want to link to a specific build.
 	// For example, 1.18-fips -> 1.18.2-1-fips.
 	partial := []string{
-		v.MajorMinor() + v.NoteWithPrefix(),
-		v.MajorMinorPatch() + v.NoteWithPrefix(),
+		v.MajorMinorPrerelease() + v.NoteWithPrefix(),
+		v.MajorMinorPatchPrerelease() + v.NoteWithPrefix(),
 		// Also include the fully specified version. This lets people use a pretty link even if they
 		// do need to pin to a specific version.
 		v.Full(),

--- a/cmd/releasego/akams_test.go
+++ b/cmd/releasego/akams_test.go
@@ -4,9 +4,9 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/go-test/deep"
 	"github.com/microsoft/go-infra/buildmodel/buildassets"
 	"github.com/microsoft/go-infra/buildmodel/dockerversions"
 )
@@ -48,8 +48,10 @@ func Test_createLinkPairs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("createLinkPairs() got %#v, want %#v", got, want)
+	if diff := deep.Equal(got, want); diff != nil {
+		for _, d := range diff {
+			t.Error(d)
+		}
 	}
 }
 

--- a/goversion/goversion.go
+++ b/goversion/goversion.go
@@ -88,17 +88,25 @@ func (v *GoVersion) MajorMinor() string {
 	return v.Major + "." + v.Minor
 }
 
+func (v *GoVersion) MajorMinorPrerelease() string {
+	return v.MajorMinor() + v.Prerelease
+}
+
 func (v *GoVersion) MajorMinorPatch() string {
 	return v.MajorMinor() + "." + v.Patch
 }
 
-func (v *GoVersion) MajorMinorPatchRevision() string {
-	return v.MajorMinorPatch() + "-" + v.Revision
+func (v *GoVersion) MajorMinorPatchPrerelease() string {
+	return v.MajorMinorPatch() + v.Prerelease
+}
+
+func (v *GoVersion) MajorMinorPatchPrereleaseRevision() string {
+	return v.MajorMinorPatchPrerelease() + "-" + v.Revision
 }
 
 // Full returns the full normalized version string, including Note if specified.
 func (v *GoVersion) Full() string {
-	return v.MajorMinorPatchRevision() + v.NoteWithPrefix()
+	return v.MajorMinorPatchPrereleaseRevision() + v.NoteWithPrefix()
 }
 
 // UpstreamFormatGitTag returns the version in the format upstream uses for Git tags. Specifically,


### PR DESCRIPTION
Change GoVersion to include Prerelease in the `Full` version string and incorporate it in the partial-version funcs for aka.ms link generation. Most parts of release automation (Git tags, GitHub releases) use `Full`, so no changes are needed in those tools after this change. Example aka.ms links:

https://aka.ms/golang/release/dev/latest/go1.19rc2.linux-amd64.tar.gz
https://aka.ms/golang/release/dev/latest/go1.19.0rc2.linux-amd64.tar.gz
https://aka.ms/golang/release/dev/latest/go1.19.0rc2-1.linux-amd64.tar.gz 

(`cmd/releasego/akams_test.go` caught a mistake when I was working on this, but the error was hard to read, so I improved it to use `deep.Equal` while I was here.)

* Fixes https://github.com/microsoft/go/issues/601