### PR TITLE
Remove go-images microsoft/nightly updates

### DIFF
--- a/eng/pipelines/update-images-pipeline.yml
+++ b/eng/pipelines/update-images-pipeline.yml
@@ -14,14 +14,13 @@ resources:
       trigger:
         branches:
           include:
-            # go-images doesn't currently have a place for updates from microsoft/main to go. This
-            # should be addressed once the repo has a nightly branch:
-            # https://github.com/microsoft/go/issues/169. Until then, don't trigger on
-            # microsoft/main because those updates will always fail to generate.
+            # The microsoft/go release branches deliver updates to go-images via
+            # release automation, not this pipeline, so they are not included.
+
+            # microsoft/main would be included if we wanted to deliver nightly
+            # in-development builds from go-images.
+            # See https://github.com/microsoft/go-lab/issues/80
             # - microsoft/main
-            - microsoft/release-branch.*
-            - microsoft/dev.boringcrypto.go*
-            - dev/official/*
   repositories:
     - repository: 1ESPipelineTemplates
       type: git

--- a/eng/sync-config.json
+++ b/eng/sync-config.json
@@ -21,7 +21,7 @@
     "Upstream": "https://github.com/docker-library/golang",
     "Target": "https://github.com/microsoft/go-images",
     "BranchMap": {
-      "master": "microsoft/nightly"
+      "master": "microsoft/main"
     },
     "AutoSyncBranches": [
       "master"


### PR DESCRIPTION
* See https://github.com/microsoft/go-lab/issues/80

The go-images `microsoft/nightly` branch is not used as we originally planned, and is causing some noise. These changes in go-infra should make most of the noise stop.

Redirect submodule updates from go-images `microsoft/nightly` to `microsoft/main`, where we might still not merge it often, but the sync PRs will at least potentially be useful.