### PR TITLE
Add internal CodeQL pipeline

### DIFF
--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -18,6 +18,8 @@ Internal pipeline definitions:
   * 🚀 internal [`microsoft-go-infra-upstream-sync`](https://dev.azure.com/dnceng/internal/_build?definitionId=1061)
 * [`fuzz-pipeline.yml`](fuzz-pipeline.yml) - Run fuzz tests internally on a schedule.
   * 🚀 internal [`microsoft-go-infra-fuzz`](https://dev.azure.com/dnceng/internal/_build?definitionId=1182)
+* [`rolling-internal-validation-pipeline.yml`](rolling-internal-validation-pipeline.yml) - Runs scheduled internal validation checks.
+  * 🚀 internal [microsoft-go-infra-validation](https://dev.azure.com/dnceng/internal/_build?definitionId=1210)
 
 Internal release pipelines (see [release process docs](/docs/release-process)):
 

--- a/eng/pipelines/rolling-internal-validation-pipeline.yml
+++ b/eng/pipelines/rolling-internal-validation-pipeline.yml
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This pipeline analyzes the repo with CodeQL.
+
+trigger: none
+pr: none
+schedules:
+  - cron: '0 16 * * Mon,Wed,Fri'
+    displayName: Analyze
+    branches:
+      include:
+        - main
+
+variables:
+  # Enable CodeQL scan and configure options.
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#additional-options
+  - name: Codeql.Enabled
+    value: true
+  - name: Codeql.Language
+    value: go
+
+jobs:
+  - job: CodeQL
+    workspace:
+      clean: all
+    pool:
+      # This is a utility job: use generic recent LTS.
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+    steps:
+      - template: steps/checkout-unix-task.yml
+      - template: steps/init-go.yml
+
+      - task: CodeQL3000Init@0
+
+      - script: go build ./...
+        displayName: Build
+
+      - task: CodeQL3000Finalize@0


### PR DESCRIPTION
* Related: https://github.com/microsoft/go/pull/801

While working on https://github.com/microsoft/go/pull/801, I made this pipeline to try a simpler CodeQL scan to debug an issue, and it worked here. This repo isn't flagged as needing CodeQL scanning, but I think it might in the future (and it makes sense to me to scan it) so I figure we might as well keep it.