### PR TITLE
Wait for MAR images to match expected `go version`

### DIFF
--- a/buildreport/buildreport.go
+++ b/buildreport/buildreport.go
@@ -290,14 +290,8 @@ func (s *State) notificationPreamble() string {
 			}
 			return notification
 		case releaseImagesPipelineName:
-			return "Completed building all images! " +
-				"Before you [announce](https://github.com/microsoft/go-infra/blob/main/docs/release-process/instructions.md#making-the-internal-announcement), " +
-				"confirm the MAR/MCR images are updated using commands like these:\n\n" +
-				"```\n" +
-				"image=mcr.microsoft.com/oss/go/microsoft/golang:1-bullseye\n" +
-				"docker pull $image\n" +
-				"docker run -it --rm $image go version\n" +
-				"```\n"
+			return "Completed building all images!\n\n" +
+				"Next, [announce the release](https://github.com/microsoft/go-infra/blob/main/docs/release-process/instructions.md#making-the-internal-announcement).\n"
 		}
 	}
 	return ""

--- a/buildreport/testdata/report/notify.images.golden.md
+++ b/buildreport/testdata/report/notify.images.golden.md
@@ -1,7 +1,3 @@
-Completed building all images! Before you [announce](https://github.com/microsoft/go-infra/blob/main/docs/release-process/instructions.md#making-the-internal-announcement), confirm the MAR/MCR images are updated using commands like these:
+Completed building all images!
 
-```
-image=mcr.microsoft.com/oss/go/microsoft/golang:1-bullseye
-docker pull $image
-docker run -it --rm $image go version
-```
+Next, [announce the release](https://github.com/microsoft/go-infra/blob/main/docs/release-process/instructions.md#making-the-internal-announcement).

--- a/cmd/releasego/wait-latest-mar-go-version.go
+++ b/cmd/releasego/wait-latest-mar-go-version.go
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+const marRepo = "mcr.microsoft.com/oss/go/microsoft/golang"
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "wait-latest-mar-go-version",
+		Summary: "Wait (poll) for the latest Microsoft Go images on MAR to match specified versions.",
+		Description: `
+
+Given a list of Go versions, constructs tag names for each one's major version (1.20.3-1 -> 1.20)
+and repeatedly tries to "docker pull" that tag and then probe the image using
+"docker run ... go version" to see if it contains the expected major+minor+patch Go version.
+`,
+		Handle: waitMarGoVersion,
+	})
+}
+
+func waitMarGoVersion(p subcmd.ParseFunc) error {
+	versionList := flag.String(
+		"versions", "",
+		"[Required] A list of full or partial microsoft/go version numbers (major.minor.patch[-revision[-suffix]]). Separated by commas.")
+
+	timeout := flag.Duration("timeout", time.Minute*5, "Time to wait before giving up.")
+	pollDelay := flag.Duration("poll-delay", time.Second*10, "Time to wait between each poll attempt.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *versionList == "" {
+		return errors.New("no versions specified")
+	}
+
+	var checkers []func() (bool, error)
+	for _, version := range strings.Split(*versionList, ",") {
+		v := goversion.New(version)
+		tag := marRepo + ":" + v.MajorMinor()
+
+		expect := "go" + v.MajorMinorPatchPrerelease() + " "
+
+		checkers = append(checkers, func() (bool, error) {
+			pullCmd := exec.Command("docker", "pull", tag)
+			if err := executil.Run(pullCmd); err != nil {
+				return false, err
+			}
+			versionCmd := exec.Command("docker", "run", "--rm", tag, "go", "version")
+			out, err := executil.SpaceTrimmedCombinedOutput(versionCmd)
+			if err != nil {
+				return false, err
+			}
+			found := strings.Contains(out, expect)
+			log.Printf("Finding %q in %q: %v\n", expect, out, found)
+			return found, nil
+		})
+	}
+
+	// Make our logs stand out from Docker's.
+	log.Default().SetPrefix("---- ")
+
+	start := time.Now()
+	end := start.Add(*timeout)
+
+	for {
+		var missing bool
+
+		for _, tag := range checkers {
+			ok, err := tag()
+			if err != nil {
+				return fmt.Errorf("unexpectedly failed check: %v", err)
+			}
+			if !ok {
+				missing = true
+			}
+		}
+
+		if !missing {
+			log.Printf("All checkers found what they expected. Done.")
+			return nil
+		}
+
+		log.Printf("Waiting %v before trying again...", *pollDelay)
+		time.Sleep(*pollDelay)
+		if time.Now().After(end) {
+			return fmt.Errorf("exceeded timeout (%v) waiting for versions", *timeout)
+		}
+	}
+}

--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -40,6 +40,10 @@ parameters:
     displayName: Publish announcement details
     type: boolean
     default: true
+  - name: runGoImageVersionCheck
+    displayName: Check Go version in latest MAR images
+    type: boolean
+    default: true
 
   # Allow retrying a build starting at any of these points.
   - name: poll1MicrosoftGoImagesCommitHash
@@ -159,7 +163,7 @@ extends:
                         buildStatus: '?'
                         start: true
                         reason: queued build
-                    # Now we have poll2MicrosoftGoImagesBuildID 
+                    # Now we have poll2MicrosoftGoImagesBuildID
                     - script: |
                         releasego wait-build \
                           -id '$(poll2MicrosoftGoImagesBuildID)' \
@@ -168,14 +172,22 @@ extends:
                           -azdopat '$(System.AccessToken)'
                       displayName: ⌚ Wait for go-images build
                       timeoutInMinutes: 120
-                - script: |
-                    releasego publish-announcement \
-                      -author '${{ parameters.notify }}' \
-                      -versions '${{ join(',', parameters.releaseVersions) }}' \
-                      -security='${{ parameters.isSecurityRelease }}' \
-                      -pat '$(GitHubPAT)'
-                  displayName: Publishing announcement details
-                  
+
+                - ${{ if eq(parameters.runPublishAnnouncement, true) }}:
+                  - script: |
+                      releasego publish-announcement \
+                        -author '${{ parameters.notify }}' \
+                        -versions '${{ join(',', parameters.releaseVersions) }}' \
+                        -security='${{ parameters.isSecurityRelease }}' \
+                        -pat '$(GitHubPAT)'
+                    displayName: 📰 Publish announcement details
+
+                - ${{ if eq(parameters.runGoImageVersionCheck, true) }}:
+                  - script: |
+                      releasego wait-latest-mar-go-version \
+                        -versions '${{ join(',', parameters.releaseVersions) }}'
+                    displayName: 🌊 Check Go version in latest MAR images
+
                 - template: ../steps/report.yml
                   parameters:
                     releaseIssue: ${{ parameters.releaseIssue }}


### PR DESCRIPTION
* Resolves https://github.com/microsoft/go/issues/1090

This is only intended as a broad check. If we're trying to ship 1.21.5-1 and the image contains 1.210.5, then something went seriously wrong, and this would catch it. This PR changes it from a manual step to an automated one.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2510014&view=results
I tested the polling case manually, locally, with versions that don't exist.

The value of this check is limited: `go version` only outputs 1.21.5, so if we're building 1.21.5-2 that replaces 1.21.5-1, it will potentially succeed too early. But, this limitation has always been there--this PR only automates the check, making it clearer that the potential problem exists.

* Related: https://github.com/microsoft/go/issues/262
* This PR isn't good enough as a way to *generally* make sure MAR has all our images. We actually should set up this .NET Docker feature: https://github.com/microsoft/go/issues/1258

Also fixes the pipeline: it was ignoring `runPublishAnnouncement`.