### PR TITLE
Add getmingw, a tool to get/use MinGW builds

### DIFF
--- a/.github/workflows/mingw-test.yml
+++ b/.github/workflows/mingw-test.yml
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This job tests that getmingw can set up MinGW and adjust PATH to use it by
+# default, and that it works in both win2019 and win2022.
+
+name: GetMinGW-Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+# This is testing a problem originally found in this action, so some parts are
+# based on what it does:
+# https://github.com/containerd/containerd/blob/a8a22c9e825c76fded5c6f767a8633ccc2dc115b/.github/workflows/ci.yml#L214-L217
+jobs:
+  mingw-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-2019, windows-2022 ]
+        go-version: [ 1.20.x, 1.21.x ]
+        mingw-version:
+          - '-source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: false # see https://github.com/actions/setup-go/issues/368
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run getmingw diag
+        run: go run ./cmd/getmingw diagnose
+
+      # Check: does this hit 0xc0000139?
+      - name: Run with -race, built in MinGW
+        run: |
+          go run -race ./cmd/getmingw diagnose || echo "Failed"
+          exit 0
+
+      - name: Set up MinGW
+        run: go run ./cmd/getmingw run ${{ matrix.mingw-version }} -ci github-actions-env
+
+      - name: Run getmingw diag
+        run: go run ./cmd/getmingw diagnose
+
+      - name: Run with race detector
+        run: go run -race ./cmd/getmingw diagnose

--- a/azdo/azdo.go
+++ b/azdo/azdo.go
@@ -79,6 +79,12 @@ func LogCmdSetVariable(name, value string) {
 	fmt.Printf("##vso[task.setvariable variable=%v]%v\n", name, value)
 }
 
+// LogCmdPrependPath uses an AzDO logging command to prepend a path to future steps' PATH env vars.
+// https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#prependpath-prepend-a-path-to-the--path-environment-variable
+func LogCmdPrependPath(path string) {
+	fmt.Printf("##vso[task.prependpath]%v\n", path)
+}
+
 // LogCmdUploadSummary uses an AzDO logging command to upload a summary file. The file is shown on
 // the build page in an "Extensions" tab. If it is a Markdown file, it is rendered with a subset of
 // Markdown features. The path must be a full path.

--- a/cmd/getmingw/clean.go
+++ b/cmd/getmingw/clean.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "clean",
+		Summary: "Removes all data in the cache directory, even if this tool could not have created it in its current state.",
+		Handle:  clean,
+	})
+}
+
+func clean(p subcmd.ParseFunc) error {
+	if err := p(); err != nil {
+		return err
+	}
+	mingwCacheDir, err := cacheDir()
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(mingwCacheDir); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/getmingw/data.json
+++ b/cmd/getmingw/data.json
@@ -54,6 +54,86 @@
     "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.6-11.0.1-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r3.7z",
     "SHA512": "8be7374bd0bf20accd61143a65f5071f04fd8fd6017b10ad72b31af85cf67ef6e819794da3a5f8661dcf02a1ce33a6d92c397623718119b0f5486a865a8ee59a"
   },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-posix-dwarf-msvcrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "dwarf",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-posix-dwarf-msvcrt-rt_v10-rev2.7z",
+    "SHA512": "e62e506c41a57f9667295ff216c30fdeb4177d5ad288963297e7f56ae8e6ee720d2721e1c204ce271bb0be02a95653d5ef389c64d16bf2867d27523785b6d9c6"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-posix-dwarf-ucrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "dwarf",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-posix-dwarf-ucrt-rt_v10-rev2.7z",
+    "SHA512": "777c3be422a763bf9381797ce9eb981e876cdff4277b734299245615b303c34f98c0e3fb1264fcb33b396b542ea25178111b3cc8be802ade84b0614f62c5ec7a"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "dwarf",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev2.7z",
+    "SHA512": "08eb37e98c57a0edaa04bb7283dc82124862b27a6f7a96aa0251acf6dc77aa9c3b487d7333bc68db75dcfd2c34ca4d3db2301bdf87bf9f8a811ddadfc5e783a9"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-ucrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "dwarf",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-ucrt-rt_v10-rev2.7z",
+    "SHA512": "8b2f905d9ae3a94260a0d4fa14c7c3c004c0a6c0efd511bdd196233db5f7cd286a445c4f90a3bf7abdbae7417a3c4cb7b3db8c839032f61af0b50ada058a0446"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-posix-seh-msvcrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-posix-seh-msvcrt-rt_v10-rev2.7z",
+    "SHA512": "95084089e65987dcfe41a229b2899590dc35ae2a750c7633383b8f15ca21393969d594715e6ad1a62d1e9c674b76703231e008393c1ee30fdcb560ef264a1bfc"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-posix-seh-ucrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-posix-seh-ucrt-rt_v10-rev2.7z",
+    "SHA512": "dd3aab104c1bfb7c96278f0cbb47f7814e55edb7f69f91a7b625d840fa32ae490264c389cf4e077f4142e123bcdbec903c2499ba10e2e8a73b073b172e0aa10c"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-win32-seh-msvcrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-win32-seh-msvcrt-rt_v10-rev2.7z",
+    "SHA512": "9c0362f519f9f13e782a047068370cd77ec09a5b6ca1f74c6cded92725e2f110f45df2670d835d4dec1dbd3149b1d2a571b617f76e125058a705f217071060ab"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-win32-seh-ucrt-rt_v10-rev2.7z": {
+    "Source": "nixman",
+    "Version": "12.2.0-rt_v10-rev2",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-win32-seh-ucrt-rt_v10-rev2.7z",
+    "SHA512": "c312d8b30d1f80cd2cac36d55812d7d8e416cb0d41b340e7c7ffbc51865759fef4b46c21640ce69f06328377431a92574a8b28b5dcf014d11e4ce15ed25d2b23"
+  },
   "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-posix-dwarf-msvcrt-rt_v11-rev0.7z": {
     "Source": "nixman",
     "Version": "13.2.0-rt_v11-rev0",

--- a/cmd/getmingw/data.json
+++ b/cmd/getmingw/data.json
@@ -1,0 +1,217 @@
+{
+  "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-i686-mcf-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z": {
+    "Source": "winlibs",
+    "Version": "13.2.0-11.0.1r3",
+    "Arch": "i686",
+    "Threading": "mcf",
+    "Exception": "dwarf",
+    "Runtime": "ucrt",
+    "LLVM": "no",
+    "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-i686-mcf-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+    "SHA512": "583ef687d580d7a1fd39ddd29e470d67afc79c3127c8f5dd82f9d3df6c2deb393f19417ca371f05f375e66c86afdf0881006bfda43c5304f11eb97c4613ca296"
+  },
+  "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-x86_64-mcf-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z": {
+    "Source": "winlibs",
+    "Version": "13.2.0-11.0.1r3",
+    "Arch": "x86_64",
+    "Threading": "mcf",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "LLVM": "no",
+    "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-x86_64-mcf-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+    "SHA512": "78ce5011d68329e59bdbdfe62c44562b9b18646ffa3ff794c171bd4f0af110765497b6446c8b80322725de35bd22820f37f6e40b0a4b28edbcb87d83372ff29f"
+  },
+  "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z": {
+    "Source": "winlibs",
+    "Version": "13.2.0-17.0.5-11.0.1r3",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "LLVM": "no",
+    "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+    "SHA512": "a1474a05348d7132906f1f1d4bb8b8e1c71d94532d0eea39c420736b7ad6179721d30719dd4f02d8f423b1df05b4dbbc304f0209bd0ed0346264d32a3295603a"
+  },
+  "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.6-11.0.1-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-llvm-17.0.6-mingw-w64msvcrt-11.0.1-r3.7z": {
+    "Source": "winlibs",
+    "Version": "13.2.0-17.0.6-11.0.1r3",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "LLVM": "llvm",
+    "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.6-11.0.1-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-llvm-17.0.6-mingw-w64msvcrt-11.0.1-r3.7z",
+    "SHA512": "82062b74d8a06544a50656ed331d19ca3a2091ed2c426f88a1ceb10384703a9ccd7a8c68f5210975f89f5da0dc4ed6a4064f5001cc359947f5ae015a5c805bfe"
+  },
+  "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.6-11.0.1-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r3.7z": {
+    "Source": "winlibs",
+    "Version": "13.2.0-17.0.6-11.0.1r3",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "LLVM": "no",
+    "URL": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.6-11.0.1-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64msvcrt-11.0.1-r3.7z",
+    "SHA512": "8be7374bd0bf20accd61143a65f5071f04fd8fd6017b10ad72b31af85cf67ef6e819794da3a5f8661dcf02a1ce33a6d92c397623718119b0f5486a865a8ee59a"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-posix-dwarf-msvcrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "dwarf",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-posix-dwarf-msvcrt-rt_v11-rev0.7z",
+    "SHA512": "afb38b13d8e3cd0868f3f533142b9a5fd85dba483de2a72dfb1a2e2d55602f7dbeb724c29efde5a91978bbd76d296e936aea09ac1081b0672002ae2f7ce11383"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-posix-dwarf-ucrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "dwarf",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-posix-dwarf-ucrt-rt_v11-rev0.7z",
+    "SHA512": "77639b8e51e164df8828312d2190b8546c173a21ce531daba6b25ab2fbdf57a9a2ccaaf10090c5a4eea8884d2004a55a7f9f6df2c17fbf2de55e43ef4c8ebcd3"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-win32-dwarf-msvcrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "dwarf",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-win32-dwarf-msvcrt-rt_v11-rev0.7z",
+    "SHA512": "5c1017430c1cd0ef3865a529eb374897071a6eb0a4e9648012aa861136767acde175fbc26d790ca6182fdc43180dda6c86848d3f0a5b909816729f0114507191"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-win32-dwarf-ucrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "dwarf",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/i686-13.2.0-release-win32-dwarf-ucrt-rt_v11-rev0.7z",
+    "SHA512": "380749ee96a638b2f313c0763dc544f1031906dd166d1179e887dc4593d18acca3d056a13a2c161e7e6a8259837d3f2bd20805b03b43de55a0cc8c22caa85480"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-posix-seh-msvcrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-posix-seh-msvcrt-rt_v11-rev0.7z",
+    "SHA512": "8fd9e1c855938eeefc3fefc01b8264a8b93623f94be59116526415334c23f43e581259a72357a6f3329b7625a9abeff1d07e2c99809c8d386eff36018c15d3ea"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-posix-seh-ucrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-posix-seh-ucrt-rt_v11-rev0.7z",
+    "SHA512": "8b4f69767da5f28bb83cddaa7e928cfaf7c64e595ccf63beac7690fe229bf9e5dc40875cc2ac08c303ddf4902c1ac994b643bdb2a009da036e45f476da55ca7b"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-win32-seh-msvcrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "seh",
+    "Runtime": "msvcrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-win32-seh-msvcrt-rt_v11-rev0.7z",
+    "SHA512": "abc9d8df0580a3b5c18e412ff3986d2fa1f0af7738e41e806aa337d0bb9abe901b01fdc83ee090b14c93964f7bcbb6dbe8305a6b1c037a1b55e111d0fd17c8b2"
+  },
+  "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-win32-seh-ucrt-rt_v11-rev0.7z": {
+    "Source": "nixman",
+    "Version": "13.2.0-rt_v11-rev0",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "seh",
+    "Runtime": "ucrt",
+    "URL": "https://github.com/niXman/mingw-builds-binaries/releases/download/13.2.0-rt_v11-rev0/x86_64-13.2.0-release-win32-seh-ucrt-rt_v11-rev0.7z",
+    "SHA512": "8875fb01503374f45695072303990f8b2e8e0649f7be13e2f6b76b50cf5173deb6efbefe962760e620a213e52961c1ff8f458d6511ae5d31e4b6e20d77ad900f"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/dwarf/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "dwarf",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/dwarf/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z/download",
+    "SHA512": "64b39e52c33e37285d5dded58966b7aa5b03d4efa66fa2d9483db5b9d6a57ca3bb98f2901e82ebaece24a3abdc3e873baaf870f21315a4f3f2ab6412f5bb1f93"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/sjlj/i686-8.1.0-release-posix-sjlj-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "i686",
+    "Threading": "posix",
+    "Exception": "sjlj",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-posix/sjlj/i686-8.1.0-release-posix-sjlj-rt_v6-rev0.7z/download",
+    "SHA512": "4d486c96a3e36cace46b3e16b99f2858a2c3c059c15c984b826ccd3641bc09551799b4f8af60a29133d557d4b7ff247ab9d7e3cbe194512218be5e1f5a1772a5"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/dwarf/i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "dwarf",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/dwarf/i686-8.1.0-release-win32-dwarf-rt_v6-rev0.7z/download",
+    "SHA512": "91515799139db25edd9273608677933d5a7ead512741c094ee9f8f2da751c831ecdfa07e2ccfda0053aac26d03c86af719d12d36ca681906e16208d8078891f0"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/i686-8.1.0-release-win32-sjlj-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "i686",
+    "Threading": "win32",
+    "Exception": "sjlj",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/i686-8.1.0-release-win32-sjlj-rt_v6-rev0.7z/download",
+    "SHA512": "caffdd5ca71856b0b49984730f1d572fd823a6742e9be35c7c47111110bed8484d308c28efe3160bf46a5d951b331babd8ae72d73b912c464d1159ae3df5ff48"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "seh",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z/download",
+    "SHA512": "77fe12564272dcee89a89e17880cc0d544133ae9b3427bf61f2c801604a2cdf2b68759f5eb2c65308d3397a9005ea5e7b6251bd932f42c4564f0e743bd12d72a"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/sjlj/x86_64-8.1.0-release-posix-sjlj-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "x86_64",
+    "Threading": "posix",
+    "Exception": "sjlj",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/sjlj/x86_64-8.1.0-release-posix-sjlj-rt_v6-rev0.7z/download",
+    "SHA512": "a12e3e923dff238e2dcbe7d73d94d6c2372907395fe64e1196c3182041fa0f2a5979f45a60549360d00a1d076e41b2159fc5c4d3893cba0290860750d6cb1590"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "seh",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/seh/x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z/download",
+    "SHA512": "40c01ab0d7bc602b83c4c58aa325c33ba1c3ee69202228a90b38f0cb78b06705947139bc9b74640fa38c56d53589d7cac84ee9ba5f7565e9e8a4f2adb0c479eb"
+  },
+  "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/x86_64-8.1.0-release-win32-sjlj-rt_v6-rev0.7z/download": {
+    "Source": "sourceforge",
+    "Version": "8.1.0",
+    "Arch": "x86_64",
+    "Threading": "win32",
+    "Exception": "sjlj",
+    "Runtime": "v6",
+    "URL": "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/x86_64-8.1.0-release-win32-sjlj-rt_v6-rev0.7z/download",
+    "SHA512": "353dc924e65791450b289a29e902f427bd15b5b892588bb088ba6a2bab331d71d17ac0b4d79674ab4e625c92c5168379195271f29218d5ee3a0df1b763b97b12"
+  }
+}

--- a/cmd/getmingw/diagnose.go
+++ b/cmd/getmingw/diagnose.go
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "diagnose",
+		Summary: "Print the current MinGW location and version based on finding gcc and clang in PATH.",
+		Handle:  diagnose,
+	})
+}
+
+func diagnose(p subcmd.ParseFunc) error {
+	if err := p(); err != nil {
+		return err
+	}
+	// Print PATH split by the path separator.
+	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println("PATH entries:")
+	var pathDirs []string
+	for _, p := range strings.Split(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		fmt.Println("  " + p)
+		pathDirs = append(pathDirs, p)
+	}
+	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println("PATHEXT:", os.Getenv("PATHEXT"))
+	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println("Investigating each gcc/clang found in specific PATH entries.")
+	// Look at each PATH entry and see if it contains gcc or clang.
+	for _, dir := range pathDirs {
+		printGccClangVersions(dir)
+	}
+	fmt.Println(strings.Repeat("-", 80))
+	fmt.Println("Finding gcc/clang with ordinary PATH resolution.")
+	printGccClangVersions("")
+	fmt.Println(strings.Repeat("-", 80))
+	// Print Go env.
+	fmt.Println("Running go env:")
+	if err := executil.Run(exec.Command("go", "env")); err != nil {
+		fmt.Printf("Failed: %v\n", err)
+	}
+	return nil
+}
+
+func printGccClangVersions(dir string) {
+	// Find gcc and clang and print their versions.
+	for _, exe := range []string{"gcc", "clang"} {
+		if dir != "" {
+			exe = filepath.Join(dir, exe)
+		}
+		path, err := exec.LookPath(exe)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			fmt.Printf("LookPath failed: %v\n", err)
+			continue
+		}
+		if err := executil.Run(exec.Command(path, "--version")); err != nil {
+			fmt.Printf("Failed: %v\n", err)
+		}
+	}
+}

--- a/cmd/getmingw/list.go
+++ b/cmd/getmingw/list.go
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"text/template"
+
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "list",
+		Summary: "List known MinGW sources and versions.",
+		Handle:  list,
+	})
+}
+
+func list(p subcmd.ParseFunc) error {
+	initFilterFlags()
+	format := flag.String("format", "", "a custom Go template used to produce each line of output")
+	unique := flag.Bool("unique", false, "only print unique lines")
+	if err := p(); err != nil {
+		return err
+	}
+
+	var tmpl *template.Template
+	if *format != "" {
+		log.Printf("Using custom format %#q", *format)
+		var err error
+		tmpl, err = template.New("").Parse(*format)
+		if err != nil {
+			return err
+		}
+	}
+
+	existingBuilds, err := unmarshal()
+	if err != nil {
+		return err
+	}
+	builds := filter(existingBuilds)
+
+	var printed map[string]struct{}
+	if *unique {
+		printed = make(map[string]struct{})
+	}
+	for _, b := range builds {
+		var line strings.Builder
+		if tmpl != nil {
+			if err := tmpl.Execute(&line, b); err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(&line, "%#v", b)
+		}
+		if *unique {
+			if _, ok := printed[line.String()]; ok {
+				continue
+			}
+			printed[line.String()] = struct{}{}
+		}
+		fmt.Println(line.String())
+	}
+	return nil
+}

--- a/cmd/getmingw/main.go
+++ b/cmd/getmingw/main.go
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"crypto/sha512"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+const description = `
+Gets specific builds of the MinGW toolchain.
+
+Intended for dev scenarios and CI tests. Not a complete list of builds or versions.
+`
+
+//go:embed data.json
+var data []byte
+
+const (
+	Nixman      string = "nixman"
+	Winlibs     string = "winlibs"
+	Sourceforge string = "sourceforge"
+)
+
+const niXmanPrefix = "https://github.com/niXman/mingw-builds-binaries/releases/tag/"
+const winlibsPrefix = "https://github.com/brechtsanders/winlibs_mingw/releases/download/"
+
+var subcommands []subcmd.Option
+
+func main() {
+	if err := subcmd.Run("getmingw", description, subcommands); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Flags responsible for filtering results in multiple commands.
+var (
+	sources    subcmd.MultiStringFlag
+	versions   subcmd.MultiStringFlag
+	arches     subcmd.MultiStringFlag
+	threadings subcmd.MultiStringFlag
+	exceptions subcmd.MultiStringFlag
+	runtimes   subcmd.MultiStringFlag
+	llvms      subcmd.MultiStringFlag
+)
+
+func initFilterFlags() {
+	flag.Var(&sources, "source", "source: see 'getmingw list'")
+	flag.Var(&versions, "version", "version: see 'getmingw list'")
+	flag.Var(&arches, "arch", "architecture: x86_64, i686")
+	flag.Var(&threadings, "threading", "threading: posix, win32, mcf")
+	flag.Var(&exceptions, "exception", "exception: seh, dwarf, sjlj")
+	flag.Var(&runtimes, "runtime", "runtime: ucrt, msvcrt")
+	flag.Var(&llvms, "llvm", "llvm build present: llvm, no")
+}
+
+func unmarshal() (r map[string]build, err error) {
+	err = json.Unmarshal(data, &r)
+	if err != nil {
+		err = fmt.Errorf("failed to read embedded JSON: %v", err)
+	}
+	return r, err
+}
+
+func marshal(data map[string]build) ([]byte, error) {
+	return json.MarshalIndent(data, "", "  ")
+}
+
+func filter(builds map[string]build) []*build {
+	var result []*build
+	match := func(msf *subcmd.MultiStringFlag, v string) bool {
+		if len(msf.Values) == 0 {
+			return true
+		}
+		for _, s := range msf.Values {
+			if s == v {
+				return true
+			}
+		}
+		return false
+	}
+	for _, b := range builds {
+		b := b
+		if match(&sources, b.Source) &&
+			match(&versions, b.Version) &&
+			match(&arches, b.Arch) &&
+			match(&threadings, b.Threading) &&
+			match(&exceptions, b.Exception) &&
+			match(&runtimes, b.Runtime) &&
+			match(&llvms, b.LLVM) {
+
+			result = append(result, &b)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].URL < result[j].URL
+	})
+	return result
+}
+
+func cacheDir() (string, error) {
+	userDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userDir, ".msft-go-infra", "getmingw"), nil
+}
+
+var errBuildNotFound = errors.New("build not found")
+
+type build struct {
+	Source    string
+	Version   string
+	Arch      string
+	Threading string
+	Exception string
+	Runtime   string
+
+	// LLVM is "llvm" or "no" for WinLibs. "" for other sources.
+	LLVM string `json:",omitempty"`
+
+	URL    string
+	SHA512 string
+}
+
+func (b *build) CreateFreshChecksum() error {
+	// Download the URL and compute the SHA512:
+	var client http.Client
+	resp, err := client.Get(b.URL)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return errBuildNotFound
+	}
+	defer resp.Body.Close()
+	hash := sha512.New()
+	if _, err := io.Copy(hash, resp.Body); err != nil {
+		return err
+	}
+	// Write the SHA512 to the struct.
+	b.SHA512 = fmt.Sprintf("%x", hash.Sum(nil))
+	return nil
+}
+
+func (b *build) GetOrCreateCacheBinDir() (string, error) {
+	mingwCacheDir, err := cacheDir()
+	if err != nil {
+		return "", err
+	}
+	buildDir := filepath.Join(mingwCacheDir, b.CacheKey())
+	if err := os.MkdirAll(buildDir, 0o777); err != nil {
+		return "", err
+	}
+	downloadFile := filepath.Join(buildDir, "mingw.7z")
+	downloadedIndicator := filepath.Join(buildDir, ".downloaded")
+	extractDir := filepath.Join(buildDir, "ext")
+	extractedIndicator := filepath.Join(buildDir, ".extracted")
+
+	var extractedBinDir string
+	switch b.Arch {
+	case "i686":
+		extractedBinDir = filepath.Join(extractDir, "mingw32", "bin")
+	case "x86_64":
+		extractedBinDir = filepath.Join(extractDir, "mingw64", "bin")
+	default:
+		return "", fmt.Errorf("unknown arch %#q", b.Arch)
+	}
+
+	if cachedHash, err := os.ReadFile(downloadedIndicator); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("unexpected error while reading %#q: %v", downloadedIndicator, err)
+		}
+		// Best effort to delete old downloaded file, in case it failed in a weird way.
+		_ = os.Remove(downloadFile)
+
+		log.Printf("Downloading %v...", b.URL)
+		// Download the URL and compute the SHA512:
+		var client http.Client
+		resp, err := client.Get(b.URL)
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("unexpected status code %v", resp.StatusCode)
+		}
+		defer resp.Body.Close()
+		// Open the file for writing:
+		f, err := os.OpenFile(downloadFile, os.O_CREATE|os.O_WRONLY, 0o666)
+		if err != nil {
+			return "", err
+		}
+		hash := sha512.New()
+		_, err = io.Copy(io.MultiWriter(f, hash), resp.Body)
+		if errClose := f.Close(); err == nil {
+			err = errClose
+		}
+		if err != nil {
+			return "", err
+		}
+		// Verify the SHA512:
+		if sum := fmt.Sprintf("%x", hash.Sum(nil)); sum != b.SHA512 {
+			return "", fmt.Errorf("SHA512 mismatch.\n  Expected: %v\n  Downloaded: %v", b.SHA512, sum)
+		}
+		// Write the download complete indicator:
+		if err := os.WriteFile(downloadedIndicator, []byte(b.SHA512), 0o666); err != nil {
+			return "", err
+		}
+	} else {
+		// Found an indicator. But was there a collision in the key?
+		if string(cachedHash) != b.SHA512 {
+			return "", fmt.Errorf("SHA512 mismatch.\n  Expected: %v\n  Cached: %v", b.SHA512, string(cachedHash))
+		}
+	}
+	if cachedHash, err := os.ReadFile(extractedIndicator); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("unexpected error while reading %#q: %v", extractedIndicator, err)
+		}
+		// Best effort to delete the old extraction dir, in case it failed in a weird way.
+		_ = os.RemoveAll(extractDir)
+
+		log.Printf("Extracting %#q...", downloadFile)
+		// Extract the 7z file:
+		cmd := exec.Command("7z", "x", "-o"+extractDir, downloadFile)
+		// If the user cancels, or one 7z processes of many fails, make sure
+		// all others are canceled. Otherwise, they may keep running in the
+		// background.
+		if out, err := executil.CombinedOutput(cmd); err != nil {
+			return "", fmt.Errorf("failed to extract: %v, output: %v", err, out)
+		}
+		// Write the extraction complete indicator:
+		if err := os.WriteFile(extractedIndicator, []byte(b.SHA512), 0o666); err != nil {
+			return "", err
+		}
+		log.Printf("Extracted to %v", extractDir)
+	} else {
+		// Found an indicator. But was there a collision in the key?
+		if string(cachedHash) != b.SHA512 {
+			return "", fmt.Errorf("SHA512 mismatch.\n  Expected: %v\n  Cached: %v", b.SHA512, string(cachedHash))
+		}
+	}
+	return extractedBinDir, nil
+}
+
+func (b *build) CacheKey() string {
+	url := b.URL
+	const maxUrlChars = 30
+	if len(url) > maxUrlChars {
+		url = url[len(url)-maxUrlChars:]
+	}
+	var u strings.Builder
+	for _, c := range url {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			u.WriteRune(c)
+		} else {
+			u.WriteRune('_')
+		}
+	}
+	u.WriteString("-")
+	u.WriteString(b.SHA512[:32])
+	return u.String()
+}

--- a/cmd/getmingw/main.go
+++ b/cmd/getmingw/main.go
@@ -38,7 +38,7 @@ const (
 	Sourceforge string = "sourceforge"
 )
 
-const niXmanPrefix = "https://github.com/niXman/mingw-builds-binaries/releases/tag/"
+const niXmanPrefix = "https://github.com/niXman/mingw-builds-binaries/releases/"
 const winlibsPrefix = "https://github.com/brechtsanders/winlibs_mingw/releases/download/"
 
 var subcommands []subcmd.Option

--- a/cmd/getmingw/run.go
+++ b/cmd/getmingw/run.go
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:           "run",
+		Summary:        "Download/extract/run with the specified MinGW in PATH.",
+		TakeArgsReason: "The command to run. If not specified, runs 'gcc --version'.",
+		Handle:         run,
+	})
+}
+
+func run(p subcmd.ParseFunc) error {
+	initFilterFlags()
+	multi := flag.Bool("multi", false, "Run the command once per matching MinGW version rather than only match one version.")
+	ciType := flag.String("ci", "", "In addition to the command, prepend to PATH in a CI-specific way. 'github-actions-env', 'azdo', or none.")
+	if err := p(); err != nil {
+		return err
+	}
+
+	if !(len(sources.Values) != 0) {
+		return fmt.Errorf("must specify at least one source")
+	}
+	if !(len(versions.Values) != 0) {
+		return fmt.Errorf("must specify at least one version")
+	}
+	if !*multi {
+		if len(sources.Values) > 1 ||
+			len(versions.Values) > 1 ||
+			len(arches.Values) > 1 ||
+			len(threadings.Values) > 1 ||
+			len(exceptions.Values) > 1 ||
+			len(runtimes.Values) > 1 ||
+			len(llvms.Values) > 1 {
+			return fmt.Errorf("multiple specified, but -multi not set")
+		}
+	}
+
+	// Get the list of builds to use to run the command.
+	builds, err := unmarshal()
+	if err != nil {
+		return err
+	}
+	matches := filter(builds)
+	if len(matches) == 0 {
+		return fmt.Errorf("no matching MinGW found")
+	}
+	if *multi {
+		log.Printf("Using %v matches:\n", len(matches))
+		for _, b := range matches {
+			log.Printf("  %#v\n", b)
+		}
+	} else {
+		if len(matches) > 1 {
+			log.Printf("Found %v matches, expected just one. Add more parameters to constrain the search, or add '-multi'. Matches:", len(matches))
+			for _, b := range matches {
+				log.Printf("  %#v\n", b)
+			}
+			return fmt.Errorf("multiple matches found")
+		}
+		matches = matches[:1]
+	}
+
+	// Download (if necessary) up front.
+	var wg sync.WaitGroup
+	for _, b := range matches {
+		b := b
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := b.GetOrCreateCacheBinDir(); err != nil {
+				log.Panicf("failed to get %#v: %v", b.URL, err)
+			}
+		}()
+	}
+	wg.Wait()
+	originalPath := os.Getenv("PATH")
+	for _, b := range matches {
+		binDir, err := b.GetOrCreateCacheBinDir()
+		if err != nil {
+			return err
+		}
+		// Set PATH so exec.Command's LookPath finds the right gcc if it's being called directly.
+		newPath := strings.Join([]string{binDir, originalPath}, string(os.PathListSeparator))
+		if err := os.Setenv("PATH", newPath); err != nil {
+			return err
+		}
+		args := flag.CommandLine.Args()
+		if len(args) == 0 {
+			args = []string{"gcc", "--version"}
+		}
+		log.Printf("Running command with:\n  %v\n  %v", b.URL, binDir)
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Env = append(os.Environ(), "PATH="+newPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Printf("Done, with error: %v", err)
+		}
+	}
+
+	// Set PATH in specific types of CI.
+	if *ciType != "" {
+		binDir, err := matches[0].GetOrCreateCacheBinDir()
+		if err != nil {
+			return err
+		}
+		if *ciType == "github-actions-env" {
+			// Append to the file specified by $GITHUB_PATH:
+			// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+			ghp := os.Getenv("GITHUB_PATH")
+			if ghp == "" {
+				return fmt.Errorf("GITHUB_PATH is not set")
+			}
+			f, err := os.OpenFile(ghp, os.O_APPEND|os.O_WRONLY, 0o666)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					f, err = os.Create(ghp)
+					if err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
+			}
+			_, err = fmt.Fprintf(f, "%v\n", binDir)
+			if errClose := f.Close(); err == nil {
+				err = errClose
+			}
+			if err != nil {
+				return err
+			}
+		} else if *ciType == "azdo" {
+			azdo.LogCmdPrependPath(binDir)
+		} else {
+			return fmt.Errorf("unknown CI type %#q", *ciType)
+		}
+	}
+	return nil
+}

--- a/cmd/getmingw/updatejson.go
+++ b/cmd/getmingw/updatejson.go
@@ -47,7 +47,7 @@ func updateJson(p subcmd.ParseFunc) error {
 	for _, seed := range flag.Args() {
 		switch *source {
 		case Nixman:
-			version, ok := stringutil.CutPrefix(seed, niXmanPrefix)
+			version, ok := stringutil.CutPrefix(seed, niXmanPrefix+"tag/")
 			if !ok {
 				return fmt.Errorf("seed %#q doesn't have a tag URL prefix", seed)
 			}
@@ -73,7 +73,7 @@ func updateJson(p subcmd.ParseFunc) error {
 							}
 							b.Source = Nixman
 							b.Version = version
-							b.URL = niXmanPrefix + version +
+							b.URL = niXmanPrefix + "download/" + version +
 								"/" + b.Arch + "-" + nums + "-release-" + b.Threading + "-" + b.Exception + "-" + b.Runtime +
 								"-" + rev + ".7z"
 							newBuilds = append(newBuilds, &b)

--- a/cmd/getmingw/updatejson.go
+++ b/cmd/getmingw/updatejson.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/microsoft/go-infra/stringutil"
 	"github.com/microsoft/go-infra/subcmd"
 )
 
@@ -46,7 +47,7 @@ func updateJson(p subcmd.ParseFunc) error {
 	for _, seed := range flag.Args() {
 		switch *source {
 		case Nixman:
-			version, ok := strings.CutPrefix(seed, niXmanPrefix)
+			version, ok := stringutil.CutPrefix(seed, niXmanPrefix)
 			if !ok {
 				return fmt.Errorf("seed %#q doesn't have a tag URL prefix", seed)
 			}
@@ -81,7 +82,7 @@ func updateJson(p subcmd.ParseFunc) error {
 				}
 			}
 		case Winlibs:
-			r, ok := strings.CutPrefix(seed, winlibsPrefix)
+			r, ok := stringutil.CutPrefix(seed, winlibsPrefix)
 			if !ok {
 				return fmt.Errorf("seed %#q doesn't have a tag URL prefix", seed)
 			}

--- a/cmd/getmingw/updatejson.go
+++ b/cmd/getmingw/updatejson.go
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "update-json",
+		Summary: "Given a MinGW source/version, update the embedded JSON data and write out the new version.",
+		TakeArgsReason: "\nA list of seed info used to inform the heuristic guesses about how to find builds. Seeds for each source are:" +
+			"\n - " + Nixman + ": a release page, like " + niXmanPrefix + "12.2.0-rt_v10-rev2" +
+			"\n - " + Winlibs + ": a 7z artifact URL, like " + winlibsPrefix + "13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-llvm-17.0.5-mingw-w64ucrt-11.0.1-r3.7z" +
+			"\n - " + Sourceforge + ": a version number, like 8.1.0",
+		Handle: updateJson,
+	})
+}
+
+func updateJson(p subcmd.ParseFunc) error {
+	out := flag.String("out", "", "Write the updated JSON to this file instead of stdout.")
+	source := flag.String(
+		"source", "",
+		"The MinGW source to update. This defines the meaning of the list of seeds provided as args.")
+	if err := p(); err != nil {
+		return err
+	}
+	if len(flag.Args()) == 0 {
+		return fmt.Errorf("must specify at least one seed")
+	}
+	existingBuilds, err := unmarshal()
+	if err != nil {
+		return err
+	}
+	var newBuilds []*build
+	for _, seed := range flag.Args() {
+		switch *source {
+		case Nixman:
+			version, ok := strings.CutPrefix(seed, niXmanPrefix)
+			if !ok {
+				return fmt.Errorf("seed %#q doesn't have a tag URL prefix", seed)
+			}
+			nums, rev, ok := strings.Cut(version, "-")
+			if !ok {
+				return fmt.Errorf("version %#q doesn't have a revision part after '-'", version)
+			}
+			for _, arch := range []string{"i686", "x86_64"} {
+				for _, ex := range []string{"seh", "dwarf"} {
+					for _, th := range []string{"posix", "win32", "mcf"} {
+						for _, rt := range []string{"msvcrt", "ucrt"} {
+							b := build{
+								Arch:      arch,
+								Exception: ex,
+								Threading: th,
+								Runtime:   rt,
+							}
+							if b.Arch == "i686" && b.Exception != "dwarf" {
+								continue
+							}
+							if b.Arch == "x86_64" && b.Exception != "seh" {
+								continue
+							}
+							b.Source = Nixman
+							b.Version = version
+							b.URL = niXmanPrefix + version +
+								"/" + b.Arch + "-" + nums + "-release-" + b.Threading + "-" + b.Exception + "-" + b.Runtime +
+								"-" + rev + ".7z"
+							newBuilds = append(newBuilds, &b)
+						}
+					}
+				}
+			}
+		case Winlibs:
+			r, ok := strings.CutPrefix(seed, winlibsPrefix)
+			if !ok {
+				return fmt.Errorf("seed %#q doesn't have a tag URL prefix", seed)
+			}
+			tag, file, ok := strings.Cut(r, "/")
+			if !ok {
+				return fmt.Errorf("seed %#q doesn't have a final part with a '/'", seed)
+			}
+			b := build{
+				Source:  Winlibs,
+				URL:     seed,
+				Version: tag,
+			}
+			if strings.Contains(file, "llvm") {
+				b.LLVM = "llvm"
+			} else {
+				b.LLVM = "no"
+			}
+			for _, x := range []string{"i686", "x86_64"} {
+				if strings.Contains(file, x) {
+					b.Arch = x
+					break
+				}
+			}
+			if b.Arch == "" {
+				return fmt.Errorf("seed %#q doesn't have an arch part", seed)
+			}
+			for _, x := range []string{"posix", "win32", "mcf"} {
+				if strings.Contains(file, x) {
+					b.Threading = x
+					break
+				}
+			}
+			if b.Threading == "" {
+				return fmt.Errorf("seed %#q doesn't have a threading part", seed)
+			}
+			for _, x := range []string{"seh", "dwarf", "sjlj"} {
+				if strings.Contains(file, x) {
+					b.Exception = x
+					break
+				}
+			}
+			if b.Exception == "" {
+				return fmt.Errorf("seed %#q doesn't have an exception part", seed)
+			}
+			for _, x := range []string{"msvcrt", "ucrt"} {
+				if strings.Contains(file, x) {
+					b.Runtime = x
+					break
+				}
+			}
+			if b.Runtime == "" {
+				return fmt.Errorf("seed %#q doesn't have a runtime part", seed)
+			}
+			// Remove some build parts from the version to avoid search overlap.
+			b.Version = strings.ReplaceAll(b.Version, b.Threading, "")
+			b.Version = strings.ReplaceAll(b.Version, b.Runtime, "")
+			b.Version = strings.ReplaceAll(b.Version, "--", "")
+			newBuilds = append(newBuilds, &b)
+		case Sourceforge:
+			for _, arch := range []string{"i686", "x86_64"} {
+				for _, ex := range []string{"seh", "sjlj", "dwarf"} {
+					for _, th := range []string{"posix", "win32"} {
+						b := build{
+							Source:    Sourceforge,
+							Version:   seed,
+							Arch:      arch,
+							Threading: th,
+							Exception: ex,
+							Runtime:   "v5",
+						}
+						if seed == "8.1.0" {
+							b.Runtime = "v6"
+						}
+						targeting := "Win64"
+						if arch == "i686" {
+							targeting = "Win32"
+						}
+						b.URL = "https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20" +
+							targeting + "/Personal%20Builds/mingw-builds/" +
+							seed + "/threads-" + th + "/" + ex + "/" + arch + "-" + seed + "-release-" + th + "-" + ex + "-rt_" + b.Runtime + "-rev0.7z/download"
+						newBuilds = append(newBuilds, &b)
+					}
+				}
+			}
+		default:
+			return fmt.Errorf("unknown source %#q", *source)
+		}
+	}
+	var wg sync.WaitGroup
+	for _, b := range newBuilds {
+		b := b
+		log.Printf("Creating checksum for %v", b.URL)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := b.CreateFreshChecksum(); err != nil {
+				if errors.Is(err, errBuildNotFound) {
+					log.Printf("skipping 404 URL %#v", b)
+				} else {
+					log.Panicf("failed to create checksum for %#v: %v", b, err)
+				}
+			} else {
+				log.Printf("Downloaded %v, generated checksum %v...", b.URL, b.SHA512[:16])
+			}
+		}()
+	}
+	wg.Wait()
+	for _, b := range newBuilds {
+		if b.SHA512 == "" {
+			// Skipped, 404.
+			continue
+		}
+		existingBuilds[b.URL] = *b
+	}
+	result, err := marshal(existingBuilds)
+	if err != nil {
+		return err
+	}
+	if *out != "" {
+		if err := os.WriteFile(*out, result, 0o666); err != nil {
+			return err
+		}
+		return nil
+	} else {
+		fmt.Println(string(result))
+	}
+	return nil
+}

--- a/subcmd/subcmd.go
+++ b/subcmd/subcmd.go
@@ -92,3 +92,17 @@ func Run(cmdBaseDoc, description string, options []Option) error {
 	printMainUsage()
 	return fmt.Errorf("error: not a valid option: %v", os.Args[1])
 }
+
+// MultiStringFlag is a flag that can be specified multiple times. Use with flag.Var.
+type MultiStringFlag struct {
+	Values []string
+}
+
+func (f *MultiStringFlag) String() string {
+	return ""
+}
+
+func (f *MultiStringFlag) Set(value string) error {
+	f.Values = append(f.Values, value)
+	return nil
+}


### PR DESCRIPTION
The main goals of this tool are:

* Get MinGW builds in a repeatable way.
* Run the same command against multiple builds of MinGW to check for problems.
* Enable quick setup on a new machine and allow broad reuse. I think Go CLIs are good at this.

There are a few real-world situations that came up recently where this could be useful:

* https://github.com/microsoft/go/issues/1085
  * Setting up our own Windows CI to run Go tests against multiple MinGW builds. We can establish a compatibility matrix *and* a known way to securely acquire and set up the builds we test against in both AzDO and GitHub Actions.
  * Having a tool to run in CI to inspect PATH, gcc/clang version, etc. without manual work each time may help figure out why (e.g.) Chocolatey changes aren't having any effect in a particular CI system.
* Diagnosing problems reported upstream with specific MinGW build configurations and confirming they're fixed across multiple versions.
* Helping our internal partners.
  * https://github.com/microsoft/go/issues/1081 is specific to an old build of MinGW on win2019, and this tool lets me test the scenario against many other MinGW versions without manually manipulating PATH repeatedly.
To try it out remotely (e.g. on a fresh VM that needs MinGWs):

```powershell
$env:GOPROXY = 'direct'
go install github.com/microsoft/go-infra/cmd/getmingw@dev/dagood/mingw-dl

getmingw run -source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -runtime msvcrt -- go test runtime/race -race
```