### PR TITLE
Fix aka.ms link generation for 1.22+ filenames

### DIFF
--- a/cmd/releasego/akams.go
+++ b/cmd/releasego/akams.go
@@ -159,10 +159,6 @@ func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
 				return nil, fmt.Errorf("unable to determine short link for %#q: not enough '/' segments to be an asset URL", u)
 			}
 			filename := urlParts[len(urlParts)-1]
-			// Make our aka.ms links more like official Go links: remove '.' between first parts.
-			if strings.HasPrefix(filename, "go.") {
-				filename = "go" + strings.TrimPrefix(filename, "go.")
-			}
 			f, err := makeFloatingFilename(filename, buildNumber, p)
 			if err != nil {
 				return nil, fmt.Errorf("unable to process URL %#q: %w", u, err)
@@ -179,16 +175,15 @@ func createLinkPairs(assets buildassets.BuildAssets) ([]akaMSLinkPair, error) {
 }
 
 func makeFloatingFilename(filename, buildNumber, floatVersion string) (string, error) {
-	// The assets.json file has no version number in it, so we need to add one.
+	// The assets.json filename has no version number in it, so we need to add one.
 	if filename == "assets.json" {
 		return "go" + floatVersion + "." + filename, nil
 	}
-	f := strings.ReplaceAll(filename, buildNumber, floatVersion)
-	// Make sure something was actually replaced.
-	if f == filename {
-		return "", fmt.Errorf("unable to find buildNumber %#q in filename %#q", buildNumber, filename)
+	// The build number and all information before it is version-related and needs to be replaced.
+	if _, after, ok := strings.Cut(filename, buildNumber); ok {
+		return "go" + floatVersion + after, nil
 	}
-	return f, nil
+	return "", fmt.Errorf("unable to find buildNumber %#q in filename %#q", buildNumber, filename)
 }
 
 func propsFileContent(pairs []akaMSLinkPair) (string, error) {

--- a/cmd/releasego/akams_test.go
+++ b/cmd/releasego/akams_test.go
@@ -60,6 +60,46 @@ func Test_createLinkPairs(t *testing.T) {
 	}
 }
 
+func Test_makeFloatingFilename(t *testing.T) {
+	type args struct {
+		filename     string
+		buildNumber  string
+		floatVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// Actual 1.21.0 names.
+		{"1.21", args{"go.20230808.6.linux-amd64.tar.gz", "20230808.6", "1.21"}, "go1.21.linux-amd64.tar.gz", false},
+		{"1.21 windows", args{"go.20230808.6.windows-amd64.zip", "20230808.6", "1.21"}, "go1.21.windows-amd64.zip", false},
+		{"1.21 src", args{"go.20230808.6.src.tar.gz", "20230808.6", "1.21"}, "go1.21.src.tar.gz", false},
+		{"1.21 assets", args{"assets.json", "20230808.6", "1.21"}, "go1.21.assets.json", false},
+
+		// The naming change in 1.22 means we need to handle cases like these.
+		{"1.22", args{"go1.22.0-1234.5.linux-amd64.tar.gz", "1234.5", "1.22"}, "go1.22.linux-amd64.tar.gz", false},
+		{"1.22 windows", args{"go1.22.0-1234.5.windows-amd64.zip", "1234.5", "1.22"}, "go1.22.windows-amd64.zip", false},
+
+		// Make sure names that don't fit the requirements are rejected.
+		{"missing build number", args{"go1.22.0-.linux-amd64.tar.gz", "1234.5", "1.22.0"}, "", true},
+		{"dev build", args{"go1.22-abc1234567-dev.linux-amd64.tar.gz", "1234.5", "1.22.0"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeFloatingFilename(tt.args.filename, tt.args.buildNumber, tt.args.floatVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("makeFloatingFilename() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("makeFloatingFilename() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_propsFileContent(t *testing.T) {
 	pairs := []akaMSLinkPair{
 		{


### PR DESCRIPTION
* Fixes future issue noticed in https://github.com/microsoft/go/pull/1021#issuecomment-1675373754

Simplifies the way the aka.ms names are chosen, which lets it be compatible with the 1.22+ names that include more information at the start of the string and still work with older versions. Includes a test for old and new filenames.