### PR TITLE
Make the placeholder go.mod file in eng/ valid

### DIFF
--- a/eng/go.mod
+++ b/eng/go.mod
@@ -1,7 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // This empty go.mod file causes the directory's contents to be excluded from go commands run in the
 // root of the go-infra repository. This approach is from this comment:
 // https://github.com/golang/go/issues/30058#issuecomment-543815369
 //
-// Exclusion is useful because the "sync" utility clones repositories into "eng/artifacts", so
-// running "go build ./..." or other similar commnads would find ".go" files inside the
-// sub-repository. By excluding the directory, this is avoided.
+// We exclude this directory because the "sync" utility clones repositories into "eng/artifacts".
+// After running "sync", running "go build ./..." or other similar commands in the go-infra
+// directory would find ".go" files inside the sub-repository and try to build them. Even if it
+// succeeds, it is not intentional, and would waste time.
+//
+// This file contains just enough info to be a valid go.mod file. A blank file is sufficient to
+// exclude the directory from Go commands, but IDEs may expect a valid go.mod file.
+
+module unused
+
+go 1.18


### PR DESCRIPTION
With the current placeholder, GoLand shows this error on startup:

![image](https://github.com/user-attachments/assets/c63dec8a-25dd-4bce-93bb-b19e03a9709f)

```
C:\tools\microsoft-go\go\bin\go.exe list -modfile=C:/git/go-infra/eng\go.mod -m -json -mod=mod all #gosetup
go: error reading C:/git/go-infra/eng\go.mod: missing module declaration. To specify the module path:
	go mod edit -module=example.com/mod
```

This PR fixes it by changing the placeholder to be a valid go.mod file.