### PR TITLE
Flatten deep nesting of release pipeline steps

### DIFF
--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -96,268 +96,41 @@ extends:
               releaseIssue: ${{ parameters.releaseIssue }}
               retryInstructionsFlags: '-checkboxes'
               variables:
-                # Set a variable for each polling parameter. If a variable starts off with 'nil', it will be
-                # overridden with a logging command as the pipeline moves on.
+                # Set a variable for each polling parameter. If a variable starts off with 'nil', it
+                # will be overridden with a logging command as the pipeline moves on. Variables are
+                # dynamic (unlike parameters) and the final state of the variables is checked at the
+                # end of the build to provide a starting point for a retry if necessary.
                 poll1MicrosoftGoPRNumber: ${{ parameters.poll1MicrosoftGoPRNumber }}
                 poll2MicrosoftGoCommitHash: ${{ parameters.poll2MicrosoftGoCommitHash }}
                 poll3MicrosoftGoBuildID: ${{ parameters.poll3MicrosoftGoBuildID }}
                 poll4MicrosoftGoImagesPRNumber: ${{ parameters.poll4MicrosoftGoImagesPRNumber }}
               steps:
-                # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
-                # retry build will have a non-nil value in one of these parameters. Only the value of the last
-                # step's parameter matters.
+                # Resume the build at the furthest step based on the inputs. A fresh build has all
+                # 'nil', and a retry build will have a non-nil value in one of these parameters.
+                # Only the value of the last step's parameter matters. To avoid excessive, unclear
+                # nesting, the nesting is all here in compact form, calling an evenly indented,
+                # linear steps template.
                 - ${{ if eq(parameters.poll4MicrosoftGoImagesPRNumber, 'nil') }}:
                   - ${{ if eq(parameters.poll3MicrosoftGoBuildID, 'nil') }}:
                     - ${{ if eq(parameters.poll2MicrosoftGoCommitHash, 'nil') }}:
                       - ${{ if eq(parameters.poll1MicrosoftGoPRNumber, 'nil') }}:
-                        # Poll for the right commit to use for this release.
-                        - script: |
-                            releasego get-upstream-commit \
-                              -version '${{ parameters.releaseVersion }}' \
-                              -set-azdo-variable upstreamReleasedCommit
-                          displayName: ⌚ Get upstream commit for release
-                          # 6 hours. This step may take an arbitrarily long time while if we ran the release
-                          # job preemptively. But at some point, a dev needs to check that the tool is working
-                          # properly and the upstream release is progressing as expected.
-                          timeoutInMinutes: 360
-                        # Either make sure the microsoft/go branch has the correct commit as its submodule, or
-                        # submit a PR that sets the submodule commit.
-                        - script: |
-                            releasego sync \
-                              -c '$(ReleaseSyncConfigPath)' \
-                              -commit '$(upstreamReleasedCommit)' \
-                              -version '${{ parameters.releaseVersion }}' \
-                              -git-auth pat \
-                              -github-user '$(GitHubUser)' \
-                              -github-pat '$(GitHubPAT)' \
-                              -github-pat-reviewer '$(GitHubPATReviewer)' \
-                              -azdo-dnceng-pat '$(AzDODncengPAT)' \
-                              -create-branches \
-                              -set-azdo-variable-pr-number poll1MicrosoftGoPRNumber \
-                              -set-azdo-variable-up-to-date-commit poll2MicrosoftGoCommitHash
-                          displayName: Sync to upstream commit
-
-                      # Now we have poll1MicrosoftGoPRNumber, which may be nil if no PR is required
-                      - script: |
-                          releasego get-merged-pr-commit \
-                            -repo '$(TargetGitHubRepo)' \
-                            -pr '$(poll1MicrosoftGoPRNumber)' \
-                            -pat '$(GitHubPAT)' \
-                            -set-azdo-variable poll2MicrosoftGoCommitHash
-                        displayName: ⌚ Get sync PR merged commit hash
-                        timeoutInMinutes: 60
-                        condition: and(succeeded(), ne(variables.poll1MicrosoftGoPRNumber, 'nil'))
-
-                    # Now we have poll2MicrosoftGoCommitHash
-                    - script: |
-                        releasego wait-azdo-commit \
-                          -commit '$(poll2MicrosoftGoCommitHash)' \
-                          -name '$(TargetAzDORepo)' \
-                          -org 'https://dev.azure.com/dnceng/' \
-                          -proj 'internal' \
-                          -azdopat '$(System.AccessToken)'
-                      displayName: ⌚ Wait for internal mirror
-                      timeoutInMinutes: 15 # This should be very quick, and a dev can easily fix it.
-                    # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
-                    # default Branch is "microsoft/main". So, we need to figure out the release branch name
-                    # and save it as a variable to pass it to AzDO.
-                    #
-                    # Testing adds a complication: testing commits won't be found in the actual release
-                    # branches, so we need a way to override. This is done using BuildPipelineFullBranchName
-                    # from the variable group. For actual releases, it should have the value
-                    # "refs/heads/microsoft/$(UpstreamTargetBranchName)". But in a testing variable group, it
-                    # can point at any ordinary dev branch that has the sync commit.
-                    - script: |
-                        releasego get-target-branch \
-                          -version '${{ parameters.releaseVersion }}' \
-                          -set-azdo-variable-branch-name UpstreamTargetBranchName
-                      displayName: Get target branch containing commit
-                    - script: |
-                        releasego build-pipeline \
-                          -commit '$(poll2MicrosoftGoCommitHash)' \
-                          -branch '$(BuildPipelineFullBranchName)' \
-                          -id '$(GoPipelineID)' \
-                          -org 'https://dev.azure.com/dnceng/' \
-                          -proj 'internal' \
-                          -azdopat '$(System.AccessToken)' \
-                          -set-azdo-variable poll3MicrosoftGoBuildID \
-                          p releaseVersion '${{ parameters.releaseVersion }}' \
-                          pOptional publishReleaseStudio true
-                      displayName: 🚀 Run microsoft/go internal build
-                    - template: ../steps/report.yml
+                        - template: /eng/pipelines/steps/release-build-steps.yml@self
+                          parameters:
+                            ${{ insert }}: ${{ parameters }}
+                            emptyPollNumber: 1
+                      - template: /eng/pipelines/steps/release-build-steps.yml@self
+                        parameters:
+                          ${{ insert }}: ${{ parameters }}
+                          emptyPollNumber: 2
+                    - template: /eng/pipelines/steps/release-build-steps.yml@self
                       parameters:
-                        releaseIssue: ${{ parameters.releaseIssue }}
-                        version: ${{ parameters.releaseVersion }}
-                        condition: succeeded()
-                        buildPipeline: microsoft-go
-                        buildID: $(poll3MicrosoftGoBuildID)
-                        buildStatus: '?'
-                        start: true
-                        reason: queued build
-                    # Above, we launched the official build. Now launch innerloop tests. We actually
-                    # don't poll this build here: it's a release pipeline, so it reports its own
-                    # status to the release issue. This also means it runs in parallel.
-                    - script: |
-                        releasego build-pipeline \
-                          -id '$(GoReleaseInnerloopPipelineID)' \
-                          -org 'https://dev.azure.com/dnceng/' \
-                          -proj 'internal' \
-                          -branch '$(Build.SourceBranch)' \
-                          -azdopat '$(System.AccessToken)' \
-                          -set-azdo-variable MicrosoftGoReleaseInnerloopBuildID \
-                          p releaseVersion '${{ parameters.releaseVersion }}' \
-                          p releaseIssue '${{ parameters.releaseIssue }}' \
-                          p microsoftGoCommitHash '$(poll2MicrosoftGoCommitHash)' \
-                          p goReleaseConfigVariableGroup '${{ parameters.goReleaseConfigVariableGroup }}'
-                      displayName: 🚀 Start microsoft-go-infra-release-innerloop
-                    - template: ../steps/report.yml
-                      parameters:
-                        releaseIssue: ${{ parameters.releaseIssue }}
-                        version: ${{ parameters.releaseVersion }}
-                        condition: succeeded()
-                        buildPipeline: microsoft-go-infra-release-innerloop
-                        buildID: $(MicrosoftGoReleaseInnerloopBuildID)
-                        buildStatus: '?'
-                        start: true
-                        reason: queued build
-
-                  # Now we have poll3MicrosoftGoBuildID
-                  - script: |
-                      releasego wait-build \
-                        -id '$(poll3MicrosoftGoBuildID)' \
-                        -org 'https://dev.azure.com/dnceng/' \
-                        -proj 'internal' \
-                        -azdopat '$(System.AccessToken)'
-                    displayName: ⌚ Wait for internal build
-                    timeoutInMinutes: 120
-                  - template: ../steps/report.yml
+                        ${{ insert }}: ${{ parameters }}
+                        emptyPollNumber: 3
+                  - template: /eng/pipelines/steps/release-build-steps.yml@self
                     parameters:
-                      releaseIssue: ${{ parameters.releaseIssue }}
-                      version: ${{ parameters.releaseVersion }}
-                      condition: succeeded()
-                      buildPipeline: microsoft-go
-                      buildID: $(poll3MicrosoftGoBuildID)
-                      buildStatus: Succeeded
-                      reason: completed internal build
-
-                  # Download build asset JSON from completed internal build to update go-images with.
-                  - task: DownloadPipelineArtifact@2
-                    displayName: Download Build Asset JSON
-                    inputs:
-                      source: specific
-                      artifact: BuildAssets
-                      project: internal
-                      pipeline: $(GoPipelineID)
-                      runVersion: specific
-                      runId: $(poll3MicrosoftGoBuildID)
-                      path: $(assetsDir)
-                  # Download built and signed binaries. These are already on blob storage, but steps in this
-                  # pipeline will publish a subset of these as GitHub Release attachments.
-                  - ${{ if eq(parameters.runGitHubRelease, true) }}:
-                    - task: DownloadPipelineArtifact@2
-                      displayName: Download binaries
-                      inputs:
-                        source: specific
-                        artifact: Binaries Signed
-                        project: internal
-                        pipeline: $(GoPipelineID)
-                        runVersion: specific
-                        runId: $(poll3MicrosoftGoBuildID)
-                        path: $(artifactsDir)
-
-                  - script: |
-                      releasego get-asset-version \
-                        -build-asset-json '$(buildAssetJsonFile)' \
-                        -version '${{ parameters.releaseVersion }}' \
-                        -set-azdo-variable 'buildAssetVersion'
-                    displayName: Read and verify build asset version
-
-                  - script: |
-                      releasego get-build-info \
-                        -id '$(poll3MicrosoftGoBuildID)' \
-                        -org 'https://dev.azure.com/dnceng/' \
-                        -proj 'internal' \
-                        -prefix 'BuildInfo' \
-                        -azdopat '$(System.AccessToken)'
-                    displayName: Get build info
-
-                  - ${{ if eq(parameters.runTag, true) }}:
-                    - script: |
-                        releasego tag \
-                          -tag 'v$(buildAssetVersion)' \
-                          -commit '$(BuildInfoSourceVersion)' \
-                          -repo '$(TargetGitHubRepo)' \
-                          -pat '$(GitHubPAT)'
-                      displayName: 🎓 Create GitHub tag
-
-                  - ${{ if eq(parameters.runGitHubRelease, true) }}:
-                    - script: |
-                        releasego repo-release \
-                          -tag 'v$(buildAssetVersion)' \
-                          -repo '$(TargetGitHubRepo)' \
-                          -build-asset-json '$(buildAssetJsonFile)' \
-                          -build-dir '$(artifactsDir)' \
-                          -pat '$(GitHubPAT)'
-                      displayName: 🎓 Create GitHub release
-
-                  - ${{ if eq(parameters.runAkaMSUpdate, true) }}:
-                    - task: AzureCLI@2
-                      displayName: 🎓 Update aka.ms links
-                      inputs:
-                        azureSubscription: 'DotNet-Engineering-Services_KeyVault'
-                        scriptType: 'bash'
-                        scriptLocation: 'inlineScript'
-                        inlineScript: |
-                          # Get Azure Key Vault's JSON cert wrapper as an intermediate file in temp.
-                          # Based on Arcade: https://github.com/dotnet/arcade/blob/7507f80c8db285bbc9939c1dff522a761cf4edc0/eng/publishing/v3/publish.yml#L125-L132
-                          az keyvault secret show --vault-name EngKeyVault --name Redirection-UST-Client-NetCoreDeployment > $(Agent.TempDirectory)/akamsclientcert.json
-
-                          # Pass the manifest file path only if a file exists there. It is only
-                          # present if the assets.json file was published via Release Studio.
-                          manifestFile=
-                          if [ -f "$(publishManifestFile)" ]; then
-                            manifestFile="$(publishManifestFile)"
-                          fi
-
-                          releasego akams \
-                            -build-asset-json '$(buildAssetJsonFile)' \
-                            -build-asset-json-publish-manifest="$manifestFile" \
-                            -prefix '$(VanityUrlPrefix)' \
-                            -clientID '$(akams-client-id)' \
-                            -clientCertVaultFile '$(Agent.TempDirectory)/akamsclientcert.json' \
-                            -tenant '$(AkaMSTenant)' \
-                            -createdBy '$(AkaMSCreatedBy)' \
-                            -groupOwner '$(AkaMSGroupOwner)' \
-                            -owners '$(AkaMSOwners)'
-
-                  - ${{ if eq(parameters.runGoImagesUpdate, true) }}:
-                    # Update the target Docker repo. The origin is defined with "_" as the username because
-                    # the username doesn't matter, only the PAT. $(GitHubPAT) may be some other user's: it is
-                    # provided by the variable group.
-                    - script: |
-                        set -euxo pipefail
-                        # Install jq, used to evaluate Dockerfile templates.
-                        sudo apt update && sudo apt install -y jq
-
-                        go run ./cmd/dockerupdatepr \
-                          -origin 'https://_:$(GitHubPAT)@github.com/$(TargetGoImagesGitHubRepo)' \
-                          -github-pat '$(GitHubPAT)' \
-                          -github-pat-reviewer '$(GitHubPATReviewer)' \
-                          -build-asset-json '$(buildAssetJsonFile)' \
-                          -manual-branch '$(TargetGoImagesBranch)' \
-                          -set-azdo-variable-pr-number poll4MicrosoftGoImagesPRNumber
-                      displayName: Update go-images
-
-                - ${{ if eq(parameters.runGoImagesUpdate, true) }}:
-                  # Now we have poll4MicrosoftGoImagesPRNumber, which may be nil if no PR is required
-                  - script: |
-                      releasego get-merged-pr-commit \
-                        -repo '$(TargetGoImagesGitHubRepo)' \
-                        -pr '$(poll4MicrosoftGoImagesPRNumber)' \
-                        -pat '$(GitHubPAT)'
-                    displayName: ⌚ Wait for go-images update PR merge
-                    timeoutInMinutes: 120
-                    # Skip this task if the PR number isn't set. This might intentionally happen if we have to
-                    # release a new binary/source revision of an out-of-support version of Go, and we don't
-                    # still support Docker images for that version.
-                    condition: and(succeeded(), ne(variables.poll4MicrosoftGoImagesPRNumber, 'nil'))
+                      ${{ insert }}: ${{ parameters }}
+                      emptyPollNumber: 4
+                - template: /eng/pipelines/steps/release-build-steps.yml@self
+                  parameters:
+                    ${{ insert }}: ${{ parameters }}
+                    emptyPollNumber: -1

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -1,0 +1,281 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+parameters:
+  # The number of the pollX{...} variable that is empty (nil) at this point in the build and should
+  # be filled in. -1 indicates that no more retryable polls remain, only finishing touches.
+  emptyPollNumber: unspecified
+
+steps:
+  - ${{ if eq(parameters.emptyPollNumber, 1) }}:
+
+    # Poll for the right commit to use for this release.
+    - script: |
+        releasego get-upstream-commit \
+          -version '${{ parameters.releaseVersion }}' \
+          -set-azdo-variable upstreamReleasedCommit
+      displayName: ⌚ Get upstream commit for release
+      # 6 hours. This step may take an arbitrarily long time while if we ran the release
+      # job preemptively. But at some point, a dev needs to check that the tool is working
+      # properly and the upstream release is progressing as expected.
+      timeoutInMinutes: 360
+    # Either make sure the microsoft/go branch has the correct commit as its submodule, or
+    # submit a PR that sets the submodule commit.
+    - script: |
+        releasego sync \
+          -c '$(ReleaseSyncConfigPath)' \
+          -commit '$(upstreamReleasedCommit)' \
+          -version '${{ parameters.releaseVersion }}' \
+          -git-auth pat \
+          -github-user '$(GitHubUser)' \
+          -github-pat '$(GitHubPAT)' \
+          -github-pat-reviewer '$(GitHubPATReviewer)' \
+          -azdo-dnceng-pat '$(AzDODncengPAT)' \
+          -create-branches \
+          -set-azdo-variable-pr-number poll1MicrosoftGoPRNumber \
+          -set-azdo-variable-up-to-date-commit poll2MicrosoftGoCommitHash
+      displayName: Sync to upstream commit
+
+  - ${{ elseif eq(parameters.emptyPollNumber, 2) }}:
+
+    # Now we have poll1MicrosoftGoPRNumber, but it may be nil if no PR is required.
+    - script: |
+        releasego get-merged-pr-commit \
+          -repo '$(TargetGitHubRepo)' \
+          -pr '$(poll1MicrosoftGoPRNumber)' \
+          -pat '$(GitHubPAT)' \
+          -set-azdo-variable poll2MicrosoftGoCommitHash
+      displayName: ⌚ Get sync PR merged commit hash
+      timeoutInMinutes: 60
+      # If no PR is required, then poll2MicrosoftGoCommitHash is already set and we can move on.
+      condition: and(succeeded(), ne(variables.poll1MicrosoftGoPRNumber, 'nil'))
+
+  - ${{ elseif eq(parameters.emptyPollNumber, 3) }}:
+
+    # Now we have poll2MicrosoftGoCommitHash
+    - script: |
+        releasego wait-azdo-commit \
+          -commit '$(poll2MicrosoftGoCommitHash)' \
+          -name '$(TargetAzDORepo)' \
+          -org 'https://dev.azure.com/dnceng/' \
+          -proj 'internal' \
+          -azdopat '$(System.AccessToken)'
+      displayName: ⌚ Wait for internal mirror
+      timeoutInMinutes: 15 # This should be very quick, and a dev can easily fix it.
+
+    # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
+    # default Branch is "microsoft/main". So, we need to figure out the release branch name
+    # and save it as a variable to pass it to AzDO.
+    #
+    # Testing adds a complication: testing commits won't be found in the actual release
+    # branches, so we need a way to override. This is done using BuildPipelineFullBranchName
+    # from the variable group. For actual releases, it should have the value
+    # "refs/heads/microsoft/$(UpstreamTargetBranchName)". But in a testing variable group, it
+    # can point at any ordinary dev branch that has the sync commit.
+    - script: |
+        releasego get-target-branch \
+          -version '${{ parameters.releaseVersion }}' \
+          -set-azdo-variable-branch-name UpstreamTargetBranchName
+      displayName: Get target branch containing commit
+
+    - script: |
+        releasego build-pipeline \
+          -commit '$(poll2MicrosoftGoCommitHash)' \
+          -branch '$(BuildPipelineFullBranchName)' \
+          -id '$(GoPipelineID)' \
+          -org 'https://dev.azure.com/dnceng/' \
+          -proj 'internal' \
+          -azdopat '$(System.AccessToken)' \
+          -set-azdo-variable poll3MicrosoftGoBuildID \
+          p releaseVersion '${{ parameters.releaseVersion }}' \
+          pOptional publishReleaseStudio true
+      displayName: 🚀 Run microsoft/go internal build
+
+    - template: ../steps/report.yml
+      parameters:
+        releaseIssue: ${{ parameters.releaseIssue }}
+        version: ${{ parameters.releaseVersion }}
+        condition: succeeded()
+        buildPipeline: microsoft-go
+        buildID: $(poll3MicrosoftGoBuildID)
+        buildStatus: '?'
+        start: true
+        reason: queued build
+
+    # Above, we launched the official build. Now launch innerloop tests. We actually
+    # don't poll this build here: it's a release pipeline, so it reports its own
+    # status to the release issue. This also means it runs in parallel.
+    - script: |
+        releasego build-pipeline \
+          -id '$(GoReleaseInnerloopPipelineID)' \
+          -org 'https://dev.azure.com/dnceng/' \
+          -proj 'internal' \
+          -branch '$(Build.SourceBranch)' \
+          -azdopat '$(System.AccessToken)' \
+          -set-azdo-variable MicrosoftGoReleaseInnerloopBuildID \
+          p releaseVersion '${{ parameters.releaseVersion }}' \
+          p releaseIssue '${{ parameters.releaseIssue }}' \
+          p microsoftGoCommitHash '$(poll2MicrosoftGoCommitHash)' \
+          p goReleaseConfigVariableGroup '${{ parameters.goReleaseConfigVariableGroup }}'
+      displayName: 🚀 Start microsoft-go-infra-release-innerloop
+
+    - template: ../steps/report.yml
+      parameters:
+        releaseIssue: ${{ parameters.releaseIssue }}
+        version: ${{ parameters.releaseVersion }}
+        condition: succeeded()
+        buildPipeline: microsoft-go-infra-release-innerloop
+        buildID: $(MicrosoftGoReleaseInnerloopBuildID)
+        buildStatus: '?'
+        start: true
+        reason: queued build
+
+  - ${{ elseif eq(parameters.emptyPollNumber, 4) }}:
+
+    # Now we have poll3MicrosoftGoBuildID
+    - script: |
+        releasego wait-build \
+          -id '$(poll3MicrosoftGoBuildID)' \
+          -org 'https://dev.azure.com/dnceng/' \
+          -proj 'internal' \
+          -azdopat '$(System.AccessToken)'
+      displayName: ⌚ Wait for internal build
+      timeoutInMinutes: 120
+
+    - template: ../steps/report.yml
+      parameters:
+        releaseIssue: ${{ parameters.releaseIssue }}
+        version: ${{ parameters.releaseVersion }}
+        condition: succeeded()
+        buildPipeline: microsoft-go
+        buildID: $(poll3MicrosoftGoBuildID)
+        buildStatus: Succeeded
+        reason: completed internal build
+
+    # Download build asset JSON from completed internal build to update go-images with.
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Build Asset JSON
+      inputs:
+        source: specific
+        artifact: BuildAssets
+        project: internal
+        pipeline: $(GoPipelineID)
+        runVersion: specific
+        runId: $(poll3MicrosoftGoBuildID)
+        path: $(assetsDir)
+
+    # Download built and signed binaries. These are already on blob storage, but steps in this
+    # pipeline will publish a subset of these as GitHub Release attachments.
+    - ${{ if eq(parameters.runGitHubRelease, true) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download binaries
+        inputs:
+          source: specific
+          artifact: Binaries Signed
+          project: internal
+          pipeline: $(GoPipelineID)
+          runVersion: specific
+          runId: $(poll3MicrosoftGoBuildID)
+          path: $(artifactsDir)
+
+    - script: |
+        releasego get-asset-version \
+          -build-asset-json '$(buildAssetJsonFile)' \
+          -version '${{ parameters.releaseVersion }}' \
+          -set-azdo-variable 'buildAssetVersion'
+      displayName: Read and verify build asset version
+
+    - script: |
+        releasego get-build-info \
+          -id '$(poll3MicrosoftGoBuildID)' \
+          -org 'https://dev.azure.com/dnceng/' \
+          -proj 'internal' \
+          -prefix 'BuildInfo' \
+          -azdopat '$(System.AccessToken)'
+      displayName: Get build info
+
+    - ${{ if eq(parameters.runTag, true) }}:
+      - script: |
+          releasego tag \
+            -tag 'v$(buildAssetVersion)' \
+            -commit '$(BuildInfoSourceVersion)' \
+            -repo '$(TargetGitHubRepo)' \
+            -pat '$(GitHubPAT)'
+        displayName: 🎓 Create GitHub tag
+
+    - ${{ if eq(parameters.runGitHubRelease, true) }}:
+      - script: |
+          releasego repo-release \
+            -tag 'v$(buildAssetVersion)' \
+            -repo '$(TargetGitHubRepo)' \
+            -build-asset-json '$(buildAssetJsonFile)' \
+            -build-dir '$(artifactsDir)' \
+            -pat '$(GitHubPAT)'
+        displayName: 🎓 Create GitHub release
+
+    - ${{ if eq(parameters.runAkaMSUpdate, true) }}:
+      - task: AzureCLI@2
+        displayName: 🎓 Update aka.ms links
+        inputs:
+          azureSubscription: 'DotNet-Engineering-Services_KeyVault'
+          scriptType: 'bash'
+          scriptLocation: 'inlineScript'
+          inlineScript: |
+            # Get Azure Key Vault's JSON cert wrapper as an intermediate file in temp.
+            # Based on Arcade: https://github.com/dotnet/arcade/blob/7507f80c8db285bbc9939c1dff522a761cf4edc0/eng/publishing/v3/publish.yml#L125-L132
+            az keyvault secret show --vault-name EngKeyVault --name Redirection-UST-Client-NetCoreDeployment > $(Agent.TempDirectory)/akamsclientcert.json
+
+            # Pass the manifest file path only if a file exists there. It is only
+            # present if the assets.json file was published via Release Studio.
+            manifestFile=
+            if [ -f "$(publishManifestFile)" ]; then
+              manifestFile="$(publishManifestFile)"
+            fi
+
+            releasego akams \
+              -build-asset-json '$(buildAssetJsonFile)' \
+              -build-asset-json-publish-manifest="$manifestFile" \
+              -prefix '$(VanityUrlPrefix)' \
+              -clientID '$(akams-client-id)' \
+              -clientCertVaultFile '$(Agent.TempDirectory)/akamsclientcert.json' \
+              -tenant '$(AkaMSTenant)' \
+              -createdBy '$(AkaMSCreatedBy)' \
+              -groupOwner '$(AkaMSGroupOwner)' \
+              -owners '$(AkaMSOwners)'
+
+    - ${{ if eq(parameters.runGoImagesUpdate, true) }}:
+      # Update the target Docker repo. The origin is defined with "_" as the username because
+      # the username doesn't matter, only the PAT. $(GitHubPAT) may be some other user's: it is
+      # provided by the variable group.
+      - script: |
+          set -euxo pipefail
+          # Install jq, used to evaluate Dockerfile templates.
+          sudo apt update && sudo apt install -y jq
+
+          go run ./cmd/dockerupdatepr \
+            -origin 'https://_:$(GitHubPAT)@github.com/$(TargetGoImagesGitHubRepo)' \
+            -github-pat '$(GitHubPAT)' \
+            -github-pat-reviewer '$(GitHubPATReviewer)' \
+            -build-asset-json '$(buildAssetJsonFile)' \
+            -manual-branch '$(TargetGoImagesBranch)' \
+            -set-azdo-variable-pr-number poll4MicrosoftGoImagesPRNumber
+        displayName: Update go-images
+
+  - ${{ elseif eq(parameters.emptyPollNumber, -1) }}:
+
+    - ${{ if eq(parameters.runGoImagesUpdate, true) }}:
+      # Now we have poll4MicrosoftGoImagesPRNumber, which may be nil if no PR is required
+      - script: |
+          releasego get-merged-pr-commit \
+            -repo '$(TargetGoImagesGitHubRepo)' \
+            -pr '$(poll4MicrosoftGoImagesPRNumber)' \
+            -pat '$(GitHubPAT)'
+        displayName: ⌚ Wait for go-images update PR merge
+        timeoutInMinutes: 120
+        # Skip this task if the PR number isn't set. This might intentionally happen if we have to
+        # release a new binary/source revision of an out-of-support version of Go, and we don't
+        # still support Docker images for that version.
+        condition: and(succeeded(), ne(variables.poll4MicrosoftGoImagesPRNumber, 'nil'))
+
+  - ${{ else }}:
+    - "Invalid emptyPollNumber ${{ parameters.emptyPollNumber }}": error


### PR DESCRIPTION
The deep nesting in eng/pipelines/release-build-pipeline.yml has always been a readability issue and makes it a lot harder to add steps to these pipelines than it should be. This PR is an attempt to fix these problems by minimizing the amount of deeply nested AzDO yaml code, allowing for the actual steps to be defined in a reasonable way.

Inspired by the classic eyebrow-raising `for i := 0; i < 10; i++ { switch(i) { ... } }`. 😄 It seems to me that the AzDO yaml lang's limitations make it difficult to do something any better while using multiple `step`s. (`step`s are nice for browsing in the AzDO UI, so there is a reason to keep using them.)

Check out the pipeline file outside of diff view to make the pattern clearer: https://github.com/microsoft/go-infra/blob/dev/dagood/unindent-release-steps/eng/pipelines/release-build-pipeline.yml#L107-L136

I originally started this as part of https://github.com/microsoft/go-lab/blob/main/docs/adr/0003-use-ddfun-for-akams.md, but realized it would be better to do this refactor in its own PR first. This way I can add new steps without modifying the indentation of all the preceding steps. I need to add at least one more new `poll*` parameter to move publish over to go-infra, which would be much more disruptive in the current arrangement.

If this pattern looks reasonable, we should apply it to the other pipelines with `poll*` parameters too.

May be difficult to review. Git doesn't track moving identical chunks between files in a nice way for us. I've double checked that the steps are the same by copying them over once again and seeing if Git shows any differences: https://gist.github.com/dagood/4c00604d3e9e9ca70f1f7ab393bc031d. The diff is in a way, inverted: it shows that I just added a few newlines and slightly clarified and deduped a comment.

Example test builds:
* Test 1.23.1-1 upstream tag polling. 1.23.1-1 doesn't exist yet, so polled until canceled. Shows that the steps are laid out as expected: https://dev.azure.com/dnceng/internal/_build/results?buildId=2522732&view=results
* Test starting at poll3MicrosoftGoBuildID and with only aka.ms update selected (including /dev/ element): https://dev.azure.com/dnceng/internal/_build/results?buildId=2522717&view=results