### PR TITLE
Doc the use of git-go-patch for other repos

### DIFF
--- a/cmd/git-go-patch/README.md
+++ b/cmd/git-go-patch/README.md
@@ -1,10 +1,19 @@
 # git-go-patch
 
-`git-go-patch` is a tool that makes it easier to work with the submodule and Git patch files used by the Microsoft Go repository. The subcommands help with common workflows for patch creation and maintenance.
+`git-go-patch` is a tool that makes it easier to work with a "patched submodule fork" workflow.
+It includes several subcommands that help with specific parts of the process.
+The [Microsoft Go repository](https://github.com/microsoft/go) uses this tool, and it's currently the main reason the tool is being developed and maintained.
+
+A "patched submodule fork" is when you don't hit GitHub's "Fork" button, but rather maintain your own Git repository that contains the upstream repo as a [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) along with `*.patch` files that modify the submodule when you use `git apply patches/*.patch`.
+For more information about why we chose this style of fork for the Microsoft Go repository, see [/docs/fork](https://github.com/microsoft/go-infra/tree/main/docs/fork).
+
+Related documentation:
+
+* [set-up-repo.md](set-up-repo.md) - How to set up your repo to work with git-go-patch.
 
 ## Installing
 
-First, install the command:
+First, use Go to build and install the command:
 
 ```
 go install github.com/microsoft/go-infra/cmd/git-go-patch@latest
@@ -18,33 +27,66 @@ Then, run the command to see the help documentation:
 git go-patch -h
 ```
 
-> `git` detects binaries that start with `git-` and makes them available as `git {command}`.
+> `git` detects that our `git-go-patch` executable starts with `git-` and makes it available as `git go-patch`. The program still works if you call it with its real name, but we think it's easier to remember and type something that looks like a `git` subcommand.
 
-## `apply` Workflow
+# Subcommands
 
-### Make changes to a patch file
+## Make changes to a patch file
 
-1. Open a terminal anywhere within the Microsoft Go repository or its submodule.
-2. Use `git go-patch apply` to apply patches onto the submodule as a series of commits.
-3. Edit the commits as desired.
+Sometimes you have to fix a bug in a patch file, add a new patch file, etc., and `apply`, `rebase`, and `extract` can help.
+
+1. Open a terminal anywhere within the repository containing the patch files or the submodule.
+1. Use `git go-patch apply` to apply patches onto the submodule as a series of commits.
+1. Navigate into the submodule.
+1. Edit the commits as desired.
+   1. `git go-patch rebase` starts an interactive rebase, allowing you to do any normal Git rebase actions like reorder, squash, drop, and edit.
    1. If it fits your workflow, use `git commit --fixup={commit}` to create fixup commits and `git go-patch rebase` to apply them.
-4. Use `git go-patch extract` to rewrite the patch files based on the changes in the submodule.
+1. Use `git go-patch extract` to rewrite the patch files based on the changes in the submodule.
 
-### Fix up patch files after a submodule update
+## Fix up patch files after a submodule update
 
-After a submodule update, patches may fail to apply and cause an error like this:
+Every so often, you need to update your submodule to the latest version of the upstream repo.
+Just like a `rebase` or `merge`, this can generate conflicts when the patches no longer apply cleanly.
+The error may look like this:
 
 ```
 error: patch failed: src/[...].go:329
 ```
 
-To fix this, follow the process to make changes to a patch file. After running `git go-patch apply`, you will see the patch failure error appear, with extra instructions about how to use `git am` to resolve it. Then:
+To fix this, follow the process to make changes to a patch file. While running `git go-patch apply`, you will see the patch failure error appear, with extra instructions about how to use `git am` to resolve it. Then:
 
 1. Make sure your terminal is inside the submodule.
-2. Resolve the conflict. There are several ways:
+1. Resolve the conflict. There are several ways:
    1. Run `git am -3`. This performs a 3-way merge, and leaves merge conflict markers in the files for manual or tool-assisted fixing.
-   2. Run `git am --reject`. This creates a `.rej` file for each file that couldn't be patched, containing the failed chunks for you to apply manually.
-   3. Redo the change from scratch.
-3. Run `git am --continue` after staging fixes.
+   1. Run `git am --reject`. This creates a `.rej` file for each file that couldn't be patched, containing the failed chunks for you to apply manually.
+   1. Redo the change from scratch.
+   1. See [`git am` documentation](https://git-scm.com/docs/git-am) for more information.
+1. Stage your fixes.
+1. Run `git am --continue` to create the fixed-up commit.
+1. If there are more conflicts, go back to step 2.
+1. Run `git go-patch extract` to save the fixes to your repository's patch files.
 
-See [`git am` documentation](https://git-scm.com/docs/git-am) for more information.
+If you have many patch files authored by different developers and it isn't reasonable for one person to resolve all the conflicts, you can fix a few patches and run `git go-patch extract` to save all the fixes completed so far.
+Be careful when staging your WIP patch files in the outer repo, because `extract` doesn't fully understand this situation and will delete the patches that haven't been fixed up yet.
+The next dev to work on resolution can then check out the WIP branch and run `git go-patch apply` to pick up where the last dev left it.
+
+## Init submodule and apply patches with a fresh clone
+
+`git go-patch apply` understands how to set up a repo's submodules, so you can use it to make it easy for a dev to look at your fork's modifications after a fresh clone:
+
+```sh
+git clone https://example.org/my/project proj
+cd proj
+git go-patch apply
+# Proj and proj's submodule are now ready to examine.
+```
+
+However, in build scripts, you may want to use traditional Git commands to avoid the dependency on our tool in production environments. We suggest:
+
+```
+git submodule update --init --recursive
+cd submodule
+git apply ../patches/*.patch
+```
+
+If you are using Azure DevOps or similar CI mechanism, it may handle submodule initialization for you.

--- a/cmd/git-go-patch/set-up-repo.md
+++ b/cmd/git-go-patch/set-up-repo.md
@@ -1,0 +1,107 @@
+# Setting up a fork repo with git-go-patch
+
+The git-go-patch tool relies on a configuration file to determine where your submodule and patch files are.
+For these instructions, we assume your repository is set up like this:
+
+* `.git/`
+* `.gitignore`
+* `.gitmodules`
+* `artifacts/` (a directory that stores temporary build artifacts, listed in `.gitignore`)
+* `submodules/`
+   * `forked-project/` (the submodule)
+* `patches/`
+   * `0001-Change-X-to-Z.patch`
+   * `0002-Fix-large-number-bug.patch`
+* `build.ps1` (a script that applies the patches to the submodule then builds it)
+
+Using a terminal that is inside your repository and outside of the submodule, run:
+
+```
+git go-patch init
+```
+
+This creates a configuration file, formatted as JSON.
+Fill in the fields.
+For the above repo structure, they would be:
+
+* `SubmoduleDir` is `submodules/forked-project`
+* `PatchesDir` is `patches`
+
+Make sure to check the config file into your repository.
+
+Now, `git go-patch` subcommands that you run in any subdirectory of your repository and inside the submodule will find the configuration file and work with your submodule and your patches.
+
+## Converting an existing fork into patch files
+
+If you have an existing "direct" fork that you want to convert into a "patched submodule" fork, there is no single right way to do it, but these tips might help.
+
+This section assumes you have your fork cloned locally and it has a remote named `origin` for your repo and a remote named `upstream` pointing at the upstream repo.
+We also assume familiarity with Git, to be able to adjust the suggestions to fit your project's situation.
+
+First, use this command to determine the latest common commit between your fork and upstream:
+
+```sh
+git merge-base origin/main upstream/main
+```
+
+We'll call the result `<common-commit>`.
+Using this commit hash instead of `upstream/main` means you aren't trying to do an upgrade to the latest version of upstream at the same time you're trying to convert your fork into patch files.
+This will save you some conflict resolution!
+
+Then, use commands like these but with your project and upstream's names to set up a submodule:
+
+```sh
+git submodule add https://example.org/upstream/repo submodules/forked-project
+# Move into the submodule. Git commands now operate on the submodule, not the outer repo.
+cd submodules/forked-project
+git checkout <common-commit>
+cd -
+# Add the submodule reference to the outer repo.
+git add .
+git commit
+```
+
+From this point on, make sure not to commit changes to `submodules/forked-project`.
+We will be creating temporary commits that don't exist in `https://example.org/upstream/repo`, and it's important that you only commit the submodule when it references a commit that exists in the URL configured in `.gitmodules`.
+
+Next, set up a second remote inside the submodule that points at your fork, and simplify your forked branch's history (remove merge commits and make it linear):
+
+```sh
+cd submodules/forked-project
+git remote add fork https://example.org/yourfork/repo
+git fetch --all
+git checkout fork/main
+git rebase <common-commit>
+cd -
+```
+
+You may be prompted to resolve conflicts during `git rebase`.
+In general, if you've had to solve merge conflicts when merging from upstream, you'll have to resolve those conflicts again during the rebase process.
+If this isn't feasible, or the history of the fork is unimportant, you can `git rebase --abort`, then use these commands to wipe out history and create a single commit that contains the entire diff with a completely new commit message:
+
+```sh
+cd submodules/forked-project
+git checkout fork/main
+git reset --soft <common-commit>
+git commit
+cd -
+```
+
+> You can also use more advanced `git reset`/`git add` commands and/or graphical Git clients to stage specific chunks of the diff and split it into multiple new commits.
+> Each commit will be extracted as its own patch file.
+>
+> Grouping related changes with explanatory commit messages can be a valuable tool in making easy-to-understand patches, because the patches show the commit message above the diff.
+
+Then, go through the first section of the doc to set up the `git go-patch` configuration.
+
+Finally, extract the patch files and commit them:
+
+```sh
+# In your repository (outer repository):
+git go-patch extract <common-commit>
+git add patches
+git commit
+```
+
+Now, you can use git-go-patch workflows like "`git go-patch apply` -> modify commits -> `git go-patch extract`".
+See [the main README.md](README.md) for more information.

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -8,4 +8,11 @@ These documents describe the reasons for this approach:
 
 * [**Patch files** vs. in-place modifications](patch-vs-in-place.md)
 * [**Submodule** vs. fork](submodule-vs-fork.md)
-* [**Branches**](branches.md)
+
+This document shows the branching we use for this repository and our fork:
+
+* [**../Branches**](../branches.md)
+
+We also developed [a tool called `git-go-patch`](../../cmd/git-go-patch) to help maintain the Microsoft Go patches.
+Other teams maintaining a submodule+patch fork may also find it useful.
+Let us know!


### PR DESCRIPTION
Make common workflows clearer and more general than just microsoft/go. Add a new doc for initial setup. Fix a broken link in docs/fork/README.md and add in more context and a link to this tool.

Rendered: https://github.com/microsoft/go-infra/tree/dev/dagood/patcher-doc/cmd/git-go-patch