### PR TITLE
Clarify go/infra branches, add release branch doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,10 @@
 # Microsoft Go Infrastructure
 
-This repository is used by Microsoft to build Go. See the root
-[README.md](../README.md) for the project overview, and the subdirectories here
-for more info about parts of the infra.
+This repository is used by Microsoft to build Go.
+See the root [README.md](../README.md) for the project overview, and the subdirectories here for more info about parts of the infra.
 
-* [pipeline-yml-style.md](pipeline-yml-style.md) - Style principles and quirk
-  notes for our YAML pipelines here and in microsoft/go.
-
-## Branches
-
-This repository has only one maintained branch, `main`. This branch contains the
-infrastructure used by Microsoft to build any Go release branch.
-
-This is similar to how all release branches of
-[`go`](https://go.googlesource.com/go/) are built and released using the one
-branch of [`x/build`](https://go.googlesource.com/build/).
-
-Using a single branch has significant tradeoffs. On the plus side:
-
-* :+1: Parts of the infra that *do not* take part in the Go build are intuitive
-  to maintain. We would only use the `main` version of this code anyway, so it
-  makes sense to only have a single branch where the code is maintained.
-  * If this code were in a repository with release branches, every release
-    branch would have **dead code**: a copy of the infra at the point in time
-    that the release branch forked from `main`.
-  * For example: auto-updating the Docker image repo is not part of the Go
-    build. It runs an Azure Pipelines `yml` file in the main branch.
-* :+1: Parts of the infra that *do* take part in the Go build can be shared more
-  easily.
-  * Instead of cherry-picking every `main` commit into every applicable release
-    branch all the time, the `go-infra` module dependency can simply be updated
-    to the latest version to get a batch of fixes.
-
-There are downsides:
-
-* :confused: When making a change to `go-infra`, it can be (very!) hard to tell
-  if the change will break a release branch.
-  * This can be mitigated by setting up PR validation jobs that that simulate an
-    update across each active release branch and run a Go build in each one.
-* :confused: It is more difficult to design changes or new infra features when
-  they must be compatible with every release branch at the same time.
-  * It may be impossible, in some cases. This forces the code to be maintained
-    in the repository rather than `go-infra`.
-
-It's important to consider the balance. This is why not all of the code
-Microsoft uses to build Go is stored in this repo, even if it could be migrated
-(even partially). A significant amount of important Go build and packaging logic
-is stored in the repo where it's used.
+* [automation/](automation/) - Some details about the automated infrastructure used to maintain a Go toolset fork.
+* [fork/](fork/) - A description of how the Microsoft Go toolset fork is set up and why we made certain decisions.
+* [release-process/](release-process/) - A description of how to release a Microsoft Go build, and details about the infra behind it.
+* [pipeline-yml-style.md](pipeline-yml-style.md) - Style principles and quirk notes for our YAML pipelines here and in microsoft/go.
+* [branches.md](branches.md) - 

--- a/docs/branches.md
+++ b/docs/branches.md
@@ -1,0 +1,56 @@
+# Branches
+
+## microsoft/go-infra
+
+This repository has only one maintained branch, `main`. This branch contains the
+infrastructure used by Microsoft to build any Go release branch.
+
+## microsoft/go
+
+The Microsoft Go toolset fork, maintained in
+[microsoft/go](https://github.com/microsoft/go), contains one branch per
+maintained major version (e.g. `microsoft/release-branch.go1.19`). They
+correspond to the branches maintained by
+[upstream](https://go.googlesource.com/go).
+
+> These branches are not forks of the upstream Git branches: the situation is
+> more complicated, and explained in
+> [fork/patch-vs-in-place.md](fork/patch-vs-in-place.md).
+
+## Why?
+
+This is similar to how all release branches of
+[`go`](https://go.googlesource.com/go/) are built and released using the one
+branch of [`x/build`](https://go.googlesource.com/build/).
+
+Using a single branch has significant tradeoffs. On the plus side:
+
+* :+1: Parts of the infra that *do not* take part in the Go build are intuitive
+  to maintain. We would only use the `main` version of this code anyway, so it
+  makes sense to only have a single branch where the code is maintained.
+  * If this code were in a repository with release branches, every release
+    branch would have **dead code**: a copy of the infra at the point in time
+    that the release branch forked from `main`.
+  * For example: auto-updating the Docker image repo is not part of the Go
+    build. It runs an Azure Pipelines `yml` file in the main branch.
+* :+1: Parts of the infra that *do* take part in the Go build can be shared more
+  easily.
+  * Instead of cherry-picking every `main` commit into every applicable release
+    branch all the time, the `go-infra` module dependency can simply be updated
+    to the latest version to get a batch of fixes.
+
+There are downsides:
+
+* :confused: When making a change to `go-infra`, it can be (very!) hard to tell
+  if the change will break a release branch.
+  * This can be mitigated by setting up PR validation jobs that that simulate an
+    update across each active release branch and run a Go build in each one.
+* :confused: It is more difficult to design changes or new infra features when
+  they must be compatible with every release branch at the same time.
+  * It may be impossible, in some cases. This forces the code to be maintained
+    in the repository rather than `go-infra`.
+
+It's important to consider the balance. This is why not all of the code
+Microsoft uses to build Go is stored in this repo, even if it could be migrated
+(even partially). A significant amount of important Go build and packaging logic
+is stored in the repo where it's used.

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -8,3 +8,4 @@ These documents describe the reasons for this approach:
 
 * [**Patch files** vs. in-place modifications](patch-vs-in-place.md)
 * [**Submodule** vs. fork](submodule-vs-fork.md)
+* [**Branches**](branches.md)

--- a/docs/release-process/README.md
+++ b/docs/release-process/README.md
@@ -3,4 +3,5 @@
 The docs in this folder describe the release process for Microsoft builds of Go and the infra behind it.
 
 * [instructions.md](instructions.md): how to run a release on release days.
+* [new-release-branch.md](new-release-branch.md): how to create a release branch for a brand new major version.
 * [design.md](design.md): how the release automation works in detail.

--- a/docs/release-process/instructions.md
+++ b/docs/release-process/instructions.md
@@ -1,5 +1,7 @@
 # How to use the release tooling
 
+> Is this a brand new major version without a release branch set up in microsoft/go? For example, 1.19beta1, 1.19rc1, and 1.19 might be the first time releasing major version "19". If so, you need to create the release branch before continuing with this document. See [new-release-branch.md](new-release-branch.md). 
+
 Open the [microsoft-go-infra-release-start](https://dev.azure.com/dnceng/internal/_build?definitionId=1153) pipeline definition. You will use it to kick off the release day.
 
 Click "Run pipeline" and fill the fields:

--- a/docs/release-process/new-release-branch.md
+++ b/docs/release-process/new-release-branch.md
@@ -1,0 +1,55 @@
+# Creating a new release branch
+
+To release any given major.minor version of Go, the microsoft/go repository needs to have a branch tracking that version.
+Early minor/patch/prerelease versions are likely to not have a branch yet, e.g. 1.19, 1.19beta1, and 1.19rc1.
+
+You can check for a specific release branch here: [list of all microsoft/go branches beginning in microsoft/release-branch.go](https://github.com/microsoft/go/branches/all?query=microsoft%2Frelease-branch.go).
+
+> In Go versions prior to 1.19, you may notice an additional `microsoft/dev.boringcrypto.go*` branch.
+> This is no longer necessary in Go 1.19+.
+
+If there isn't an existing branch, you need to create one.
+The steps below use `1.x` as a stand-in for the target version of Go and `main` for the version built by `microsoft/main`:
+
+1. Identify where to create the branch on the microsoft/go repo.
+    * In most cases, simply use the latest commit of `microsoft/main`.
+    * If you *know* that a PR has been merged that works in `main` but would make `1.x` fail, pick the commit before that PR was merged.
+    * If in doubt, pick the latest `microsoft/main` commit. If something ends up failing, you can still fix it later.
+
+1. Create a branch in microsoft/go called `microsoft/release-branch.go1.x` on the selected commit.
+    * E.g. 1.19rc1 -> `microsoft/release-branch.go1.19`
+    * You can use `git push origin <commit>:refs/heads/microsoft/release-branch.go1.x`.
+    * You can the GitHub web UI by opening the tree at the target commit, typing the new branch name in the branch selection dropdown, and clicking "Create ...".
+    * If you don't have permission to create branches in microsoft/go, ask a team member to add you to [golang-compiler](https://repos.opensource.microsoft.com/orgs/microsoft/teams/golang-compiler).
+
+1. Clone/fetch the repo and create a dev branch.  
+    ```
+    # In an existing clone:
+    git fetch --all
+    git checkout -b dev/myname/fork1.x origin/microsoft/release-branch.go1.x
+    ```
+
+1. Update the submodule to point at the latest `1.x` commit:
+    1. First, enter the submodule: `cd go`
+    1. Determine the commit to use. If an upstream branch hasn't been created yet (e.g. 1.19beta1), use the latest `origin/master` commit. If one has been created, make sure you have the latest state using `git fetch --all`, then use `origin/release-branch.go1.x`.
+    1. Use `git checkout`, e.g. `git checkout origin/release-branch.go1.x`.
+    1. Leave the submodule: `cd ..`
+    1. Stage the submodule change with `git add go`
+    1. `git commit` with a message like "Update submodule for 1.x".
+    1. Push the commit and submit the branch as a microsoft/go PR into the branch you created earlier.
+
+1. Fix up PR CI failures.
+    * Changing the submodule commit can cause patch conflicts, so you may need to resolve them. See [the git-go-patch README](/cmd/git-go-patch/README.md).
+    * Add commits onto your dev branch. If necessary, you can add `git revert` commits for changes in `main` that don't apply to `1.x`.
+
+1. Request review from the team in a Teams chat.
+
+1. After approval and green PR CI, merge.
+
+1. To ensure the change works in internal CI, go to [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958) and wait for a build to appear and start running.
+    * This is not necessary if you're planning to run the release automation next. It runs an internal build as part of the release process and you will see any issues then.
+
+Done!
+
+> Some of the steps above make assumptions about how you have Git set up and how you normally use Git and GitHub.
+> For the most part, the shell commands are only suggestions intended to be easy to understand.

--- a/docs/release-process/new-release-branch.md
+++ b/docs/release-process/new-release-branch.md
@@ -9,17 +9,20 @@ You can check for a specific release branch here: [list of all microsoft/go bran
 > This is no longer necessary in Go 1.19+.
 
 If there isn't an existing branch, you need to create one.
-The steps below use `1.x` as a stand-in for the target version of Go and `main` for the version built by `microsoft/main`:
+The steps below use `1.x` as a stand-in for the target version of Go:
 
 1. Identify where to create the branch on the microsoft/go repo.
-    * In most cases, simply use the latest commit of `microsoft/main`.
-    * If you *know* that a PR has been merged that works in `main` but would make `1.x` fail, pick the commit before that PR was merged.
-    * If in doubt, pick the latest `microsoft/main` commit. If something ends up failing, you can still fix it later.
+    * In most cases, simply use the latest commit of the `microsoft/main` branch in the microsoft/go repo.
+        * This branch tracks the upstream `master` branch.
+        * In general, upstream ships "beta" builds from `master`, and only splits a release branch before the first "rc" release.
+        * In microsoft/go, we always split a release branch, even for a "beta" release. This simplifies our release infra by letting it assume that we always use a release branch for releases.
+    * If you *know* that a PR has been merged that works in `microsoft/main` but would make `1.x` fail, choose the commit before that PR was merged.
+    * If in doubt, choose the latest `microsoft/main` commit. If something ends up failing, you can still fix it later.
 
 1. Create a branch in microsoft/go called `microsoft/release-branch.go1.x` on the selected commit.
     * E.g. 1.19rc1 -> `microsoft/release-branch.go1.19`
     * You can use `git push origin <commit>:refs/heads/microsoft/release-branch.go1.x`.
-    * You can the GitHub web UI by opening the tree at the target commit, typing the new branch name in the branch selection dropdown, and clicking "Create ...".
+    * You can use the GitHub web UI by opening the tree at the target commit, typing the new branch name in the branch selection dropdown, and clicking "Create ...".
     * If you don't have permission to create branches in microsoft/go, ask a team member to add you to [golang-compiler](https://repos.opensource.microsoft.com/orgs/microsoft/teams/golang-compiler).
 
 1. Clone/fetch the repo and create a dev branch.  
@@ -40,7 +43,7 @@ The steps below use `1.x` as a stand-in for the target version of Go and `main` 
 
 1. Fix up PR CI failures.
     * Changing the submodule commit can cause patch conflicts, so you may need to resolve them. See [the git-go-patch README](/cmd/git-go-patch/README.md).
-    * Add commits onto your dev branch. If necessary, you can add `git revert` commits for changes in `main` that don't apply to `1.x`.
+    * Add commits onto your dev branch. If necessary, you can add `git revert` commits for changes in `microsoft/main` that don't apply to `1.x`.
 
 1. Request review from the team in a Teams chat.
 


### PR DESCRIPTION
* Slightly clarify the branching structure of microsoft/go and microsoft/go-infra.
* Add instructions for creating new release branches for new major Go releases, and point it out from the main release automation instructions doc.

We've gone through the release process for a servicing release, but this doc should make it reasonable for someone other than me to work on major releases, too. 🙂 