### PR TITLE
Add runtime parameter doc, link to yaml-multiline

### DIFF
--- a/docs/pipeline-yml-style.md
+++ b/docs/pipeline-yml-style.md
@@ -10,6 +10,9 @@ Useful AzDO Pipeline YAML docs:
 * [Template types & usage](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops)
 * [Build and release tasks](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/?view=azure-devops)
 
+General YAML resources:
+* [Advanced multi-line value handling (`>`, `|`, ...)](https://yaml-multiline.info/)
+
 ## Faster retry: one stage per job
 
 A typical way to arrange an AzDO pipeline is to add a job for each platform into a single stage:
@@ -60,6 +63,28 @@ parameters:
 In this mode, any additional parameters passed by a `- template: ...` statement are rejected as a template evaluation error. If we need some arbitrary parameters, we use an extra `object` param.
 
 Because `orange` is passed as a `boolean`, `${{ if parameters.orange }}` evaluates as expected.
+
+## Runtime parameters
+
+[Runtime parameters](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters) are a way to specify parameters for a pipeline run that show up at the top level of the "Run" dialogue. These are nicer to use for commonly adjusted user inputs than variables: you don't need to dig deep in the UI to change them, and they have friendly labels defined in the pipeline YML file. The parameters are also usable in AzDO templates without the limitations of variables.
+
+We also use runtime parameters to transfer release data between pipelines in the automated release process.
+
+In AzDO YML, a runtime parameter either has a default value, or a value must be assigned by the user before the "Run" button is enabled.
+
+### 'nil' string default
+
+A problem is that AzDO doesn't treat the empty string `''` as a valid default value: AzDO requires the user to specify some non-empty string before hitting "Run". We sometimes need to define an optional string parameter without any meaningful default value. If `''` worked, it would be the easy choice for this scenario, but it doesn't work.
+
+As a workaround, when we need an optional string parameter, we use the string `nil` as the default value and `ne(parameter.example, 'nil')` to check if the parameter was set. For example:
+
+```yml
+parameters:
+  - name: example
+    displayName: 'Description of an example pseudo-optional string parameter'
+    type: string
+    default: nil
+```
 
 ## Templates for data reuse
 

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Use runtime parameters to define these selections in YML. This also makes them
-# show up in the "Run" popup directly. This makes them much easier to set
-# manually, vs. digging into the Variables submenu with many clicks.
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
   - name: releaseVersion
     displayName: Version to release, including Microsoft revision suffix (-1) and boring/FIPS suffix (-fips) if they apply.

--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Use runtime parameters to define these selections in YML. This also makes them
-# show up in the "Run" popup directly. This makes them much easier to set
-# manually, vs. digging into the Variables submenu with many clicks.
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
   - name: releaseVersions
     displayName: >

--- a/eng/pipelines/release-go-start-pipeline.yml
+++ b/eng/pipelines/release-go-start-pipeline.yml
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# Use runtime parameters to define these selections in YML. This also makes them
-# show up in the "Run" popup directly. This makes them much easier to set
-# manually, vs. digging into the Variables submenu with many clicks.
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
   - name: releaseVersions
     displayName: >


### PR DESCRIPTION
Expand on the meaning of `default: nil` and move the general info about runtime parameters to a central doc. I'm planning on adding a runtime parameter to microsoft/go's internal build, so it will be nice to reference this doc.

I originally used `>` in my example and included the yaml-multiline.info link to explain it. I simplified the example, but it still might be a useful link, so I left it in.

Rendered: https://github.com/dagood/go-infra/blob/dev/dagood/doc-runtime-param/docs/pipeline-yml-style.md