### PR TITLE
Create aka.ms URL for assets.json file

### DIFF
--- a/cmd/releasego/akams.go
+++ b/cmd/releasego/akams.go
@@ -145,6 +145,10 @@ func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
 		urls = appendPathAndVerificationFilePaths(urls, a.URL)
 	}
 	urls = appendPathAndVerificationFilePaths(urls, assets.GoSrcURL)
+	// The assets.json is uploaded in the same virtual dir as src.
+	// Make an aka.ms URL for it.
+	urlBase := strings.Join(goSrcURLParts[:len(goSrcURLParts)-1], "/") + "/"
+	urls = append(urls, urlBase+"assets.json")
 
 	pairs := make([]akaMSLinkPair, 0, len(urls)*len(partial))
 
@@ -175,7 +179,12 @@ func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
 }
 
 func makeFloatingFilename(filename, buildNumber, floatVersion string) (string, error) {
+	// The assets.json file has no version number in it, so we need to add one.
+	if filename == "assets.json" {
+		return "go" + floatVersion + "." + filename, nil
+	}
 	f := strings.ReplaceAll(filename, buildNumber, floatVersion)
+	// Make sure something was actually replaced.
 	if f == filename {
 		return "", fmt.Errorf("unable to find buildNumber %#q in filename %#q", buildNumber, filename)
 	}

--- a/cmd/releasego/akams_test.go
+++ b/cmd/releasego/akams_test.go
@@ -31,18 +31,23 @@ func Test_createLinkPairs(t *testing.T) {
 		{Short: "testing/go1.17.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
 		{Short: "testing/go1.17.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
 		{Short: "testing/go1.17.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.assets.json", Target: "https://example.org/golang/build/1234.10/assets.json"},
+
 		{Short: "testing/go1.17.7.linux-amd64.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
 		{Short: "testing/go1.17.7.linux-amd64.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
 		{Short: "testing/go1.17.7.linux-amd64.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
 		{Short: "testing/go1.17.7.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
 		{Short: "testing/go1.17.7.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
 		{Short: "testing/go1.17.7.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.7.assets.json", Target: "https://example.org/golang/build/1234.10/assets.json"},
+
 		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz"},
 		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sha256"},
 		{Short: "testing/go1.17.7-1.linux-amd64.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.linux-amd64.tar.gz.sig"},
 		{Short: "testing/go1.17.7-1.src.tar.gz", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz"},
 		{Short: "testing/go1.17.7-1.src.tar.gz.sha256", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sha256"},
 		{Short: "testing/go1.17.7-1.src.tar.gz.sig", Target: "https://example.org/golang/build/1234.10/go.1234.10.src.tar.gz.sig"},
+		{Short: "testing/go1.17.7-1.assets.json", Target: "https://example.org/golang/build/1234.10/assets.json"},
 	}
 	got, err := createLinkPairs(input)
 	if err != nil {


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/945

We're already uploading the assets.json file to blob storage, so it's relatively simple to add aka.ms links.

All the blob storage uploads are done before any aka.ms link updates, so it should be possible to use the aka.ms assets.json URL to download the assets.json then use the absolute URLs inside the assets.json file to download a Go `tar.gz` and `tar.gz.sig` and verify the checksum without any races.

Excerpt of the results from a test run (`dev` in aka.ms links): https://dev.azure.com/dnceng/internal/_build/results?buildId=2206722&view=results

Short | Full
--- | ---
https://aka.ms/golang/release/dev/latest/go1.19.assets.json  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/assets.json
https://aka.ms/golang/release/dev/latest/go1.19.10.assets.json  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/assets.json
https://aka.ms/golang/release/dev/latest/go1.19.10-1.assets.json  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/assets.json
https://aka.ms/golang/release/dev/latest/go1.19.linux-amd64.tar.gz  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-amd64.tar.gz
https://aka.ms/golang/release/dev/latest/go1.19.linux-amd64.tar.gz.sha256  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-amd64.tar.gz.sha256
https://aka.ms/golang/release/dev/latest/go1.19.linux-amd64.tar.gz.sig  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.linux-amd64.tar.gz.sig
https://aka.ms/golang/release/dev/latest/go1.19.windows-amd64.zip  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.windows-amd64.zip
https://aka.ms/golang/release/dev/latest/go1.19.windows-amd64.zip.sha256  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.windows-amd64.zip.sha256
https://aka.ms/golang/release/dev/latest/go1.19.src.tar.gz  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.src.tar.gz
https://aka.ms/golang/release/dev/latest/go1.19.src.tar.gz.sha256  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.src.tar.gz.sha256
https://aka.ms/golang/release/dev/latest/go1.19.src.tar.gz.sig  |  https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.19/20230606.2/go.20230606.2.src.tar.gz.sig
