### PR TITLE
cmd/releasego: make the first sentence the post's summary

### DIFF
--- a/cmd/releasego/templates/announcement.template.md
+++ b/cmd/releasego/templates/announcement.template.md
@@ -5,7 +5,9 @@ post_slug: {{.Slug}}
 categories: {{.CategoriesString}}
 tags: {{.TagsString}}
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds
+{{- if .SecurityRelease }} including security fixes {{ else }} {{ end -}}
+is now available for download.
 ---
 
 A new set of Microsoft Go builds

--- a/cmd/releasego/testdata/publish-announcement/2024-06-04-nonsecurity.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/2024-06-04-nonsecurity.golden.md
@@ -5,7 +5,7 @@ post_slug: go-1-22-4-1-and-1-21-11-1-microsoft-builds-now-available
 categories: Microsoft for Go Developers
 tags: go, release
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds is now available for download.
 ---
 
 A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#download-and-install).

--- a/cmd/releasego/testdata/publish-announcement/2024-06-04-note.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/2024-06-04-note.golden.md
@@ -5,7 +5,7 @@ post_slug: go-1-22-4-1--1-22-4-1-fips-1-21-11-1-and-1-21-11-1-fips-microsoft-bui
 categories: Microsoft for Go Developers
 tags: go, release
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds is now available for download.
 ---
 
 A new set of Microsoft Go builds is now [available for download](https://github.com/microsoft/go#download-and-install).

--- a/cmd/releasego/testdata/publish-announcement/2024-06-04-real.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/2024-06-04-real.golden.md
@@ -5,7 +5,7 @@ post_slug: go-1-22-4-1-and-1-21-11-1-microsoft-builds-now-available
 categories: Microsoft for Go Developers, Security
 tags: go, release, security
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds including security fixes is now available for download.
 ---
 
 A new set of Microsoft Go builds including security fixes is now [available for download](https://github.com/microsoft/go#download-and-install).

--- a/cmd/releasego/testdata/publish-announcement/only-one-branch.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/only-one-branch.golden.md
@@ -5,7 +5,7 @@ post_slug: go-1-22-8-3-microsoft-build-now-available
 categories: Microsoft for Go Developers, Security
 tags: go, release, security
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds including security fixes is now available for download.
 ---
 
 A new set of Microsoft Go builds including security fixes is now [available for download](https://github.com/microsoft/go#download-and-install).

--- a/cmd/releasego/testdata/publish-announcement/three-branches.golden.md
+++ b/cmd/releasego/testdata/publish-announcement/three-branches.golden.md
@@ -5,7 +5,7 @@ post_slug: go-1-23-1-1--1-22-8-1-and-1-21-11-16-microsoft-builds-now-available
 categories: Microsoft for Go Developers, Security
 tags: go, release, security
 featured_image:
-summary: The Microsoft builds of the Go security patches released today, are now available for download.
+summary: A new set of Microsoft Go builds including security fixes is now available for download.
 ---
 
 A new set of Microsoft Go builds including security fixes is now [available for download](https://github.com/microsoft/go#download-and-install).


### PR DESCRIPTION
This PR goes after a few issues with `The Microsoft builds of the Go security patches released today, are now available for download.`:
* The comma is disruptive.
* It always says security patches even if the release isn't security related.
* It says the security patches are released today, but we might have only successfully built them some days afterwards.

I'm changing the summary to simply be the same as the first line of the blog post instead. (But without the link.) This seems like how the summaries are usually made in e.g. the Microsoft Java blog.

Summary shows up on the main page:

> ![image](https://github.com/user-attachments/assets/0a964db9-f40e-43dc-92e6-e4db34a61c24)