### PR TITLE
Include arch variant for Mariner 1.0: now in manifest

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -308,9 +308,9 @@ func makeOSArchPlatform(os, osVersion string, env *dockerversions.ArchEnv) *dock
 	// to specify more info: a version. .NET Docker infra calls this a "variant". This
 	// is not the same as the Official Go Image "variant" (OS name/version).
 	archVariant := env.GoImageArchVersionSuffix()
-	// CBL-Mariner 1.0 and 2.0 don't specify an ARM arch variant (version) in the Docker manifest,
+	// CBL-Mariner 2.0 doesn't specify an ARM arch variant (version) in the Docker manifest,
 	// so we must omit it, too: .NET Docker infra checks they match.
-	if strings.HasPrefix(osVersion, "cbl-mariner") {
+	if osVersion == "cbl-mariner2.0" {
 		archVariant = ""
 	}
 	return &dockermanifest.Platform{

--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -308,11 +308,6 @@ func makeOSArchPlatform(os, osVersion string, env *dockerversions.ArchEnv) *dock
 	// to specify more info: a version. .NET Docker infra calls this a "variant". This
 	// is not the same as the Official Go Image "variant" (OS name/version).
 	archVariant := env.GoImageArchVersionSuffix()
-	// CBL-Mariner 2.0 doesn't specify an ARM arch variant (version) in the Docker manifest,
-	// so we must omit it, too: .NET Docker infra checks they match.
-	if osVersion == "cbl-mariner2.0" {
-		archVariant = ""
-	}
 	return &dockermanifest.Platform{
 		Architecture: env.GOARCH,
 		Variant:      archVariant,

--- a/buildmodel/buildmodel_test.go
+++ b/buildmodel/buildmodel_test.go
@@ -138,16 +138,11 @@ func Test_makeOsArchPlatform(t *testing.T) {
 		},
 		{
 			"linux-arm no version if Mariner",
-			args{"linux", "cbl-mariner1.0", "arm", "7"},
-			want{"linux", "cbl-mariner1.0", "arm", ""},
+			args{"linux", "cbl-mariner2.0", "arm", "7"},
+			want{"linux", "cbl-mariner2.0", "arm", ""},
 		},
 		{
 			"linux-arm64 no version if Mariner",
-			args{"linux", "cbl-mariner1.0", "arm64", ""},
-			want{"linux", "cbl-mariner1.0", "arm64", ""},
-		},
-		{
-			"linux-arm64 no version if Mariner 2.0",
 			args{"linux", "cbl-mariner2.0", "arm64", ""},
 			want{"linux", "cbl-mariner2.0", "arm64", ""},
 		},

--- a/buildmodel/buildmodel_test.go
+++ b/buildmodel/buildmodel_test.go
@@ -137,14 +137,9 @@ func Test_makeOsArchPlatform(t *testing.T) {
 			want{"linux", "", "arm", "v7"},
 		},
 		{
-			"linux-arm no version if Mariner",
-			args{"linux", "cbl-mariner2.0", "arm", "7"},
-			want{"linux", "cbl-mariner2.0", "arm", ""},
-		},
-		{
-			"linux-arm64 no version if Mariner",
+			"linux-arm64 Mariner v8",
 			args{"linux", "cbl-mariner2.0", "arm64", ""},
-			want{"linux", "cbl-mariner2.0", "arm64", ""},
+			want{"linux", "cbl-mariner2.0", "arm64", "v8"},
 		},
 	}
 	for _, tt := range tests {

--- a/buildmodel/testdata/UpdateManifest/updatedManifest.golden.json
+++ b/buildmodel/testdata/UpdateManifest/updatedManifest.golden.json
@@ -161,6 +161,7 @@
                 "REPO": "$(Repo:golang)"
               },
               "architecture": "arm64",
+              "variant": "v8",
               "dockerfile": "src/microsoft/1.18/fips-linux/cbl-mariner1.0",
               "os": "linux",
               "osVersion": "cbl-mariner1.0",


### PR DESCRIPTION
Update microsoft/go-images update tool to match upstream changes to the Mariner 1.0 Docker manifest (~~but not the 2.0 manifest, oddly~~ (Edit: This now applies to both 1.0 and 2.0)):

```
#> docker manifest inspect cblmariner.azurecr.io/base/core:1.0
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:d511642f10740c1f90a74deea5cb4ee32737b9b5b9156883e0a8a68c70986af4",
         "platform": {
            "architecture": "amd64",
            "os": "linux",
            "os.version": "cbl-mariner-1.0"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:0daba5010297b0806c5267dd76c9c479233167bda0aebb6cdecbd366ed29ad3c",
         "platform": {
            "architecture": "arm64",
            "os": "linux",
            "os.version": "cbl-mariner-1.0",
            "variant": "v8"
         }
      }
   ]
}
#> docker manifest inspect cblmariner.azurecr.io/base/core:2.0
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:db5c018a7c951446a16f0882b5e48322878a150b840a7123a9216f27404bbb38",
         "platform": {
            "architecture": "amd64",
            "os": "linux",
            "os.version": "cbl-mariner-2.0"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:114f0da57062e3f88cb476804d6bec6119ff0f4bf43e35ba5cad89285d841370",
         "platform": {
            "architecture": "arm64",
            "os": "linux",
            "os.version": "cbl-mariner-2.0"
         }
      }
   ]
}
```

* I'm trying this in go-images CI here: https://github.com/microsoft/go-images/pull/218