### PR TITLE
Mention innerloop in release issue notification

### DIFF
--- a/buildreport/buildreport.go
+++ b/buildreport/buildreport.go
@@ -271,7 +271,7 @@ func (s *State) notificationPreamble() string {
 	case SymbolSucceeded:
 		switch s.Name {
 		case releaseBuildPipelineName:
-			notification := "Completed releasing one version! If every version's release-build has finished, approve the release-go-images build to continue.\n"
+			notification := "Completed releasing one version! If every version's release-build and innerloop tests are successful, approve the release-go-images build to continue.\n"
 			if goversion.New(s.Version).Patch == "0" {
 				notification += "\nThis appears to be a new major version! If so, here are a few things that will need an update when the release is done:\n" +
 					"* [ ] The [microsoft/go download links](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)\n" +

--- a/buildreport/testdata/report/notify.go-new-branch.golden.md
+++ b/buildreport/testdata/report/notify.go-new-branch.golden.md
@@ -1,4 +1,4 @@
-Completed releasing one version! If every version's release-build has finished, approve the release-go-images build to continue.
+Completed releasing one version! If every version's release-build and innerloop tests are successful, approve the release-go-images build to continue.
 
 This appears to be a new major version! If so, here are a few things that will need an update when the release is done:
 * [ ] The [microsoft/go download links](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/Downloads.md)

--- a/buildreport/testdata/report/notify.go-servicing.golden.md
+++ b/buildreport/testdata/report/notify.go-servicing.golden.md
@@ -1,1 +1,1 @@
-Completed releasing one version! If every version's release-build has finished, approve the release-go-images build to continue.
+Completed releasing one version! If every version's release-build and innerloop tests are successful, approve the release-go-images build to continue.


### PR DESCRIPTION
* Fix the release notification bot comment to match https://github.com/microsoft/go-infra/pull/101

When I saw the announcement about the upstream release coming soon, I randomly realized this wasn't consistent.