### PR TITLE
Use checklist for new major version reminders; test it

### DIFF
--- a/buildreport/buildreport_test.go
+++ b/buildreport/buildreport_test.go
@@ -138,3 +138,32 @@ func Test_commentBody_body_UpdateExisting(t *testing.T) {
 	}
 	goldentest.Check(t, "go test ./buildreport -run "+t.Name(), filepath.Join("testdata", "report", "update-existing.golden.md"), got)
 }
+
+func Test_State_notificationPreamble(t *testing.T) {
+	tests := []struct {
+		name         string
+		pipelineName string
+		version      string
+		status       string
+	}{
+		{"not-started", releaseBuildPipelineName, "1.21.1-1", SymbolNotStarted},
+		{"go-new-branch", releaseBuildPipelineName, "1.21.0-1", SymbolSucceeded},
+		{"go-servicing", releaseBuildPipelineName, "1.21.3-1", SymbolSucceeded},
+		{"images", releaseImagesPipelineName, "1.21.1-1", SymbolSucceeded},
+		{"failed", releaseBuildPipelineName, "1.21.1-1", SymbolFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &State{
+				Name:    tt.pipelineName,
+				Version: tt.version,
+				Status:  tt.status,
+			}
+			goldentest.Check(
+				t,
+				"go test ./buildreport -run "+t.Name(),
+				filepath.Join("testdata", "report", "notify."+tt.name+".golden.md"),
+				s.notificationPreamble())
+		})
+	}
+}

--- a/buildreport/testdata/report/notify.failed.golden.md
+++ b/buildreport/testdata/report/notify.failed.golden.md
@@ -1,0 +1,1 @@
+Build failed!

--- a/buildreport/testdata/report/notify.go-new-branch.golden.md
+++ b/buildreport/testdata/report/notify.go-new-branch.golden.md
@@ -1,0 +1,6 @@
+Completed releasing one version! If every version's release-build has finished, approve the release-go-images build to continue.
+
+This appears to be a new major version! If so, here are a few things that will need an update when the release is done:
+* [ ] The [microsoft/go download links](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)
+* [ ] The [internal site's download links](https://eng.ms/docs/more/languages-at-microsoft/go/articles/overview#go-releases)
+* [ ] The [recommended Docker tags](https://github.com/microsoft/go-images#recommended-tags)

--- a/buildreport/testdata/report/notify.go-servicing.golden.md
+++ b/buildreport/testdata/report/notify.go-servicing.golden.md
@@ -1,0 +1,1 @@
+Completed releasing one version! If every version's release-build has finished, approve the release-go-images build to continue.

--- a/buildreport/testdata/report/notify.images.golden.md
+++ b/buildreport/testdata/report/notify.images.golden.md
@@ -1,0 +1,7 @@
+Completed building all images! Before you [announce](https://github.com/microsoft/go-infra/blob/main/docs/release-process/instructions.md#making-the-internal-announcement), confirm the MAR/MCR images are updated using commands like these:
+
+```
+image=mcr.microsoft.com/oss/go/microsoft/golang:1-bullseye
+docker pull $image
+docker run -it --rm $image go version
+```


### PR DESCRIPTION
Improve upon https://github.com/microsoft/go-infra/pull/91: use a checklist, include the internal site, and add golden tests to preview the output.