### PR TITLE
Include checksum and sig URLs in assets.json

### DIFF
--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -117,10 +117,9 @@ func (b BuildAssets) GoVersion() *goversion.GoVersion {
 // archiving infra is stored in each release branch to make it local to the code it operates on and
 // less likely to unintentionally break, so some of that information is duplicated here.
 var (
-	archiveSuffixes     = []string{".tar.gz", ".zip"}
-	checksumSuffix      = ".sha256"
-	signatureSuffix     = ".sig"
-	sourceArchiveSuffix = ".src.tar.gz"
+	archiveSuffixes = []string{".tar.gz", ".zip"}
+	checksumSuffix  = ".sha256"
+	signatureSuffix = ".sig"
 )
 
 // BuildResultsDirectoryInfo points to locations in the filesystem that contain a Go build from

--- a/buildmodel/buildassets/buildassets.go
+++ b/buildmodel/buildassets/buildassets.go
@@ -10,7 +10,6 @@ package buildassets
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -22,6 +21,7 @@ import (
 	"github.com/microsoft/go-infra/buildmodel/dockerversions"
 	"github.com/microsoft/go-infra/buildmodel/publishmanifest"
 	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/stringutil"
 )
 
 // BuildAssets is the root object of a build asset JSON file.
@@ -34,10 +34,12 @@ type BuildAssets struct {
 	// Version of the build, as 'major.minor.patch-revision'. Doesn't include version note (-fips).
 	Version string `json:"version"`
 	// Arches is the list of artifacts that was produced for this version, typically one per target
-	// os/architecture. The name "Arches" is shared with the versions.json format.
+	// os/architecture and one with no "env" (representing the source tarball). The name "Arches" is
+	// shared with the versions.json format.
 	Arches []*dockerversions.Arch `json:"arches"`
 
 	// GoSrcURL is a URL pointing at a tar.gz archive of the pre-patched Go source code.
+	// Arches may also contain source archive details as an arch with no "env".
 	GoSrcURL string `json:"goSrcURL"`
 	// GoSrcSHA256 is the SHA256 hash of the pre-patched Go source code tar.gz archive stored at GoSrcURL.
 	GoSrcSHA256 string `json:"goSrcSHA256"`
@@ -117,6 +119,7 @@ func (b BuildAssets) GoVersion() *goversion.GoVersion {
 var (
 	archiveSuffixes     = []string{".tar.gz", ".zip"}
 	checksumSuffix      = ".sha256"
+	signatureSuffix     = ".sig"
 	sourceArchiveSuffix = ".src.tar.gz"
 )
 
@@ -185,13 +188,9 @@ func (b BuildResultsDirectoryInfo) CreateSummary() (*BuildAssets, error) {
 	}
 	// Swap out getURL with a func that gets info from the destination manifest file, if one exists.
 	if b.DestinationManifest != "" {
-		data, err := os.ReadFile(b.DestinationManifest)
-		if err != nil {
+		var manifest publishmanifest.Manifest
+		if err := stringutil.ReadJSONFile(b.DestinationManifest, &manifest); err != nil {
 			return nil, fmt.Errorf("unable to read destination manifest file '%v': %w", b.DestinationManifest, err)
-		}
-		manifest, err := publishmanifest.Read(bytes.NewReader(data))
-		if err != nil {
-			return nil, fmt.Errorf("unable to unmarshal destination manifest file '%v': %w", b.DestinationManifest, err)
 		}
 		byFilename, err := manifest.ByFilename()
 		if err != nil {
@@ -219,89 +218,90 @@ func (b BuildResultsDirectoryInfo) CreateSummary() (*BuildAssets, error) {
 			if e.IsDir() {
 				continue
 			}
-			fmt.Printf("Artifact file: %v\n", e.Name())
 
 			fullPath := filepath.Join(b.ArtifactsDir, e.Name())
-
-			// Is it a source archive file?
-			if strings.HasSuffix(e.Name(), sourceArchiveSuffix) {
-				goSrcURL, err = getURL(e.Name())
-				if err != nil {
-					return nil, fmt.Errorf("unable to get URL for source archive %q: %w", e.Name(), err)
-				}
+			_, platform, _, ok := CutToolsetFileParts(e.Name())
+			if !ok {
 				continue
 			}
-			// Is it a source archive file checksum?
-			if strings.HasSuffix(e.Name(), sourceArchiveSuffix+checksumSuffix) {
-				// The build asset JSON doesn't keep track of this info.
-				fileContent, err := os.ReadFile(fullPath)
-				if err != nil {
-					return nil, fmt.Errorf("unable to read checksum file '%v': %w", fullPath, err)
-				}
-				goSrcSHA256 = strings.Fields(string(fileContent))[0]
 
-				continue
-			}
 			// Is it a checksum file?
-			if strings.HasSuffix(e.Name(), checksumSuffix) {
-				// Find/create the arch that matches up with this checksum file.
-				a := getOrCreateArch(strings.TrimSuffix(e.Name(), checksumSuffix))
-				// Extract the checksum column from the file and store it in the summary.
+			if associatedName, ok := stringutil.CutSuffix(e.Name(), checksumSuffix); ok {
+				a := getOrCreateArch(associatedName)
+
+				// Store the checksum value.
 				checksumLine, err := os.ReadFile(fullPath)
 				if err != nil {
-					return nil, fmt.Errorf("unable to read checksum file '%v': %w", fullPath, err)
+					return nil, fmt.Errorf("unable to read checksum file %q: %w", fullPath, err)
 				}
 				a.SHA256 = strings.Fields(string(checksumLine))[0]
+
+				if platform == "src" {
+					goSrcSHA256 = a.SHA256
+				}
+
+				a.SHA256ChecksumURL, err = getURL(e.Name())
+				if err != nil {
+					return nil, fmt.Errorf("unable to get URL for checksum file %q: %w", e.Name(), err)
+				}
 				continue
 			}
-			// Is it an archive?
-			for _, suffix := range archiveSuffixes {
-				if strings.HasSuffix(e.Name(), suffix) {
-					// Extract OS/ARCH from the end of a filename like:
-					// "go.12.{...}.3.4.{GOOS}-{GOARCH}.tar.gz"
-					extensionless := strings.TrimSuffix(e.Name(), suffix)
-					lastDotIndex := strings.LastIndex(extensionless, ".")
-					if lastDotIndex == -1 {
-						return nil, fmt.Errorf(
-							"expected '.' in %q after removing extension from archive %q, but found none",
-							extensionless,
-							e.Name(),
-						)
-					}
 
-					osArch := extensionless[lastDotIndex+1:]
-					osArchParts := strings.Split(osArch, "-")
-					if len(osArchParts) != 2 {
-						return nil, fmt.Errorf(
-							"expected two parts separated by '-' in last segment %q of archive %q, but found %v",
-							osArch,
-							e.Name(),
-							len(osArchParts),
-						)
-					}
+			// Is it a signature file?
+			if associatedName, ok := stringutil.CutSuffix(e.Name(), signatureSuffix); ok {
+				a := getOrCreateArch(associatedName)
 
-					goOS, goArch := osArchParts[0], osArchParts[1]
-					var goARM string
-
-					// "armv6l" in the filename is a special case: it represents GOARCH=arm GOARM=6.
-					// There are no other active values of GOARM, so it's not worth generalizing.
-					if goArch == "armv6l" {
-						goArch = "arm"
-						goARM = "6"
-					}
-
-					a := getOrCreateArch(e.Name())
-					a.URL, err = getURL(e.Name())
-					if err != nil {
-						return nil, fmt.Errorf("unable to get URL for binary archive %q: %w", e.Name(), err)
-					}
-					a.Env = dockerversions.ArchEnv{
-						GOOS:   goOS,
-						GOARCH: goArch,
-						GOARM:  goARM,
-					}
-					break
+				a.PGPSignatureURL, err = getURL(e.Name())
+				if err != nil {
+					return nil, fmt.Errorf("unable to get URL for signature file %q: %w", e.Name(), err)
 				}
+				continue
+			}
+
+			// Is it a source archive file?
+			if platform == "src" {
+				goSrcURL, err = getURL(e.Name())
+				if err != nil {
+					return nil, fmt.Errorf("source archive %q: %w", e.Name(), err)
+				}
+				a := getOrCreateArch(e.Name())
+				a.URL = goSrcURL
+				continue
+			}
+
+			// At this point, it must be an archive of a compiled Go toolset.
+
+			// Extract OS/ARCH from the end of a filename like:
+			// "go.12.{...}.3.4.{GOOS}-{GOARCH}.tar.gz"
+			osArchParts := strings.Split(platform, "-")
+			if len(osArchParts) != 2 {
+				return nil, fmt.Errorf(
+					"expected two parts separated by '-' in last segment %q of archive %q, but found %v",
+					platform,
+					e.Name(),
+					len(osArchParts),
+				)
+			}
+
+			goOS, goArch := osArchParts[0], osArchParts[1]
+			var goARM string
+
+			// "armv6l" in the filename is a special case: it represents GOARCH=arm GOARM=6.
+			// There are no other active values of GOARM, so it's not worth generalizing.
+			if goArch == "armv6l" {
+				goArch = "arm"
+				goARM = "6"
+			}
+
+			a := getOrCreateArch(e.Name())
+			a.URL, err = getURL(e.Name())
+			if err != nil {
+				return nil, fmt.Errorf("unable to get URL for binary archive %q: %w", e.Name(), err)
+			}
+			a.Env = &dockerversions.ArchEnv{
+				GOOS:   goOS,
+				GOARCH: goArch,
+				GOARM:  goARM,
 			}
 		}
 	}
@@ -324,6 +324,35 @@ func (b BuildResultsDirectoryInfo) CreateSummary() (*BuildAssets, error) {
 		GoSrcURL:    goSrcURL,
 		GoSrcSHA256: goSrcSHA256,
 	}, nil
+}
+
+// CutToolsetFileParts cuts the given filename into a prefix containing the version information,
+// platform (treating "src" as a platform), and extension. The extension always begins with ".". If
+// the filename doesn't match the expected format, returns ok = false.
+//
+// This func handles the results of our current builds. It intentionally doesn't parse the version
+// section of the string, as its format varies and is generally intended to be informational. The
+// assets.json file should be used for the canonical version information.
+func CutToolsetFileParts(filename string) (prefix, platform, ext string, ok bool) {
+	for _, archiveExt := range archiveSuffixes {
+		for _, ext := range []string{
+			archiveExt,
+			archiveExt + checksumSuffix,
+			archiveExt + signatureSuffix,
+		} {
+			preExt, ok := stringutil.CutSuffix(filename, ext)
+			if !ok {
+				continue
+			}
+			// A platform may be "linux-amd64", "src", etc.
+			prefix, platform, ok := stringutil.CutLast(preExt, ".")
+			if !ok {
+				continue
+			}
+			return prefix, platform, ext, true
+		}
+	}
+	return "", "", "", false
 }
 
 // getVersion reads the file at path, if it exists. If it doesn't exist, returns the default

--- a/buildmodel/buildassets/testdata/1.17-build/result.golden.txt
+++ b/buildmodel/buildassets/testdata/1.17-build/result.golden.txt
@@ -9,7 +9,9 @@
         "GOOS": "linux"
       },
       "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "url": "https://example.org/go.linux-amd64.tar.gz"
+      "url": "https://example.org/go.linux-amd64.tar.gz",
+      "sha256ChecksumUrl": "https://example.org/go.linux-amd64.tar.gz.sha256",
+      "pgpSignatureUrl": "https://example.org/go.linux-amd64.tar.gz.sig"
     },
     {
       "env": {
@@ -17,7 +19,9 @@
         "GOOS": "linux"
       },
       "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "url": "https://example.org/go.linux-arm64.tar.gz"
+      "url": "https://example.org/go.linux-arm64.tar.gz",
+      "sha256ChecksumUrl": "https://example.org/go.linux-arm64.tar.gz.sha256",
+      "pgpSignatureUrl": "https://example.org/go.linux-arm64.tar.gz.sig"
     },
     {
       "env": {
@@ -26,7 +30,9 @@
         "GOOS": "linux"
       },
       "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "url": "https://example.org/go.linux-armv6l.tar.gz"
+      "url": "https://example.org/go.linux-armv6l.tar.gz",
+      "sha256ChecksumUrl": "https://example.org/go.linux-armv6l.tar.gz.sha256",
+      "pgpSignatureUrl": "https://example.org/go.linux-armv6l.tar.gz.sig"
     }
   ],
   "goSrcURL": "",

--- a/buildmodel/buildassets/testdata/1.23dev-publish/result.golden.txt
+++ b/buildmodel/buildassets/testdata/1.23dev-publish/result.golden.txt
@@ -10,7 +10,9 @@
         "GOOS": "linux"
       },
       "sha256": "11cb59a7da47abfdb8b88be7339d97ce1e9e0ca3ebd8e0fbdc1cfde73d547279",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/4f51/go1.23-0def9d5c-20240709.2.linux-armv6l.tar.gz"
+      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/4f51/go1.23-0def9d5c-20240709.2.linux-armv6l.tar.gz",
+      "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/3df7/go1.23-0def9d5c-20240709.2.linux-armv6l.tar.gz.sha256",
+      "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/c211/go1.23-0def9d5c-20240709.2.linux-armv6l.tar.gz.sig"
     },
     {
       "env": {
@@ -18,7 +20,8 @@
         "GOOS": "windows"
       },
       "sha256": "cd6a8dc304f80147155fb3aded2e714238a4a7f939fb57e47f4b75281e662555",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/704a/go1.23-0def9d5c-20240709.2.windows-amd64.zip"
+      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/704a/go1.23-0def9d5c-20240709.2.windows-amd64.zip",
+      "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/0f69/go1.23-0def9d5c-20240709.2.windows-amd64.zip.sha256"
     },
     {
       "env": {
@@ -26,7 +29,9 @@
         "GOOS": "linux"
       },
       "sha256": "4d43335c30e564053b32a0f4489eeaf399d49fe5a201961a573e42234201e5d3",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/c226/go1.23-0def9d5c-20240709.2.linux-amd64.tar.gz"
+      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/c226/go1.23-0def9d5c-20240709.2.linux-amd64.tar.gz",
+      "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/3507/go1.23-0def9d5c-20240709.2.linux-amd64.tar.gz.sha256",
+      "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/20eb/go1.23-0def9d5c-20240709.2.linux-amd64.tar.gz.sig"
     },
     {
       "env": {
@@ -34,7 +39,15 @@
         "GOOS": "linux"
       },
       "sha256": "4ff938e9b8bafe42809d441ec288679fb9759b34a5c4b162e0e4c335ecb4bcdd",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/cee0/go1.23-0def9d5c-20240709.2.linux-arm64.tar.gz"
+      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/cee0/go1.23-0def9d5c-20240709.2.linux-arm64.tar.gz",
+      "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/a6f0/go1.23-0def9d5c-20240709.2.linux-arm64.tar.gz.sha256",
+      "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/c815f/go1.23-0def9d5c-20240709.2.linux-arm64.tar.gz.sig"
+    },
+    {
+      "sha256": "e18be7a50671fa8fce652bf58cb5e0960b2ebcd064d526c7616274ad3799a1cf",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/e035/go1.23-0def9d5c-20240709.2.src.tar.gz",
+      "sha256ChecksumUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/85a9/go1.23-0def9d5c-20240709.2.src.tar.gz.sha256",
+      "pgpSignatureUrl": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/eb070/go1.23-0def9d5c-20240709.2.src.tar.gz.sig"
     }
   ],
   "goSrcURL": "https://download.visualstudio.microsoft.com/download/pr/1234-56-78-123456/e035/go1.23-0def9d5c-20240709.2.src.tar.gz",

--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -149,6 +149,10 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 				if !arch.Supported {
 					continue
 				}
+				// Skip src.
+				if arch.Env == nil {
+					continue
+				}
 				// Skip platforms that don't match the current variant. v.Arches is actually a list
 				// of OS/ARCHes, not just architectures.
 				if arch.Env.GOOS != os {
@@ -169,7 +173,7 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 					}
 				}
 
-				p := makeOSArchPlatform(os, osVersion, &arch.Env)
+				p := makeOSArchPlatform(os, osVersion, arch.Env)
 				p.BuildArgs = buildArgs
 				p.Dockerfile = dockerfileDir
 				p.Tags = map[string]dockermanifest.Tag{
@@ -283,6 +287,10 @@ func UpdateVersions(assets *buildassets.BuildAssets, versions dockerversions.Ver
 	// Look through the asset arches, find an arch in the versions file that matches each asset,
 	// and update its info.
 	for _, arch := range assets.Arches {
+		// Skip src.
+		if arch.Env == nil {
+			continue
+		}
 		// Special case for arm artifacts: change it to arm32v7. We produce arm32v6 builds of Go
 		// but package them in arm/v7 (armhf) Docker images. The upstream Go official image repo
 		// does this in their versions.json file: there are v6 and v7 Dockerfile arches that

--- a/buildmodel/buildmodel_test.go
+++ b/buildmodel/buildmodel_test.go
@@ -20,7 +20,7 @@ var update = flag.Bool("update", false, "Update the golden files instead of fail
 
 func TestBuildAssets_UpdateVersions(t *testing.T) {
 	newArch := &dockerversions.Arch{
-		Env: dockerversions.ArchEnv{
+		Env: &dockerversions.ArchEnv{
 			GOARCH: "amd64",
 			GOOS:   "linux",
 		},
@@ -39,7 +39,7 @@ func TestBuildAssets_UpdateVersions(t *testing.T) {
 				Revision: "",
 				Arches: map[string]*dockerversions.Arch{
 					"amd64": {
-						Env:       dockerversions.ArchEnv{},
+						Env:       &dockerversions.ArchEnv{},
 						SHA256:    "old-sha",
 						URL:       "old-url",
 						Supported: true,

--- a/buildmodel/dockerversions/dockerversions.go
+++ b/buildmodel/dockerversions/dockerversions.go
@@ -65,16 +65,38 @@ func (m *MajorMinorVersion) GoVersion() *goversion.GoVersion {
 
 // Arch points at the publicly accessible artifacts for a specific OS/arch.
 type Arch struct {
-	Env       ArchEnv `json:"env"`
-	SHA256    string  `json:"sha256"`
-	Supported bool    `json:"supported,omitempty"`
-	URL       string  `json:"url"`
+	// Env is the environment the artifact runs on, or nil if it's a source archive.
+	Env *ArchEnv `json:"env,omitempty"`
+
+	// SHA256 is the SHA256 checksum of the artifact as a hex string.
+	SHA256 string `json:"sha256"`
+
+	// Supported indicates this artifact should have a Docker image generated for it. The name
+	// "Supported" comes from upstream Go image infrastructure.
+	Supported bool `json:"supported,omitempty"`
+
+	// URL is a URL from which the artifact can be downloaded. The artifact may be a build of Go or
+	// a source tarball, determined by Env.
+	URL string `json:"url"`
+
+	// SHA256ChecksumURL is the URL of a file containing the SHA256 checksum in a format that works
+	// with "sha256sum -c" and similar tools.
+	//
+	// If not specified, the file can be reached by appending ".sha256" to the URL.
+	SHA256ChecksumURL string `json:"sha256ChecksumUrl,omitempty"`
+
+	// PGPSignatureURL is the URL of a PGP signature file for this artifact, commonly verified using
+	// the "gpg" tool.
+	//
+	// If not specified, the file can be reached by appending ".sig" to the URL.
+	PGPSignatureURL string `json:"pgpSignatureUrl,omitempty"`
 }
 
+// ArchEnv is the environment an artifact is expected to be useful in.
 type ArchEnv struct {
-	GOARCH string
-	GOARM  string `json:"GOARM,omitempty"`
-	GOOS   string
+	GOARCH string `json:",omitempty"`
+	GOARM  string `json:",omitempty"`
+	GOOS   string `json:",omitempty"`
 }
 
 // GoImageArchVersionSuffix is the string used in docker-library/golang and .NET Docker infrastructure to

--- a/buildmodel/publishmanifest/publishmanifest.go
+++ b/buildmodel/publishmanifest/publishmanifest.go
@@ -4,23 +4,8 @@
 package publishmanifest
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-
-	"golang.org/x/text/encoding/unicode"
-	"golang.org/x/text/transform"
 )
-
-// Read reads a [Manifest] from r, which may begin with a BOM.
-func Read(r io.Reader) (*Manifest, error) {
-	r = transform.NewReader(r, unicode.BOMOverride(transform.Nop))
-	var m Manifest
-	if err := json.NewDecoder(r).Decode(&m); err != nil {
-		return nil, err
-	}
-	return &m, nil
-}
 
 // Manifest is a publish manifest file, written by DevDiv.MS.Go.Publishing.
 type Manifest struct {

--- a/buildmodel/publishmanifest/publishmanifest_test.go
+++ b/buildmodel/publishmanifest/publishmanifest_test.go
@@ -4,19 +4,15 @@
 package publishmanifest
 
 import (
-	"bytes"
-	"os"
 	"testing"
+
+	"github.com/microsoft/go-infra/stringutil"
 )
 
 // Test that reading a manifest with a BOM doesn't cause JSON parsing to fail.
 func TestReadBOMManifest(t *testing.T) {
-	data, err := os.ReadFile("testdata/msGo.output.manifest.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = Read(bytes.NewReader(data))
-	if err != nil {
+	var m Manifest
+	if err := stringutil.ReadJSONFile("testdata/msGo.output.manifest.json", &m); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -8,12 +8,23 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 // CutPrefix behaves like strings.Cut, but only cuts a prefix, not anywhere in the string.
 func CutPrefix(s, prefix string) (after string, found bool) {
 	if strings.HasPrefix(s, prefix) {
 		return s[len(prefix):], true
+	}
+	return s, false
+}
+
+// CutSuffix behaves like strings.Cut, but only cuts a suffix, not anywhere in the string.
+func CutSuffix(s, suffix string) (before string, found bool) {
+	if strings.HasSuffix(s, suffix) {
+		return s[:len(s)-len(suffix)], true
 	}
 	return s, false
 }
@@ -29,7 +40,15 @@ func CutTwice(s, sep1, sep2 string) (before, between, after string, found bool) 
 	return s, "", "", false
 }
 
-// ReadJSONFile reads one JSON value from the specified file.
+// CutLast is [strings.Cut], but cutting at the last occurrence of sep rather than the first.
+func CutLast(s, sep string) (before, after string, found bool) {
+	if i := strings.LastIndex(s, sep); i != -1 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return "", s, false
+}
+
+// ReadJSONFile reads one JSON value from the specified file. Supports BOM.
 func ReadJSONFile(path string, i interface{}) (err error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -41,7 +60,8 @@ func ReadJSONFile(path string, i interface{}) (err error) {
 		}
 	}()
 
-	d := json.NewDecoder(f)
+	content := transform.NewReader(f, unicode.BOMOverride(transform.Nop))
+	d := json.NewDecoder(content)
 	if err := d.Decode(i); err != nil {
 		return fmt.Errorf("unable to decode JSON file %v: %w", path, err)
 	}


### PR DESCRIPTION
## Context

Current asset.json files say that windows-amd64 is at `https://example.org/1234/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz`. It doesn't contain the URLs of the sha256 and sig file, and our tooling needs to calculate these URLs:
`https://example.org/1234/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz.sha256`
`https://example.org/1234/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz.sig`
This has been working fine for now because we publish to blob storage, and everything before `/` is always the same for a given build of Go.

This is no longer the case when we publish with Release Studio, because we get URLs like this:

```
https://download.visualstudio.microsoft.com/download/pr/538a1...79f66/85bf...5550/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz
https://download.visualstudio.microsoft.com/download/pr/538a1...79f66/44a9...d9ac/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz.sha256
https://download.visualstudio.microsoft.com/download/pr/538a1...79f66/c844...9d0c/go1.23-90bcc55-20240626.1.linux-amd64.tar.gz.sig
                                                                      ^^^^^^^^^^^
```

This random string means the `asset.json` generated with the current tooling (only listing the first file) wouldn't contain enough information to reach all three of those files.

Another problem: there's no where in the current `asset.json` file to put the URLs of the sha256 and sig files for the Go source tarball. The fields are only the URL of the tarball itself and the actual SHA512 hash.

## Fix

Adding the URLs into the asset.json file alongside the asset URLs is a fairly straightforward fix. This can be done in a backward compatible way.

I also started including the Go source tarball in `arches`. This avoids some special cases in the implementation, and it lets me avoid adding `GoSrcSHA256URL` and `GoSrcSignatureURL` fields alongside `GoSrcURL` and `GoSrcSHA256`. It actually follows the official Go image's version.json behavior, which our model is based on: https://github.com/docker-library/golang/blob/0f7f657aa4011345f663f34c252e2b4630ce7eea/versions.json#L341-L345.

## Review notes

The most significant change here is `BuildResultsDirectoryInfo.CreateSummary`, which now keeps track of more URLs. I tried to keep it simple and share some logic.

I moved publish manifest BOM handling to `stringutil.ReadJSONFile`, where it's easier to use from other places in the infra that will now need it.

I initially worked on this in the same branch as some changes to `releasego akams` that handle this update. I tried to make this PR easier to review by splitting that work out. I think I split it cleanly but might have missed something. 🙂 The new `CutToolsetFileParts` func will also be used in that PR.

Example build that generated an assets.json with the new info (see the BuildAssets artifact):
* https://dev.azure.com/dnceng/internal/_build/results?buildId=2496236&view=results