### PR TITLE
Fix hard-coded "go" dirs

### DIFF
--- a/buildmodel/commands.go
+++ b/buildmodel/commands.go
@@ -513,7 +513,7 @@ func RunDockerfileGeneration(repoRoot string, forceSubmoduleReset bool) error {
 		// No err: the submodule directory exists. Now, ensure the submodule is set up correctly and
 		// patched, so we can use the patched templates inside to generate our Dockerfiles.
 		fmt.Println("---- Resetting submodule...")
-		if err := submodule.Reset(repoRoot, forceSubmoduleReset); err != nil {
+		if err := submodule.Reset(repoRoot, goDir, forceSubmoduleReset); err != nil {
 			return err
 		}
 		fmt.Println("---- Applying patches to submodule index...")

--- a/cmd/git-go-patch/apply.go
+++ b/cmd/git-go-patch/apply.go
@@ -59,7 +59,7 @@ func handleApply(p subcmd.ParseFunc) error {
 	}
 
 	if !*noRefresh {
-		if err := submodule.Reset(rootDir, *force); err != nil {
+		if err := submodule.Reset(rootDir, goDir, *force); err != nil {
 			return err
 		}
 	}
@@ -107,8 +107,8 @@ func getCurrentCommit(goDir string) (string, error) {
 	return executil.SpaceTrimmedCombinedOutput(currentCmd)
 }
 
-func getTargetSubmoduleCommit(rootDir string) (string, error) {
-	cmd := exec.Command("git", "ls-tree", "HEAD", "go")
+func getTargetSubmoduleCommit(rootDir, submoduleDir string) (string, error) {
+	cmd := exec.Command("git", "ls-tree", "HEAD", submoduleDir)
 	cmd.Dir = rootDir
 	// Format, from Git docs: "<mode> SP <type> SP <object> TAB <file>"
 	lsOut, err := executil.SpaceTrimmedCombinedOutput(cmd)
@@ -171,7 +171,7 @@ func ensureSubmoduleCommitNotDirty(config *patch.FoundConfig) error {
 	// Check if the submodule commit is the same as what the Git index of the outer repo expects. We
 	// need to check this because the user could have checked out a different version of the outer
 	// repo and run "git submodule update" without running "apply" again.
-	currentTargetCommit, err := getTargetSubmoduleCommit(rootDir)
+	currentTargetCommit, err := getTargetSubmoduleCommit(rootDir, goDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes an issue where `git go-patch apply -f` fails to find `go/` if the submodule dir is configured to be something else. (E.g. the test dir in https://github.com/microsoft/go-infra/pull/74) and dirtiness detection.