### PR TITLE
Handle upstream 1.21.0 change to have zero in tag

### DIFF
--- a/goversion/goversion.go
+++ b/goversion/goversion.go
@@ -109,15 +109,26 @@ func (v *GoVersion) Full() string {
 	return v.MajorMinorPatchPrereleaseRevision() + v.NoteWithPrefix()
 }
 
-// UpstreamFormatGitTag returns the version in the format upstream uses for Git tags. Specifically,
-// revision, note, and trailing ".0" strings are omitted, and the prefix is "go".
+// UpstreamFormatGitTag returns the version in the format upstream uses for Git tags.
 func (v *GoVersion) UpstreamFormatGitTag() string {
-	n := v.Major
-	if v.Patch != "0" || v.Minor != "0" {
-		n += "." + v.Minor
+	// In versions of Go older than 1.21, zeros are omitted. https://github.com/golang/go/issues/57631
+	var omitZeros bool
+	if v.Major == "1" {
+		if minorNum, err := strconv.Atoi(v.Minor); err == nil {
+			omitZeros = minorNum < 21
+		}
 	}
-	if v.Patch != "0" {
-		n += "." + v.Patch
+	var n string
+	if omitZeros {
+		n = v.Major
+		if v.Patch != "0" || v.Minor != "0" {
+			n += "." + v.Minor
+		}
+		if v.Patch != "0" {
+			n += "." + v.Patch
+		}
+	} else {
+		n = v.Major + "." + v.Minor + "." + v.Patch
 	}
 	return "go" + n + v.Prerelease
 }

--- a/goversion/goversion_test.go
+++ b/goversion/goversion_test.go
@@ -111,7 +111,12 @@ func TestGoVersion_UpstreamFormatGitTag(t *testing.T) {
 		{"do not drop middle zero", "1.0.1", "go1.0.1"},
 		{"drop ending zero", "1.1.0", "go1.1"},
 		{"never drop ones", "1.1.1", "go1.1.1"},
-		{"drop zeroes for v2", "2.0.0", "go2"},
+		// 1.21 changed zero behavior. https://github.com/golang/go/issues/57631
+		{"no zero in 1.20", "1.20.0", "go1.20"},
+		{"zero in 1.21", "1.21.0", "go1.21.0"},
+		{"zero in 1.22", "1.22.0", "go1.22.0"},
+		{"same 1.21 patching behavior", "1.21.1", "go1.21.1"},
+		{"don't drop zeros for v2", "2.0.0", "go2.0.0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/888
* Handle https://github.com/golang/go/issues/57631

Upstream has this set up to apply at 1.21.0, so put that in our infra. This is called by the part of release automation that polls the upstream repo on release day. If it doesn't end up working out for some reason, we'll need to revert this PR and re-run automation.

I considered polling both the old and new formats at the same time, but I would prefer to simply get it right rather than add a tag check race. I haven't seen any indication that upstream would go back to the old versioning scheme if something went wrong, so I don't know if it would actually end up being used even in that case.