### PR TITLE
Upgrade go-cose and -fuzztime argument

### DIFF
--- a/cmd/fuzzcrypto/main.go
+++ b/cmd/fuzzcrypto/main.go
@@ -40,6 +40,8 @@ The special syntax Nx means to run each fuzz target N times
 
 const helpRun = `Run only those fuzz targets matching the regular expression.`
 
+const defaultFuzzTime = 5 * time.Minute
+
 func main() {
 	var verbose = flag.Bool("v", false, "Verbose output.")
 	var fuzzDuration durationOrCountFlag
@@ -51,6 +53,9 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "%s\n\n", description)
 	}
 	flag.Parse()
+	if fuzzDuration.d == 0 && fuzzDuration.n == 0 {
+		fuzzDuration.d = defaultFuzzTime
+	}
 
 	targets := filterTargets(*run)
 


### PR DESCRIPTION
This PR upgrades go-cose to latest, which contains a fix to reduce memory consumption while fuzzing: https://github.com/veraison/go-cose/pull/104/

I've also fixed a bug in the processing of `-fuzztime` argument, where the default value was not being used when the argument was unset.