### PR TITLE
cmd/git-go-patch: Update README to mention not committing submodule

### DIFF
--- a/cmd/git-go-patch/README.md
+++ b/cmd/git-go-patch/README.md
@@ -66,6 +66,10 @@ To fix this, follow the process to make changes to a patch file. While running `
 1. If there are more conflicts, go back to step 2.
 1. Run `git go-patch extract` to save the fixes to your repository's patch files.
 
+When creating a commit with the fixed patch files, make sure not to include the submodule change.
+`git go-patch apply` creates temporary local commits inside the submodule with unique commit hashes.
+References to these hashes won't work in other clones of the repository, causing submodule initialization errors.
+
 If you have many patch files authored by different developers and it isn't reasonable for one person to resolve all the conflicts, you can fix a few patches and run `git go-patch extract` to save all the fixes completed so far.
 Be careful when staging your WIP patch files in the outer repo, because `extract` doesn't fully understand this situation and will delete the patches that haven't been fixed up yet.
 The next dev to work on resolution can then check out the WIP branch and run `git go-patch apply` to pick up where the last dev left it.

--- a/docs/automation/sync.md
+++ b/docs/automation/sync.md
@@ -1,8 +1,13 @@
 # Automated branch sync
 
-microsoft/go-infra implements branch sync infrastructure for the Microsoft Go repositories. Sync is used to keep Microsoft's repos up to date with upstream repos, and to update dev branches with the latest changes from their upstream branches.
+microsoft/go-infra implements branch sync infrastructure for the Microsoft Go repositories.
+Sync is used to keep Microsoft's repos up to date with upstream repos, and to update dev branches with the latest changes from their upstream branches.
 
 This sometimes involves automatically resolving merge conflicts, so the infra is implemented here rather than relying on existing infra that assumes clean merges.
+
+For help resolving patch conflicts, see [the patch fixup section of the `git-go-patch` README](/cmd/git-go-patch#fix-up-patch-files-after-a-submodule-update).
+
+These files control how automated sync operates:
 
 * [/eng/sync-config.json](/eng/sync-config.json) configures the list of branches to sync.
 * [/sync/model.go](/sync/model.go) documents the configuration file format.


### PR DESCRIPTION
Update git-go-patch README to mention not committing the submodule.

Also update docs/automation/sync.md to point at this readme. The sync doc is pointed to by the submodule update PR body.