### PR TITLE
Pass publishReleaseStudio to microsoft-go as optional parameter

### DIFF
--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/go-infra/azdo"
@@ -110,7 +111,10 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 
 	// Make our own client. The AzDO library doesn't support the 7.1 API needed to pass parameters:
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-7.1
-	var client http.Client
+	client := http.Client{
+		// Generous timeout. Maximum observed time on dev machine during development: 10 seconds.
+		Timeout: time.Minute * 3,
+	}
 
 	request := &buildPipelineRequest{
 		DefinitionID:  *id,

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
 	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/stringutil"
 	"github.com/microsoft/go-infra/subcmd"
 )
 
@@ -25,8 +27,18 @@ func init() {
 		Summary: "Queue an AzDO build pipeline.",
 		Description: `
 
-Takes extra args: parameters and variables to queue the build with. Pass a parameter by passing
-three args 'p <name> <value>', or pass a variable with 'v <name> <value>'.
+Takes extra args defining the parameters and variables to queue the build with:
+
+  p <name> <value>
+    Pass a parameter. The parameter must be accepted by the target pipeline or
+    this command fails.
+
+  pOptional <name> <value>
+    Pass a parameter, but if the target pipeline doesn't accept it, try again
+    without this parameter. This may be useful for backward compatibility.
+
+  v <name> <value>
+    Pass a variable. A variable is a simple bag and has no validation.
 `,
 		TakeArgsReason: "Parameters and variables to pass to the build.",
 		Handle:         handleBuildPipeline,
@@ -53,7 +65,9 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 		return err
 	}
 
+	// parameters contains both optional and non-optional parameters.
 	parameters := make(map[string]string)
+	optionalParameters := make(map[string]string)
 	variables := make(map[string]string)
 
 	if url := azdo.GetEnvBuildURL(); url != "" {
@@ -69,6 +83,14 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 				return fmt.Errorf("not enough args remaining for 'p': %v", remaining)
 			}
 			parameters[remaining[1]] = remaining[2]
+			i += 2
+
+		case "pOptional":
+			if len(remaining) < 3 {
+				return fmt.Errorf("not enough args remaining for 'pOptional': %v", remaining)
+			}
+			parameters[remaining[1]] = remaining[2]
+			optionalParameters[remaining[1]] = remaining[2]
 			i += 2
 
 		case "v":
@@ -88,37 +110,113 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 
 	// Make our own client. The AzDO library doesn't support the 7.1 API needed to pass parameters:
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-7.1
-	client := new(http.Client)
+	var client http.Client
 
-	variablesJSON, err := json.Marshal(variables)
-	if err != nil {
-		return err
+	request := &buildPipelineRequest{
+		DefinitionID:  *id,
+		SourceBranch:  *branch,
+		SourceVersion: *commit,
+		Parameters:    parameters,
+		Variables:     variables,
 	}
 
-	url := *azdoFlags.Org + *azdoFlags.Proj + "/_apis/build/builds?definitionId=" + *id + "&api-version=7.1-preview.7"
+	b, err := sendBuildPipelineRunRequest(ctx, &client, azdoFlags, request)
+	if err != nil {
+		var reqErr *errBuildPipelineBadRequest
+		if !errors.As(err, &reqErr) {
+			return err
+		}
+		// Retry. AzDO should send the full list of unexpected parameters back to us in the 400
+		// response (if any), so only a single retry is needed.
+
+		// If there are no unexpected parameters (something else went wrong),
+		// there's no point in retrying.
+		if len(reqErr.unexpectedParameters) == 0 {
+			return err
+		}
+
+		// Check that all unexpected parameters are optional, and if so, get ready to run the
+		// request again with each one removed from the map of parameters.
+		var nonOptional []string
+		for _, unexpected := range reqErr.unexpectedParameters {
+			if _, ok := optionalParameters[unexpected]; ok {
+				delete(parameters, unexpected)
+			} else {
+				nonOptional = append(nonOptional, unexpected)
+			}
+		}
+		if len(nonOptional) > 0 {
+			return fmt.Errorf("response indicated unexpected parameters %q, which are not optional", nonOptional)
+		}
+
+		log.Printf("Retrying after removing unexpected parameters %q\n", reqErr.unexpectedParameters)
+		b, err = sendBuildPipelineRunRequest(ctx, &client, azdoFlags, request)
+		if err != nil {
+			return fmt.Errorf("failed retry after removing unexpected parameters: %v", err)
+		}
+	}
+
+	log.Printf("Queued build id %v\n", *b.Id)
+	if *setVariable != "" {
+		azdo.LogCmdSetVariable(*setVariable, strconv.Itoa(*b.Id))
+	}
+
+	if url, ok := azdo.GetBuildWebURL(b); ok {
+		log.Printf("Web build URL: %v\n", url)
+	} else {
+		log.Printf("Unable to find web URL in API response: %v\n", b.Links)
+	}
+
+	return nil
+}
+
+type buildPipelineRequest struct {
+	DefinitionID  string
+	SourceBranch  string
+	SourceVersion string
+	Parameters    map[string]string
+	Variables     map[string]string
+}
+
+type errBuildPipelineBadRequest struct {
+	unexpectedParameters []string
+}
+
+func (e *errBuildPipelineBadRequest) Error() string {
+	return fmt.Sprintf("build pipeline request got 400 response; unexpected parameters: %#v", e.unexpectedParameters)
+}
+
+func sendBuildPipelineRunRequest(ctx context.Context, client *http.Client, azdoFlags *azdo.ClientFlags, request *buildPipelineRequest) (*build.Build, error) {
+	variablesJSON, err := json.Marshal(request.Variables)
+	if err != nil {
+		return nil, err
+	}
 	body := map[string]interface{}{
 		"definition": map[string]interface{}{
-			"id": *id,
+			"id": request.DefinitionID,
 		},
-		"sourceBranch":       *branch,
-		"sourceVersion":      *commit,
-		"templateParameters": parameters,
+		"sourceBranch":       request.SourceBranch,
+		"sourceVersion":      request.SourceVersion,
+		"templateParameters": request.Parameters,
 		// Variables is a JSON string of a map[string]string. "parameters" is a legacy name in the
 		// AzDO UI--this is unrelated to the template parameters.
 		"parameters": string(variablesJSON),
 	}
 
+	url := *azdoFlags.Org + *azdoFlags.Proj +
+		"/_apis/build/builds?definitionId=" +
+		request.DefinitionID +
+		"&api-version=7.1-preview.7"
 	bodyJSON, err := json.MarshalIndent(body, "", "  ")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	log.Printf("Sending body to %q:\n%v\n", url, string(bodyJSON))
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyJSON))
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	log.Printf("Sending body:\n%v\n", string(bodyJSON))
 
 	// Based on https://github.com/microsoft/azure-devops-go-api/blob/00dac5c867394a3c5ca4e12b6965d7625a1588c6/azuredevops/client.go#L172-L181
 	req.Header.Add("Authorization", azdoFlags.NewConnection().AuthorizationString)
@@ -127,32 +225,46 @@ func handleBuildPipeline(p subcmd.ParseFunc) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusBadRequest {
+		// Try to parse the error response for specific types of issues the caller is interested in.
+		bodyObj := struct {
+			CustomProperties struct {
+				ValidationResults []struct {
+					Result  string `json:"result"`
+					Message string `json:"message"`
+				}
+			} `json:"customProperties"`
+		}{}
+		if err := json.Unmarshal(bodyBytes, &bodyObj); err != nil {
+			return nil, fmt.Errorf("failed to parse 400 error response: %v", err)
+		}
+		var reqErr errBuildPipelineBadRequest
+		for _, vr := range bodyObj.CustomProperties.ValidationResults {
+			if vr.Result != "error" {
+				continue
+			}
+			before, name, after, found := stringutil.CutTwice(vr.Message, "Unexpected parameter '", "'")
+			if !found || before != "" || after != "" {
+				continue
+			}
+			reqErr.unexpectedParameters = append(reqErr.unexpectedParameters, name)
+		}
+		return nil, &reqErr
 	}
 	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
-		return fmt.Errorf("non-success status code: %#v\nresponse data: %v", resp, string(bodyBytes))
+		return nil, fmt.Errorf("non-success status code: %#v\nresponse data: %v", resp, string(bodyBytes))
 	}
 
 	var b build.Build
 	if err := json.Unmarshal(bodyBytes, &b); err != nil {
-		return err
+		return nil, err
 	}
-
-	log.Printf("Queued build id %v\n", *b.Id)
-	if *setVariable != "" {
-		azdo.LogCmdSetVariable(*setVariable, strconv.Itoa(*b.Id))
-	}
-
-	if url, ok := azdo.GetBuildWebURL(&b); ok {
-		log.Printf("Web build URL: %v\n", url)
-	} else {
-		log.Printf("Unable to find web URL in API response: %v\n", b.Links)
-	}
-
-	return nil
+	return &b, nil
 }

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -39,7 +39,7 @@ Takes extra args defining the parameters and variables to queue the build with:
     without this parameter. This may be useful for backward compatibility.
 
   v <name> <value>
-    Pass a variable. A variable is a simple bag and has no validation.
+    Pass a variable. AzDO pipelines don't validate variables before running.
 `,
 		TakeArgsReason: "Parameters and variables to pass to the build.",
 		Handle:         handleBuildPipeline,

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -181,7 +181,8 @@ extends:
                           -proj 'internal' \
                           -azdopat '$(System.AccessToken)' \
                           -set-azdo-variable poll3MicrosoftGoBuildID \
-                          p releaseVersion '${{ parameters.releaseVersion }}'
+                          p releaseVersion '${{ parameters.releaseVersion }}' \
+                          pOptional publishReleaseStudio true
                       displayName: 🚀 Run microsoft/go internal build
                     - template: ../steps/report.yml
                       parameters:


### PR DESCRIPTION
Using Release Studio means that publishing every single microsoft-go build to the public would be more wasteful than it was before. So, I'm planning on adding a `publishReleaseStudio` parameter to the microsoft-go build to enable publishing, and now it will only be enabled by the release automation flow (or by devs for testing).

This is tricky for compatibility. This PR adds a feature so that we can pass a parameter *if the variable is declared* by the target pipeline/branch. This means our release automation pipeline doesn't need to worry about whether or not each release branch or main branch has implemented `publishReleaseStudio` yet. It will simply pass true if it's declared.

This feature could be avoided by implementing `publishReleaseStudio` in lockstep across all branches. However, I think allowing for incremental progress is worthwhile, and this feature may be useful for other parts of release automation in the future, too.

---

You'd think there would be a simpler way to do this. A few ways I tried:

* Use a variable! This would work, but AzDO variables are very limited in functionality compared to parameters, and introduce other complexities/annoyances/etc.
* Have `publishReleaseStudio` default to `true` and have the CI triggers turn it off! I didn't see a way to determine whether a build is triggered by CI in a way that works while the template is being evaluated, like parameters do. Maybe there are some side effects that could be used to figure it out.

In general, I think complexity in Go code is cozy compared to complexity in AzDO yml code, so I don't think this is a difficult choice, but I thought it's worth mentioning. 😄