### PR TITLE
Add innerloop pipeline to the release process

### DIFF
--- a/docs/release-process/instructions.md
+++ b/docs/release-process/instructions.md
@@ -38,11 +38,13 @@ For example, a security patch release for 1.18 and 1.19 may look like this:
     * It will take some time to reserve a build agent. Expect up to ten minutes.
 
 1. Wait for notifications on the release tracking issue.
-    * When the "microsoft-go-infra-release-build" build is complete and successful for every version in the release, continue to the next step.
+    * Continue once both of these builds complete successfully for every version in the release:
+        * **microsoft-go-infra-release-build**
+        * **microsoft-go-infra-release-innerloop**
     * If an error occurs, refer to the rest of this doc for diagnosis and retry guidance.
 
 1. Click on the "microsoft-go-infra-release-go-images" build and approve it to let it continue.
-    * It is ok to do this a little early if you expect the builds to be done soon. The approval gate only exists to prevent excessive polling.
+    * Don't do this early. This pipeline updates active tags in MAR, so it's important to make sure the innerloop run is successful on the exact commit to be released.
 
 1. Wait for a notification on the release tracking issue.
     * Continue if the images build is successful.

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -29,3 +29,5 @@ Internal release pipelines (see [release process docs](/docs/release-process)):
   * 🚀 internal [`microsoft-go-infra-release-build`](https://dev.azure.com/dnceng/internal/_build?definitionId=1142)
 * (3) [`release-go-images-pipeline.yml`](release-go-images-pipeline.yml)
   * 🚀 internal [`microsoft-go-infra-release-go-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1151)
+* (4) [`release-innerloop-pipeline.yml`](release-innerloop-pipeline.yml)
+  * 🚀 internal [`microsoft-go-infra-release-innerloop`](https://dev.azure.com/dnceng/internal/_build?definitionId=1348)

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -64,6 +64,7 @@ variables:
   - group: DotNet-VSTS-Infra-Access
   # Import config group. This may direct the build to use secrets from the other groups.
   - group: ${{ parameters.goReleaseConfigVariableGroup }}
+  - template: variables/release-pipelines.yml
 
 resources:
   repositories:
@@ -187,6 +188,32 @@ extends:
                         condition: succeeded()
                         buildPipeline: microsoft-go
                         buildID: $(poll3MicrosoftGoBuildID)
+                        buildStatus: '?'
+                        start: true
+                        reason: queued build
+                    # Above, we launched the official build. Now launch innerloop tests. We actually
+                    # don't poll this build here: it's a release pipeline, so it reports its own
+                    # status to the release issue. This also means it runs in parallel.
+                    - script: |
+                        releasego build-pipeline \
+                          -id '$(GoReleaseInnerloopPipelineID)' \
+                          -org 'https://dev.azure.com/dnceng/' \
+                          -proj 'internal' \
+                          -branch '$(Build.SourceBranch)' \
+                          -azdopat '$(System.AccessToken)' \
+                          -set-azdo-variable MicrosoftGoReleaseInnerloopBuildID \
+                          p releaseVersion '${{ parameters.releaseVersion }}' \
+                          p releaseIssue '${{ parameters.releaseIssue }}' \
+                          p microsoftGoCommitHash '$(poll2MicrosoftGoCommitHash)' \
+                          p goReleaseConfigVariableGroup '${{ parameters.goReleaseConfigVariableGroup }}'
+                      displayName: 🚀 Start microsoft-go-infra-release-innerloop
+                    - template: ../steps/report.yml
+                      parameters:
+                        releaseIssue: ${{ parameters.releaseIssue }}
+                        version: ${{ parameters.releaseVersion }}
+                        condition: succeeded()
+                        buildPipeline: microsoft-go-infra-release-innerloop
+                        buildID: $(MicrosoftGoReleaseInnerloopBuildID)
                         buildStatus: '?'
                         start: true
                         reason: queued build

--- a/eng/pipelines/release-innerloop-pipeline.yml
+++ b/eng/pipelines/release-innerloop-pipeline.yml
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
+parameters:
+  - name: releaseVersion
+    displayName: Version to release, including Microsoft revision suffix (-1) and boring/FIPS suffix (-fips) if they apply.
+    type: string
+
+  - name: releaseIssue
+    displayName: microsoft/go issue number to comment on once complete, or nil.
+    type: string
+    default: 'nil'
+  
+  - name: microsoftGoCommitHash
+    displayName: The commit to run the innerloop tests for.
+    type: string
+
+  # Allow retrying a build pointing at an existing run.
+  - name: poll1MicrosoftGoInnerloopBuildID
+    displayName: '1: internal innerloop build ID to poll for completion.'
+    type: string
+    default: nil
+
+  # This parameter intentionally has no default: see release-go-pipeline.yml
+  - name: goReleaseConfigVariableGroup
+    displayName: '[Use "go-release-config" for a real release] Variable group that specifies release target locations and auth.'
+    type: string
+
+trigger: none
+pr: none
+
+variables:
+  - group: Microsoft-GoLang-bot
+  # Import config group. This may direct the build to use secrets from the other groups.
+  - group: ${{ parameters.goReleaseConfigVariableGroup }}
+  - template: variables/release-pipelines.yml
+
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)/eng/compliance/tsaoptions.json
+
+    stages:
+      - stage: Release
+        jobs:
+          - template: /eng/pipelines/jobs/releasego.yml@self
+            parameters:
+              releaseVersion: ${{ parameters.releaseVersion }}
+              releaseIssue: ${{ parameters.releaseIssue }}
+              variables:
+                # Set a variable for each polling parameter. If a variable starts off with 'nil', it will be
+                # overridden with a logging command as the pipeline moves on.
+                poll1MicrosoftGoInnerloopBuildID: ${{ parameters.poll1MicrosoftGoInnerloopBuildID }}
+              steps:
+                # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
+                # retry build will have a non-nil value in one of these parameters. Only the value of the last
+                # step's parameter matters.
+                - ${{ if eq(parameters.poll1MicrosoftGoInnerloopBuildID, 'nil') }}:
+                  # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
+                  # default Branch is "microsoft/main". So, we need to figure out the release branch name
+                  # and save it as a variable to pass it to AzDO.
+                  #
+                  # Testing adds a complication: testing commits won't be found in the actual release
+                  # branches, so we need a way to override. This is done using BuildPipelineFullBranchName
+                  # from the variable group. For actual releases, it should have the value
+                  # "refs/heads/microsoft/$(UpstreamTargetBranchName)". But in a testing variable group, it
+                  # can point at any ordinary dev branch that has the sync commit.
+                  - script: |
+                      releasego get-target-branch \
+                        -version '${{ parameters.releaseVersion }}' \
+                        -set-azdo-variable-branch-name UpstreamTargetBranchName
+                    displayName: Get target branch containing commit
+                  - script: |
+                      releasego build-pipeline \
+                        -commit '${{ parameters.microsoftGoCommitHash }}' \
+                        -branch '$(BuildPipelineFullBranchName)' \
+                        -id '$(GoInnerloopPipelineID)' \
+                        -org 'https://dev.azure.com/dnceng/' \
+                        -proj 'internal' \
+                        -azdopat '$(System.AccessToken)' \
+                        -set-azdo-variable poll1MicrosoftGoInnerloopBuildID
+                    displayName: 🚀 Run microsoft/go internal innerloop build
+                  # Report that the job started to provide the release runner with a direct link.
+                  - template: ../steps/report.yml
+                    parameters:
+                      releaseIssue: ${{ parameters.releaseIssue }}
+                      version: ${{ parameters.releaseVersion }}
+                      condition: succeeded()
+                      buildPipeline: microsoft-go-innerloop
+                      buildID: $(poll1MicrosoftGoInnerloopBuildID)
+                      buildStatus: NotStarted
+                      start: true
+                      reason: queued build
+
+                # Now we have poll1MicrosoftGoInnerloopBuildID
+                - script: |
+                    releasego wait-build \
+                      -id '$(poll1MicrosoftGoInnerloopBuildID)' \
+                      -org 'https://dev.azure.com/dnceng/' \
+                      -proj 'internal' \
+                      -azdopat '$(System.AccessToken)'
+                  displayName: ⌚ Wait for innerloop
+                  timeoutInMinutes: 120
+                - template: ../steps/report.yml
+                  parameters:
+                    releaseIssue: ${{ parameters.releaseIssue }}
+                    version: ${{ parameters.releaseVersion }}
+                    condition: and(ne('$(poll1MicrosoftGoInnerloopBuildID)', 'nil'), succeededOrFailed())
+                    buildPipeline: microsoft-go-innerloop
+                    buildID: $(poll1MicrosoftGoInnerloopBuildID)
+                    reason: innerloop status

--- a/eng/pipelines/variables/release-pipelines.yml
+++ b/eng/pipelines/variables/release-pipelines.yml
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Release-related pipeline IDs, for queueing.
+
+variables:
+  # Pipeline that runs the innerloop test pipeline.
+  - name: GoReleaseInnerloopPipelineID
+    value: 1348
+  # Innerloop test pipeline.
+  - name: GoInnerloopPipelineID
+    value: 1342


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/1159

Here's a basic approach to running innerloop tests in our release process. It puts the burden of the "join" on the release runner. (That "Approve" button now has a functional purpose. 🙂)

---

The build job *could* wait for one pipeline and then wait for the other in sequence, but this compromises on a few things:

* It would take longer to report the status of the second pipeline to the release runner if it fails.
* If the first pipeline hangs, it prevents reporting on the other pipeline.
* Retry queueing UX gets bad when both builds are in flight.
  * Copying *two* values is much worse than one. The Run dialog is modal and doesn't save progress, so the user would need to have a temp doc to transfer things over, or have multiple tabs open, or something along those lines.
  * Encoding two values into one copy-pasteable value is complicated to implement and makes it more difficult to specify manually when the dev is doing a fixup.
    * However, longer term, perhaps going all-in and using a YML/JSON object rather than individual text fields would be a good idea. (Has its own downsides.)

---

The build job could also be even more serialized: run innerloop to completion and only then queue the official job. (Or the other way around.) This avoids the compromises, but it's ~40min--not a pleasant thing to add synchronously, especially when there's the opportunity to run it parallel to signing, which can vary dramatically.