### PR TITLE
Add pipeline-css-rules.md for build readability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ See the root [README.md](../README.md) for the project overview, and the subdire
 * [fork/](fork/) - A description of how the Microsoft Go toolset fork is set up and why we made certain decisions.
 * [release-process/](release-process/) - A description of how to release a Microsoft Go build, and details about the infra behind it.
 * [pipeline-yml-style.md](pipeline-yml-style.md) - Style principles and quirk notes for our YAML pipelines here and in microsoft/go.
+* [pipeline-css-rules.md](pipeline-css-rules.md) - custom CSS rules for Azure Pipelines to make our builds easier to read.
 * [branches.md](branches.md) - 

--- a/docs/pipeline-css-rules.md
+++ b/docs/pipeline-css-rules.md
@@ -1,0 +1,49 @@
+# Azure Pipeline CSS rules for readability
+
+Some of the Azure Pipelines in use for Microsoft Go have a very large number of steps, jobs, and stages.
+The Azure Pipelines UI uses a large amount of whitespace and a fixed-size left column, which can make it difficult to understand.
+
+Here are some CSS rules that can be applied by a browser extension like [Stylus](https://en.wikipedia.org/wiki/Stylus_(browser_extension)) to make the build results easier to read without hovering over and clicking various items to see full names.
+
+> [!NOTE]
+> These rules may break the Azure Pipelines UI at any time.
+> Try disabling these first if something seems wrong.
+
+```css
+/*
+Make the job log sidebar wide enough to avoid cutting off detailed job names,
+build step names, and stage names.
+*/
+.bolt-master-panel {
+    width: 440px;
+}
+
+/*
+Trim a significant amount of padding around each build step in job log sidebar.
+This shows many more steps at once by saving vertical space.
+*/
+.run-logs-tree .run-tree-cell {
+    height: 8px;
+}
+
+.bolt-tree-cell .bolt-table-cell-content {
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
+/*
+Trim whitespace from Stage cells (labels).
+*/
+.bolt-table-header-cell-content {
+    margin: 1px 0;
+    padding: .1rem .1rem;
+}
+
+/*
+Trim whitespace from the build/run name at the top-left of the job log sidebar.
+*/
+.bolt-master-panel-header {
+    padding-top: 2px;
+    padding-bottom: 8px;
+}
+```


### PR DESCRIPTION
I've had these rules hanging around in my browser for a very long time, but with the 1ES pipeline template work seeming to make the readability situation even worse, decided I should finally boil down my custom CSS to the rules that still apply to the current AzDO UI and put them here.

Here's a public CI run now:
(https://dev.azure.com/dnceng-public/public/_build/results?buildId=587984&view=logs&s=02cf21c3-501e-5594-db91-bf94d756da9e)

![image](https://github.com/microsoft/go-infra/assets/12819531/bcf16f2b-e8a8-4892-af9c-228f8f2374d5)

Here it is with these rules:

![image](https://github.com/microsoft/go-infra/assets/12819531/afa8c9f5-e5d3-4bf2-9263-322570829e79)

(1080p, left side browser tabs, Edge. I think it's written as a responsive UI so YMMV.)