### PR TITLE
Improve golden test behavior

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,8 @@
 *.sh text eol=lf
 # Always use LF for Go files to avoid CRLF issues with golangci-lint.
 *.go text eol=lf
-# Use LF for txtar files to avoid CR inputs to standard txtar library.
-*.txtar text eol=lf
+# Use LF for all testdata files to avoid CR affecting txtar, goldentest, etc.
+**/testdata/** text eol=lf
+# Use LF for all embedded markdown template files to avoid different results per
+# platform and mismatching tests.
+*.template.md text eol=lf

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -37,6 +37,15 @@ jobs:
           testResultsFiles: $(Build.StagingDirectory)/TestResults.xml
           publishRunAttachments: true
 
+      # If the failure was a mismatch with golden files, show the difference for easier diagnosis.
+      - script: go test ./... -update
+        displayName: Update golden test results
+        condition: failed()
+
+      - script: git diff
+        displayName: 🔍 Show golden file difference
+        condition: failed()
+
   - template: jobs/fuzz.yml
     parameters:
       name: TestFuzz1x

--- a/goldentest/goldentest.go
+++ b/goldentest/goldentest.go
@@ -20,6 +20,8 @@ var update = flag.Bool("update", false, "Update the golden files instead of fail
 // fail if it's incorrect. If "-update" is passed to the "go test" command, instead of failing, it
 // writes actual to goldenPath.
 func Check(t *testing.T, rerunCmd, goldenPath, actual string) {
+	t.Helper()
+
 	if *update {
 		if err := os.MkdirAll(filepath.Dir(goldenPath), os.ModePerm); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Use LF for templates and more testdata for clean Windows test runs.

Add t.Helper() to goldentest.Check for better test failure output.

Add diff to CI test output for easier diagnosis.

---

Here's a simulated bug on top of this change to show what the `git diff` looks like: https://dev.azure.com/dnceng-public/public/_build/results?buildId=743874&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=999d1e63-f491-5647-b12a-6f602a65e22e&l=23