### PR TITLE
Support "fips/" image wrappers, including Windows

### DIFF
--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -19,7 +19,7 @@ import (
 	"github.com/microsoft/go-infra/stringutil"
 )
 
-// fipsTagPrefixes is a list of prefixes that indicate the images is an image
+// fipsTagPrefixes is a list of prefixes that indicate a tag specifies an image
 // wrapping another image for the purpose of modifying it to support FIPS.
 var fipsTagPrefixes = []string{
 	"fips-linux/",


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/930
* Result in images repo is over here: https://github.com/microsoft/go-images/pull/238.

This updates the tool to not only support a `fips-linux/` prefix for `opensslcrypto`, but a `fips/` prefix for `systemcrypto`, for 1.21.

The `fips/` prefix needs to be composable, to support `windows/fips/foo`. That's why instead of checking `variant`, it checks `osVersion` now.

Specifying `GOEXPERIMENT` happens on the go-images side.

