### PR TITLE
Skip FuzzRSASignPSS if fuzz key size too small

### DIFF
--- a/cmd/fuzzcrypto/std/rsa_test.go
+++ b/cmd/fuzzcrypto/std/rsa_test.go
@@ -120,6 +120,14 @@ func FuzzRSASignPSS(f *testing.F) {
 		if key.Validate() != nil {
 			return
 		}
+		// Check if key size is too small for PSS signature, based on crypto/rsa/pss.go
+		hLen := crypto.SHA256.Size()
+		sLen := hLen // Same as hash size thanks to SaltLength option.
+		emBits := key.N.BitLen() - 1
+		emLen := (emBits + 7) / 8
+		if emLen < hLen+sLen+2 {
+			return // "crypto/rsa: key size too small for PSS signature"
+		}
 		hashed := sha256.Sum256(msg)
 		sig, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, hashed[:], &opts)
 		if err != nil {

--- a/cmd/fuzzcrypto/std/rsa_test.go
+++ b/cmd/fuzzcrypto/std/rsa_test.go
@@ -120,17 +120,14 @@ func FuzzRSASignPSS(f *testing.F) {
 		if key.Validate() != nil {
 			return
 		}
-		// Check if key size is too small for PSS signature, based on crypto/rsa/pss.go
-		hLen := crypto.SHA256.Size()
-		sLen := hLen // Same as hash size thanks to SaltLength option.
-		emBits := key.N.BitLen() - 1
-		emLen := (emBits + 7) / 8
-		if emLen < hLen+sLen+2 {
-			return // "crypto/rsa: key size too small for PSS signature"
-		}
 		hashed := sha256.Sum256(msg)
 		sig, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, hashed[:], &opts)
 		if err != nil {
+			switch err.Error() {
+			// Key size being too small is an invalid input, not a problem.
+			case "crypto/rsa: key size too small for PSS signature", "crypto/rsa: invalid key size":
+				return
+			}
 			t.Fatal(err)
 		}
 		err = rsa.VerifyPSS(&key.PublicKey, crypto.SHA256, hashed[:], sig, &opts)


### PR DESCRIPTION
I happened to notice this error in an example fuzz test run. Easily reproducible locally, unlike the issues with memory we've been running into. It's just an issue with the inputs, not the library's behavior.

https://dev.azure.com/dnceng/internal/_build/results?buildId=2002188&view=logs&j=55c8d132-ed74-525b-1d69-265188317290&t=b5ce8968-48a5-5335-4111-4f857844d28d&l=3380

```
--- FAIL: FuzzRSASignPSS (2083.31s)
    --- FAIL: FuzzRSASignPSS (0.00s)
        rsa_test.go:126: crypto/rsa: invalid key size
    
    Failing input written to testdata\fuzz\FuzzRSASignPSS\f8e9f0db75c54772972fb2f46f6871a0c2311fc17ad6bcc68cb84c789bdd9e2c
    To re-run:
    go test -run=FuzzRSASignPSS/f8e9f0db75c54772972fb2f46f6871a0c2311fc17ad6bcc68cb84c789bdd9e2c
```

Also repros without cngcrypto locally:

```
--- FAIL: FuzzRSASignPSS (0.00s)
    --- FAIL: FuzzRSASignPSS/f8e9f0db75c54772972fb2f46f6871a0c2311fc17ad6bcc68cb84c789bdd9e2c (0.00s)
        rsa_test.go:134: crypto/rsa: key size too small for PSS signature
```

I dug around for the logic to test for this condition: the check seems to be fairly deep in the crypto methods in a way that I can't see how to reuse here, so I copied out the relevant lines.

I'm guessing we shouldn't check in `f8e9f0db75c54772972fb2f46f6871a0c2311fc17ad6bcc68cb84c789bdd9e2c` because this isn't really an interesting result, it's just an input validity check we didn't have yet. Or should we check it in anyway so fuzz testing can see an example of this `return` branch being hit?