### PR TITLE
Fix `git-go-patch extract` patch dir output with config file

### DIFF
--- a/cmd/git-go-patch/extract.go
+++ b/cmd/git-go-patch/extract.go
@@ -66,8 +66,7 @@ func handleExtract(p subcmd.ParseFunc) error {
 		return err
 	}
 	rootDir, goDir := config.FullProjectRoots()
-
-	patchDir := filepath.Join(rootDir, "patches")
+	patchDir := filepath.Join(rootDir, config.PatchesDir)
 
 	since := *sinceFlag
 	if since == "" {


### PR DESCRIPTION
Fix a hard-coded "patches" dir: use the config file, which defaults to "patches". (The defaults are now the only places `"patches"` shows up in the repo.)