### PR TITLE
publish-announcement: mention security fixes in body

### DIFF
--- a/cmd/releasego/publish-announcement.go
+++ b/cmd/releasego/publish-announcement.go
@@ -43,13 +43,14 @@ var githubToWordpressUsernames = map[string]string{
 }
 
 type ReleaseInfo struct {
-	Title         string
-	Author        string
-	Slug          string
-	Categories    []string
-	Tags          []string
-	FeaturedImage string // Add this field for featured_image
-	Versions      []GoVersionData
+	Title           string
+	Author          string
+	Slug            string
+	Categories      []string
+	Tags            []string
+	FeaturedImage   string // Add this field for featured_image
+	Versions        []GoVersionData
+	SecurityRelease bool
 }
 
 // take all this methods and make it one constructor function for ReleaseInfo
@@ -82,6 +83,7 @@ func NewReleaseInfo(releaseDate time.Time, versions []string, author string, sec
 	if security {
 		ri.Categories = append(ri.Categories, "Security")
 		ri.Tags = append(ri.Tags, "security")
+		ri.SecurityRelease = true
 	}
 
 	return ri

--- a/cmd/releasego/publish-announcement_test.go
+++ b/cmd/releasego/publish-announcement_test.go
@@ -23,7 +23,8 @@ func Test_ReleaseInfo_WriteAnnouncement(t *testing.T) {
 		name string
 		ri   *ReleaseInfo
 	}{
-		{"real-2024-06-04", NewReleaseInfo(testTime, []string{"1.22.4-1", "1.21.11-1"}, author, true)},
+		{"2024-06-04-real", NewReleaseInfo(testTime, []string{"1.22.4-1", "1.21.11-1"}, author, true)},
+		{"2024-06-04-nonsecurity", NewReleaseInfo(testTime, []string{"1.22.4-1", "1.21.11-1"}, author, false)},
 		{"only-one-branch", NewReleaseInfo(testTime, []string{"1.22.8-3"}, author, true)},
 		{"three-branches", NewReleaseInfo(testTime, []string{"1.23.1-1", "1.22.8-1", "1.21.11-16"}, author, true)},
 	}

--- a/cmd/releasego/templates/announcement.template.md
+++ b/cmd/releasego/templates/announcement.template.md
@@ -8,7 +8,10 @@ featured_image:
 summary: The Microsoft builds of the Go security patches released today, are now available for download.
 ---
 
-A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#binary-distribution). For more information about this release and the changes included, see the table below:
+A new set of Microsoft Go builds
+{{- if .SecurityRelease }} including security fixes {{ else }} {{ end -}}
+is now [available for download](https://github.com/microsoft/go#binary-distribution).
+For more information about this release and the changes included, see the table below:
 
 | Microsoft Release | Upstream Tag |
 |-------------------|--------------|

--- a/cmd/releasego/testdata/publish-announcement/2024-06-04-nonsecurity.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/2024-06-04-nonsecurity.golden.md
@@ -2,13 +2,14 @@
 post_title: Go 1.22.4-1 and 1.21.11-1 Microsoft builds now available
 author1: Test Author
 post_slug: go-1-22-4-1-and-1-21-11-1-microsoft-builds-now-available
-categories: Microsoft for Go Developers, Security
-tags: go, release, security
+categories: Microsoft for Go Developers
+tags: go, release
 featured_image:
 summary: The Microsoft builds of the Go security patches released today, are now available for download.
 ---
 
-A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#binary-distribution). For more information about this release and the changes included, see the table below:
+A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#binary-distribution).
+For more information about this release and the changes included, see the table below:
 
 | Microsoft Release | Upstream Tag |
 |-------------------|--------------|

--- a/cmd/releasego/testdata/publish-announcement/2024-06-04-real.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/2024-06-04-real.golden.md
@@ -1,7 +1,7 @@
 ---
-post_title: Go 1.22.8-3 Microsoft build now available
+post_title: Go 1.22.4-1 and 1.21.11-1 Microsoft builds now available
 author1: Test Author
-post_slug: go-1-22-8-3-microsoft-build-now-available
+post_slug: go-1-22-4-1-and-1-21-11-1-microsoft-builds-now-available
 categories: Microsoft for Go Developers, Security
 tags: go, release, security
 featured_image:
@@ -13,4 +13,5 @@ For more information about this release and the changes included, see the table 
 
 | Microsoft Release | Upstream Tag |
 |-------------------|--------------|
-| [v1.22.8-3](https://github.com/microsoft/go/releases/tag/v1.22.8-3) | go1.22.8 [release notes](https://go.dev/doc/devel/release#go1.22.8) |
+| [v1.22.4-1](https://github.com/microsoft/go/releases/tag/v1.22.4-1) | go1.22.4 [release notes](https://go.dev/doc/devel/release#go1.22.4) |
+| [v1.21.11-1](https://github.com/microsoft/go/releases/tag/v1.21.11-1) | go1.21.11 [release notes](https://go.dev/doc/devel/release#go1.21.11) |

--- a/cmd/releasego/testdata/publish-announcement/three-branches.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/three-branches.golden.md
@@ -8,7 +8,8 @@ featured_image:
 summary: The Microsoft builds of the Go security patches released today, are now available for download.
 ---
 
-A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#binary-distribution). For more information about this release and the changes included, see the table below:
+A new set of Microsoft Go builds including security fixes is now [available for download](https://github.com/microsoft/go#binary-distribution).
+For more information about this release and the changes included, see the table below:
 
 | Microsoft Release | Upstream Tag |
 |-------------------|--------------|


### PR DESCRIPTION
Currently if you paste the blog body somewhere else (like when sending it out to the internal mailing list), there's no indication of whether it's a security release. I think it's worth mentioning in the text.