### PR TITLE
Add Fuzz test pipeline and validation in PR CI

### DIFF
--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -5,23 +5,25 @@ This directory contains Azure DevOps (AzDO) YAML pipelines for CI and utilities.
 Public pipeline definitions using these YAML files:
 
 * [`pr-pipeline.yml`](pr-pipeline.yml) - PR validation
-  * [`microsoft-go-infra`](https://dev.azure.com/dnceng/public/_build?definitionId=1051)
+  * 🚀 dnceng-public [`microsoft-go-infra`](https://dev.azure.com/dnceng-public/public/_build?definitionId=197)
 
 Internal pipeline definitions:
 
 * [`update-images-pipeline.yml`](update-images-pipeline.yml) - Update dependencies in microsoft/go-images after a Go build.
-  * [`microsoft-go-infra-update-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1040&_a=summary)
+  * 🚀 internal [`microsoft-go-infra-update-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1040&_a=summary)
     * To manually queue an update to a specific build, use the "Resources" options in the "Run pipeline" dialog.
     * To see where an update came from, click the "X consumed" button:  
       > ![](img/consumed-artifacts.png)
 * [`upstream-sync-pipeline.yml`](upstream-sync-pipeline.yml) - Sync repositories with their upstreams.
-  * [`microsoft-go-infra-upstream-sync`](https://dev.azure.com/dnceng/internal/_build?definitionId=1061)
+  * 🚀 internal [`microsoft-go-infra-upstream-sync`](https://dev.azure.com/dnceng/internal/_build?definitionId=1061)
+* [`fuzz-pipeline.yml`](fuzz-pipeline.yml) - Run fuzz tests internally on a schedule.
+  * 🚀 internal [`microsoft-go-infra-fuzz`](https://dev.azure.com/dnceng/internal/_build?definitionId=1182)
 
 Internal release pipelines (see [release process docs](/docs/release-process)):
 
 * (1) [`release-go-start-pipeline.yml`](release-go-start-pipeline.yml)
-  * [`microsoft-go-infra-release-start`](https://dev.azure.com/dnceng/internal/_build?definitionId=1153)
+  * 🚀 internal [`microsoft-go-infra-release-start`](https://dev.azure.com/dnceng/internal/_build?definitionId=1153)
 * (2) [`release-build-pipeline.yml`](release-build-pipeline.yml)
-  * [`microsoft-go-infra-release-build`](https://dev.azure.com/dnceng/internal/_build?definitionId=1142)
+  * 🚀 internal [`microsoft-go-infra-release-build`](https://dev.azure.com/dnceng/internal/_build?definitionId=1142)
 * (3) [`release-go-images-pipeline.yml`](release-go-images-pipeline.yml)
-  * [`microsoft-go-infra-release-go-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1151)
+  * 🚀 internal [`microsoft-go-infra-release-go-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1151)

--- a/eng/pipelines/fuzz-pipeline.yml
+++ b/eng/pipelines/fuzz-pipeline.yml
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+trigger: none
+pr: none
+schedules:
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#cron-syntax
+  - cron: '0 8 * * 1-5'
+    displayName: Run fuzz tests once a day
+    branches:
+      include:
+        - main
+    always: true
+
+resources:
+  pipelines:
+    - pipeline: build
+      source: microsoft-go
+      branch: microsoft/main
+
+stages:
+  - stage: Fuzz
+    jobs:
+      - template: jobs/fuzz.yml
+        parameters:
+          name: Linux
+          platform: linux-amd64
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals 1es-ubuntu-2004
+
+      - template: jobs/fuzz.yml
+        parameters:
+          name: Windows
+          platform: windows-amd64
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals 1es-windows-2019

--- a/eng/pipelines/fuzz-pipeline.yml
+++ b/eng/pipelines/fuzz-pipeline.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# Run fuzz tests internally on a schedule.
+
 trigger: none
 pr: none
 schedules:

--- a/eng/pipelines/jobs/fuzz.yml
+++ b/eng/pipelines/jobs/fuzz.yml
@@ -6,14 +6,18 @@
 parameters:
   name: ''
   pool: null
+  # Platform, as it appears in the Microsoft Go pipeline artifact name: OS-Arch.
   platform: ''
+  # Use the Microsoft Go toolset from a pipeline resource called "build", rather than official Go.
   useMicrosoftGo: true
-  fuzztime: 60m
-  # Fuzz step timeout in minutes. Set this a little lower than job timeout but a little higher than
-  # fuzztime to make sure we get a chance to upload testdata even if the fuzz command doesn't stop
-  # when it should.
-  fuzzTimeoutMinutes: 100
-  jobTimeoutMinutes: 120
+  # Fuzz time per job. The default is specified in minutes so it's easy to compare against the other
+  # times, which AzDO only accepts as minutes.
+  fuzztime: 180m
+  # Fuzz pipeline step timeout in minutes. Set this a little higher than fuzztime but a little lower
+  # than job timeout to make sure we get a chance to upload testdata even if the fuzz command
+  # doesn't stop when it should.
+  fuzzTimeoutMinutes: 200
+  jobTimeoutMinutes: 220
 
 jobs:
   - job: ${{ parameters.name }}

--- a/eng/pipelines/jobs/fuzz.yml
+++ b/eng/pipelines/jobs/fuzz.yml
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Run fuzz tests using cmd/fuzzcrypto on the specified platform and pool.
+
+parameters:
+  name: ''
+  pool: null
+  platform: ''
+  useMicrosoftGo: true
+  fuzztime: 60m
+  # Fuzz step timeout in minutes. Set this a little lower than job timeout but a little higher than
+  # fuzztime to make sure we get a chance to upload testdata even if the fuzz command doesn't stop
+  # when it should.
+  fuzzTimeoutMinutes: 100
+  jobTimeoutMinutes: 120
+
+jobs:
+  - job: ${{ parameters.name }}
+    pool: ${{ parameters.pool }}
+    timeoutInMinutes: ${{ parameters.jobTimeoutMinutes }}
+    workspace:
+      clean: all
+    steps:
+      - checkout: self
+        submodules: true
+        fetchDepth: 1
+
+      - ${{ if eq(parameters.useMicrosoftGo, true) }}:
+        - template: ../steps/init-microsoft-go.yml
+          parameters:
+            platform: ${{ parameters.platform }}
+
+        - ${{ if contains(parameters.platform, 'windows') }}:
+          - script: |
+              cd cmd\fuzzcrypto
+              set GOEXPERIMENT=cngcrypto
+              go run . -v -fuzztime ${{ parameters.fuzztime }}
+            displayName: Fuzz
+            timeoutInMinutes: ${{ parameters.fuzzTimeoutMinutes }}
+        - ${{ else }}:
+          - script: |
+              cd cmd/fuzzcrypto
+              GOEXPERIMENT=opensslcrypto go run . -v -fuzztime ${{ parameters.fuzztime }}
+            displayName: Fuzz
+            timeoutInMinutes: ${{ parameters.fuzzTimeoutMinutes }}
+
+        - publish: $(Build.SourcesDirectory)/cmd/fuzzcrypto
+          artifact: ${{ parameters.name }} testdata
+          displayName: Upload testdata on failure
+          condition: failed()
+
+      - ${{ else }}:
+        # Test with ordinary Go.
+        - template: ../steps/init-go.yml
+        - script: |
+            cd cmd/fuzzcrypto
+            go run . -v -fuzztime ${{ parameters.fuzztime }}
+          displayName: Fuzz

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -44,4 +44,9 @@ jobs:
         vmImage: ubuntu-20.04
       platform: linux-amd64
       useMicrosoftGo: false
+      # 1x runs the tests only once. It uses the first entry in the corpus so won't generate any
+      # interesting results, only helps prevent regression for the actual fuzz runs.
       fuzztime: 1x
+      # If 1x takes longer than a minute, it is probably frozen. Give some leeway, but terminate
+      # much sooner than the actual fuzz tests would (an hour or more).
+      jobTimeoutMinutes: 20

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -36,3 +36,12 @@ jobs:
           testResultsFormat: JUnit
           testResultsFiles: $(Build.StagingDirectory)/TestResults.xml
           publishRunAttachments: true
+
+  - template: jobs/fuzz.yml
+    parameters:
+      name: TestFuzz1x
+      pool:
+        vmImage: ubuntu-20.04
+      platform: linux-amd64
+      useMicrosoftGo: false
+      fuzztime: 1x

--- a/eng/pipelines/steps/init-go.yml
+++ b/eng/pipelines/steps/init-go.yml
@@ -6,4 +6,4 @@
 steps:
   - task: GoTool@0
     inputs:
-      version: 1.18
+      version: 1.19

--- a/eng/pipelines/steps/init-microsoft-go.yml
+++ b/eng/pipelines/steps/init-microsoft-go.yml
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Set up a microsoft/go toolset on the build machine. Requires a pipeline
+# resource called "build" that will be used as the source for the Go toolset.
+
+parameters:
+  platform: ''
+
+steps:
+  - download: build
+    artifact: Binaries Signed
+    patterns: go*${{ parameters.platform }}*.*
+
+  - task: ExtractFiles@1
+    inputs:
+      archiveFilePatterns: |
+        $(Pipeline.Workspace)/build/Binaries Signed/*.tar.gz
+        $(Pipeline.Workspace)/build/Binaries Signed/*.zip
+      cleanDestinationFolder: true
+      overwriteExistingFiles: false
+      destinationFolder: $(Pipeline.Workspace)/build/go
+
+  - ${{ if contains(parameters.platform, 'windows') }}:
+    - script: 'echo ##vso[task.prependpath]$(Pipeline.Workspace)\build\go\go\bin'
+      displayName: 'Add Go to PATH (Windows)'
+  - ${{ else }}:
+    - script: echo '##vso[task.prependpath]$(Pipeline.Workspace)/build/go/go/bin'
+      displayName: 'Add Go to PATH (non-Windows)'
+
+  - script: go env
+    displayName: 'Print Go env'


### PR DESCRIPTION
Adds an internal fuzz testing pipeline. Adds a job in in go-infra PR validation to run fuzz testing with `1x` to validate that each go-infra PR doesn't break the tool or tests, but without actually running with any new fuzz data.

Internal build with a simulated test failure to see that the testdata is included in the uploaded artifact: https://dev.azure.com/dnceng/internal/_build/results?buildId=1994508&view=results

I also have a full run going:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1994517&view=results

The artifact also contains the source code and go-cose submodule data, but I think this is fine: we don't expect this pipeline to fail often, and it turns out to be 2 MB. To improve it, we would have to search the dir and copy the testdata files to a fresh dir to upload, and that doesn't seem worth the complexity.

The fuzz test currently grabs the newest Go version built by microsoft/main. We could pretty reasonably extend this to release branches, or even consume our publicly available bits rather than pulling from the official build pipeline. This would require listing each release branch here and customizing it further for pre-1.19 (no GOEXPERIMENT, different toolset) so I'm not doing this in the initial implementation at least.

This PR doesn't yet support notifications, filing issues, etc., it just makes the pipeline fail.