### PR TITLE
Mirror all release branches in scheduled sync

### DIFF
--- a/cmd/releasego/sync.go
+++ b/cmd/releasego/sync.go
@@ -81,6 +81,7 @@ func handleSync(p subcmd.ParseFunc) error {
 
 	// Only sync the single branch we intend to.
 	foundEntry.AutoSyncBranches = []string{versionUpstream}
+	foundEntry.AutoMirrorBranches = nil
 	if *commit != "" {
 		// Use the target commit, not just what happens to be the latest.
 		foundEntry.SourceBranchLatestCommit = map[string]string{versionUpstream: *commit}

--- a/docs/release-process/new-release-branch.md
+++ b/docs/release-process/new-release-branch.md
@@ -40,6 +40,10 @@ The steps below use `1.x` as a stand-in for the target version of Go:
     1. Stage the submodule change with `git add go`
     1. `git commit` with a message like "Update submodule for 1.x".
     1. Push the commit and submit the branch as a microsoft/go PR into the branch you created earlier.
+    1. Make sure the upstream branch and commit are available in the internal [microsoft-go-mirror](https://dev.azure.com/dnceng/internal/_git/microsoft-go-mirror) repo.
+        * If not, queue [microsoft-go-infra-upstream-sync](https://dev.azure.com/dnceng/internal/_build?definitionId=1061) to run with default parameters. It automatically mirrors all upstream release branches.
+        * If the upstream sync pipeline ran relatively recently, this step isn't necessary.
+        * Missing branches/commits can cause the internal build to fail in a later step. Public CI doesn't use the internal mirror, so it won't catch this issue.
 
 1. Fix up PR CI failures.
     * Changing the submodule commit can cause patch conflicts, so you may need to resolve them. See [the git-go-patch README](/cmd/git-go-patch/README.md).

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -6,15 +6,13 @@
     "MirrorTarget": "https://dnceng@dev.azure.com/dnceng/internal/_git/microsoft-go-mirror",
     "BranchMap": {
       "master": "microsoft/main",
-      "release-branch.go*": "microsoft/?",
-      "dev.boringcrypto.go*": "microsoft/?"
+      "release-branch.go*": "microsoft/?"
     },
     "AutoSyncBranches": [
-      "master",
-      "release-branch.go1.18",
-      "dev.boringcrypto.go1.18",
-      "release-branch.go1.17",
-      "dev.boringcrypto.go1.17"
+      "master"
+    ],
+    "AutoMirrorBranches": [
+      "release-branch.go*"
     ],
     "MainBranch": "microsoft/main",
     "SubmoduleTarget": "go"

--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -111,6 +111,30 @@ func (b SyncPRRefSet) ForkFromMainRefspec(mainBranch string) string {
 	return createRefspec(mainBranch, b.Name)
 }
 
+// MirrorRefSet calculates the set of refs that correspond to a pure mirroring
+// operation, where the set of mirrored branches is specified by a pattern.
+type MirrorRefSet struct {
+	UpstreamPattern string
+}
+
+// UpstreamMirrorLocalBranchPattern is the name of the local ref (or pattern
+// matching multiple local refs) after it has been fetched from the upstream.
+func (b MirrorRefSet) UpstreamMirrorLocalBranchPattern() string {
+	return "fetched-upstream-mirror-pattern/" + b.UpstreamPattern
+}
+
+// UpstreamMirrorFetchRefspec fetches the remote refs that match the pattern to
+// local branches.
+func (b MirrorRefSet) UpstreamMirrorFetchRefspec() string {
+	return createRefspec(b.UpstreamPattern, b.UpstreamMirrorLocalBranchPattern())
+}
+
+// UpstreamMirrorRefspec pushes the local mirroring branches to back to
+// branches with the same name as the branches they were fetched from.
+func (b MirrorRefSet) UpstreamMirrorRefspec() string {
+	return createRefspec(b.UpstreamMirrorLocalBranchPattern(), b.UpstreamPattern)
+}
+
 // Remote is a parsed version of a Git Remote. It helps determine how to send a GitHub PR.
 type Remote struct {
 	url      string

--- a/sync/model.go
+++ b/sync/model.go
@@ -39,7 +39,8 @@ type ConfigEntry struct {
 	Head string
 	// MirrorTarget	is an optional Git repository to push the upstream branch to. All mirroring
 	// operations must succeed before sync continues with this sync config entry. The mirror target
-	// is intended to be an internal repo, for reliability and security purposes.
+	// is intended to be an internal repo, for reliability and security purposes. Mirrored branches
+	// use the same name as they have in Upstream, ignoring BranchMap.
 	MirrorTarget string
 
 	// BranchMap is a map of source branch names in Upstream (keys) to use to update a corresponding
@@ -53,6 +54,11 @@ type ConfigEntry struct {
 	// command ignores this list, syncing a user-specified branch instead that may not even be in
 	// the AutoSyncBranches list.
 	AutoSyncBranches []string
+
+	// AutoMirrorBranches is a list of branches that should be mirrored to MirrorTarget, in addition
+	// to the list of branches in AutoSyncBranches. A "*" is glob matched. "./cmd/releasego sync"
+	// ignores this list to keep release activity separate from unrelated branch mirroring.
+	AutoMirrorBranches []string
 
 	// MainBranch is the main/master branch of the target repository. When creating a new release
 	// branch, it is forked from the tip of this branch.


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go/issues/859
* This PR cleans up old EOL branches in the sync config that had no effect. (Related: https://github.com/microsoft/go/issues/555)

Includes an update to the docs to check that the internal mirror is done so the internal build is more likely to work on the first try for a fresh release branch.

Testing this is tricky because it depends a lot on Git behavior and we don't have robust tests set up around this system. However, testing in dry-run mode seemed to do what I expect and it isn't super complicated.

One edge case I thought of is what happens when `push` refs overlap. E.g. if we have:

```
git push mirrorrepo \
  mirror/release-branch.go1.19:release-branch.go1.19 \
  mirror-pattern/release-branch.go*:release-branch.go*
```

Luckily, Git automatically excludes 1.19 from the pattern matching in that case and uses the explicitly defined arg. This overlap could happen if we have 1.19 set up to use automatic sync (which includes mirroring that specific branch) and also have wildcard mirroring.