### PR TITLE
Add fuzz target bucketization, more jobs

### DIFF
--- a/cmd/fuzzcrypto/bucket.go
+++ b/cmd/fuzzcrypto/bucket.go
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+type targetBucket struct {
+	targets     []target
+	totalWeight float64
+}
+
+// targetBucketHeap implements heap.Interface for lowest total bucket weight. Implementation follows the
+// example at https://pkg.go.dev/container/heap.
+type targetBucketHeap []targetBucket
+
+func (b targetBucketHeap) Len() int           { return len(b) }
+func (b targetBucketHeap) Less(i, j int) bool { return b[i].totalWeight < b[j].totalWeight }
+func (b targetBucketHeap) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+
+func (b *targetBucketHeap) Push(x any) {
+	*b = append(*b, x.(targetBucket))
+}
+
+func (b *targetBucketHeap) Pop() any {
+	old := *b
+	n := len(old)
+	x := old[n-1]
+	*b = old[0 : n-1]
+	return x
+}

--- a/cmd/fuzzcrypto/main.go
+++ b/cmd/fuzzcrypto/main.go
@@ -136,7 +136,7 @@ func flagBucket(name, usage string) (bucket, bucketCount *int) {
 		}
 
 		if b < 1 || b > c {
-			return fmt.Errorf("bucket %v is not in range 1 - %v", b, c)
+			return fmt.Errorf("bucket %v is not in range [1, %v]", b, c)
 		}
 		return nil
 	})

--- a/cmd/fuzzcrypto/main.go
+++ b/cmd/fuzzcrypto/main.go
@@ -136,7 +136,7 @@ func flagBucket(name, usage string) (bucket, bucketCount *int) {
 		}
 
 		if b < 1 || b > c {
-			return fmt.Errorf("bucket %v is not in range [1, %v]", b, c)
+			return fmt.Errorf("bucket %v is not in interval [1, %v]", b, c)
 		}
 		return nil
 	})

--- a/eng/pipelines/fuzz-pipeline.yml
+++ b/eng/pipelines/fuzz-pipeline.yml
@@ -29,12 +29,22 @@ stages:
           platform: linux-amd64
           pool:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals 1es-ubuntu-2004
+            demands: ImageOverride -equals build.ubuntu.1804.amd64
 
       - template: jobs/fuzz.yml
         parameters:
-          name: Windows
-          platform: windows-amd64
+          name: Linux_openssl
+          platform: linux-amd64
+          goExperiment: opensslcrypto
           pool:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals 1es-windows-2019
+            demands: ImageOverride -equals build.ubuntu.1804.amd64
+
+      - template: jobs/fuzz.yml
+        parameters:
+          name: Windows_cng
+          platform: windows-amd64
+          goExperiment: cngcrypto
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.amd64.vs2022

--- a/eng/pipelines/jobs/fuzz.yml
+++ b/eng/pipelines/jobs/fuzz.yml
@@ -10,6 +10,8 @@ parameters:
   platform: ''
   # Use the Microsoft Go toolset from a pipeline resource called "build", rather than official Go.
   useMicrosoftGo: true
+  # The value of GOEXPERIMENT to use, or empty string.
+  goExperiment: ''
   # Fuzz time per job. The default is specified in minutes so it's easy to compare against the other
   # times, which AzDO only accepts as minutes.
   fuzztime: 180m
@@ -18,46 +20,56 @@ parameters:
   # doesn't stop when it should.
   fuzzTimeoutMinutes: 200
   jobTimeoutMinutes: 220
+  # The list of runner IDs: sequential numbers starting from 0. The number of elements determines
+  # the number of runner jobs to start in parallel. We would use "range" here if it existed.
+  runnerIDs: [1, 2, 3]
 
 jobs:
-  - job: ${{ parameters.name }}
-    pool: ${{ parameters.pool }}
-    timeoutInMinutes: ${{ parameters.jobTimeoutMinutes }}
-    workspace:
-      clean: all
-    steps:
-      - checkout: self
-        submodules: true
-        fetchDepth: 1
+  - ${{ each id in parameters.runnerIDs }}:
+    - job: ${{ parameters.name }}_${{ id }}
+      displayName: ${{ parameters.name }} ${{ id }}
+      pool: ${{ parameters.pool }}
+      timeoutInMinutes: ${{ parameters.jobTimeoutMinutes }}
 
-      - ${{ if eq(parameters.useMicrosoftGo, true) }}:
-        - template: ../steps/init-microsoft-go.yml
-          parameters:
-            platform: ${{ parameters.platform }}
+      workspace:
+        clean: all
 
-        - ${{ if contains(parameters.platform, 'windows') }}:
+      variables:
+        bucketArgs: -bucket ${{ id }}/${{ length(parameters.runnerIDs) }}
+        ${{ if contains(parameters.platform, 'windows') }}:
+          cdFuzzCrypto: 'cd cmd\fuzzcrypto'
+          setExperiment: 'set GOEXPERIMENT='
+        ${{ else }}:
+          cdFuzzCrypto: 'set -x ; cd cmd/fuzzcrypto'
+          setExperiment: 'export GOEXPERIMENT='
+
+      steps:
+        - checkout: self
+          submodules: true
+          fetchDepth: 1
+
+        - ${{ if eq(parameters.useMicrosoftGo, true) }}:
+          - template: ../steps/init-microsoft-go.yml
+            parameters:
+              platform: ${{ parameters.platform }}
+
           - script: |
-              cd cmd\fuzzcrypto
-              set GOEXPERIMENT=cngcrypto
-              go run . -v -fuzztime ${{ parameters.fuzztime }}
+              $(cdFuzzCrypto)
+              go env
+              $(setExperiment)${{ parameters.goExperiment }}
+              go run . -v -fuzztime ${{ parameters.fuzztime }} $(bucketArgs)
             displayName: Fuzz
             timeoutInMinutes: ${{ parameters.fuzzTimeoutMinutes }}
+
+          - publish: $(Build.SourcesDirectory)/cmd/fuzzcrypto
+            artifact: ${{ parameters.name }} ${{ id }} testdata
+            displayName: Upload testdata on failure
+            condition: failed()
+
         - ${{ else }}:
+          # Test with ordinary Go.
+          - template: ../steps/init-go.yml
           - script: |
               cd cmd/fuzzcrypto
-              GOEXPERIMENT=opensslcrypto go run . -v -fuzztime ${{ parameters.fuzztime }}
+              go run . -v -fuzztime ${{ parameters.fuzztime }}
             displayName: Fuzz
-            timeoutInMinutes: ${{ parameters.fuzzTimeoutMinutes }}
-
-        - publish: $(Build.SourcesDirectory)/cmd/fuzzcrypto
-          artifact: ${{ parameters.name }} testdata
-          displayName: Upload testdata on failure
-          condition: failed()
-
-      - ${{ else }}:
-        # Test with ordinary Go.
-        - template: ../steps/init-go.yml
-        - script: |
-            cd cmd/fuzzcrypto
-            go run . -v -fuzztime ${{ parameters.fuzztime }}
-          displayName: Fuzz

--- a/eng/pipelines/jobs/fuzz.yml
+++ b/eng/pipelines/jobs/fuzz.yml
@@ -36,12 +36,6 @@ jobs:
 
       variables:
         bucketArgs: -bucket ${{ id }}/${{ length(parameters.runnerIDs) }}
-        ${{ if contains(parameters.platform, 'windows') }}:
-          cdFuzzCrypto: 'cd cmd\fuzzcrypto'
-          setExperiment: 'set GOEXPERIMENT='
-        ${{ else }}:
-          cdFuzzCrypto: 'set -x ; cd cmd/fuzzcrypto'
-          setExperiment: 'export GOEXPERIMENT='
 
       steps:
         - checkout: self
@@ -54,11 +48,12 @@ jobs:
               platform: ${{ parameters.platform }}
 
           - script: |
-              $(cdFuzzCrypto)
               go env
-              $(setExperiment)${{ parameters.goExperiment }}
               go run . -v -fuzztime ${{ parameters.fuzztime }} $(bucketArgs)
             displayName: Fuzz
+            workingDirectory: $(Build.SourcesDirectory)/cmd/fuzzcrypto
+            env:
+              GOEXPERIMENT: ${{ parameters.goExperiment }}
             timeoutInMinutes: ${{ parameters.fuzzTimeoutMinutes }}
 
           - publish: $(Build.SourcesDirectory)/cmd/fuzzcrypto

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -50,3 +50,4 @@ jobs:
       # If 1x takes longer than a minute, it is probably frozen. Give some leeway, but terminate
       # much sooner than the actual fuzz tests would (an hour or more).
       jobTimeoutMinutes: 20
+      runnerIDs: [1]


### PR DESCRIPTION
We aren't sure we have enough fuzz time with one agent running through each target sequentially over an hour, so this PR distributes the targets between several jobs. (https://github.com/microsoft/go-infra/pull/63#issuecomment-1248463682)

Distributing the targets between agents is generally more effective than running every target on multiple agents because Go fuzz testing builds up a local cache of interesting data points that it uses to refine its search for issues, guided by coverage.

This PR doesn't fix the existing issues we've been having with memory usage. These seem to actually be issues in the code under test, not the infra, so we can/will fix these as followup and hopefully end up with green fuzz test runs.

Test build I triggered: https://dev.azure.com/dnceng/internal/_build/results?buildId=2002188&view=results