### PR TITLE
Add Azure Linux updating pipeline

### DIFF
--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -66,7 +66,7 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 		return err
 	}
 
-	if updateBranch == "" {
+	if updateBranch == "nil" || updateBranch == "" {
 		updateBranch = generateUpdateBranchNameFromAssets(assets)
 	}
 

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -29,5 +29,5 @@ Internal release pipelines (see [release process docs](/docs/release-process)):
   * 🚀 internal [`microsoft-go-infra-release-go-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1151)
 * (4) [`release-innerloop-pipeline.yml`](release-innerloop-pipeline.yml)
   * 🚀 internal [`microsoft-go-infra-release-innerloop`](https://dev.azure.com/dnceng/internal/_build?definitionId=1348)
-* (5) [`update-azure-linux-pipeline.yml](update-azure-linux-pipeline.yml)
+* (5) [`update-azure-linux-pipeline.yml`](update-azure-linux-pipeline.yml)
   * 🚀 internal [`microsoft-go-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -30,4 +30,4 @@ Internal release pipelines (see [release process docs](/docs/release-process)):
 * (4) [`release-innerloop-pipeline.yml`](release-innerloop-pipeline.yml)
   * 🚀 internal [`microsoft-go-infra-release-innerloop`](https://dev.azure.com/dnceng/internal/_build?definitionId=1348)
 * (5) [`update-azure-linux-pipeline.yml`](update-azure-linux-pipeline.yml)
-  * 🚀 internal [`microsoft-go-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)
+  * 🚀 internal [`microsoft-go--infra-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -30,4 +30,4 @@ Internal release pipelines (see [release process docs](/docs/release-process)):
 * (4) [`release-innerloop-pipeline.yml`](release-innerloop-pipeline.yml)
   * 🚀 internal [`microsoft-go-infra-release-innerloop`](https://dev.azure.com/dnceng/internal/_build?definitionId=1348)
 * (5) [`update-azure-linux-pipeline.yml`](update-azure-linux-pipeline.yml)
-  * 🚀 internal [`microsoft-go--infra-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)
+  * 🚀 internal [`microsoft-go-infra-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -29,3 +29,5 @@ Internal release pipelines (see [release process docs](/docs/release-process)):
   * 🚀 internal [`microsoft-go-infra-release-go-images`](https://dev.azure.com/dnceng/internal/_build?definitionId=1151)
 * (4) [`release-innerloop-pipeline.yml`](release-innerloop-pipeline.yml)
   * 🚀 internal [`microsoft-go-infra-release-innerloop`](https://dev.azure.com/dnceng/internal/_build?definitionId=1348)
+* (5) [`update-azure-linux-pipeline.yml](update-azure-linux-pipeline.yml)
+  * 🚀 internal [`microsoft-go-update-azure-linux`](https://dev.azure.com/dnceng/internal/_build?definitionId=1405)

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -83,10 +83,10 @@ extends:
                 - ${{ if eq(parameters.runCreatePullRequest, true) }}:
                   - script: |
                       releasego update-azure-linux \
-                        -pat '$(GitHubPAT)'
-                        -build-asset-json '$(buildAssetJsonFile)'
-                        -owner '$(owner)'
-                        -repo '$(repo)'
-                        -update-branch '$(updateBranch)'
+                        -pat '$(GitHubPAT)' \
+                        -build-asset-json $(buildAssetJsonFile) \
+                        -owner ${{ parameters.owner }} \
+                        -repo ${{ parameters.repo }} \
+                        -update-branch ${{ parameters.updateBranch }}
                     displayName: Create Pull Request to Update Azure Linux Specfiles
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -24,6 +24,10 @@ parameters:
     displayName: '[Use "go-release-config" for a real release] Variable group that specifies release target locations and auth.'
     type: string
 
+  - name: pipelineBuildID
+    displayName: 'The ID of the microsoft-go build pipeline that triggered this pipeline.'
+    type: string
+    default: '2516760' # TODO: Remove default value
 trigger: none
 pr: none
 
@@ -78,12 +82,22 @@ extends:
                 # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
                 # retry build will have a non-nil value in one of these parameters. Only the value of the last
                 # step's parameter matters.
-                - download: build
-                  artifact: BuildAssets
+                # Download build asset JSON from completed internal build to update Azure Linux specfiles with. 
+                - task: DownloadPipelineArtifact@2 
+                  displayName: Download Build Asset JSON 
+                  inputs: 
+                    source: specific 
+                    artifact: BuildAssets 
+                    project: internal 
+                    pipeline: $(GoPipelineID) 
+                    runVersion: specific 
+                    runId: $(parameters.pipelineBuildID) 
+                    path: $(assetJsonPath) 
 
                 - ${{ if eq(parameters.runCreatePullRequest, true) }}:
                   - script: |
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)'
+                        -build-asset-json '$(assetJsonPath)'
                     displayName: 📰 Publish announcement details
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -91,7 +91,7 @@ extends:
                     project: internal 
                     pipeline: $(GoPipelineID) 
                     runVersion: specific 
-                    runId: $(parameters.pipelineBuildID) 
+                    runId: ${{ parameters.pipelineBuildID }}
                     path: $(assetJsonPath) 
 
                 - ${{ if eq(parameters.runCreatePullRequest, true) }}:

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -3,15 +3,6 @@
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
-  # If someone's manually queueing this build, let them skip the approval stage. It takes time to
-  # acquire a serverless agent to present the approval step, so the dev has to pay attention and
-  # catch it. Instead, let them approve it ahead of time by skipping it. The default is always used
-  # by automation, so this is only used for dev builds and retries.
-  - name: approveAheadOfTime
-    displayName: Approve right now, skipping the approval stage.
-    type: boolean
-    default: false
-
   # Allow disabling specific parts of the internal build release. These can be used to re-run
   # specific parts of a release if necessary, e.g. if a step silently failed.
   - name: runCreatePullRequest
@@ -57,19 +48,18 @@ extends:
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
-      - ${{ if eq(parameters.approveAheadOfTime, false) }}:
-        - stage: WaitForApproval
-          jobs:
-            - job: Approve
-              pool: server
-              timeoutInMinutes: 1440 # 1 day
-              steps:
-                - task: ManualValidation@0
-                  inputs:
-                    instructions: >
-                      Once the microsoft/go build is complete, approve this step to automatically update 
-                      the Azure Linux specfiles and create a pull request.
-                    onTimeout: 'reject'
+      - stage: WaitForApproval
+        jobs:
+          - job: Approve
+            pool: server
+            timeoutInMinutes: 1440 # 1 day
+            steps:
+              - task: ManualValidation@0
+                inputs:
+                  instructions: >
+                    Once the microsoft/go build is complete, approve this step to automatically update 
+                    the Azure Linux specfiles and create a pull request.
+                  onTimeout: 'reject'
 
       - stage: Release
         jobs:
@@ -97,5 +87,5 @@ extends:
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)'
                         -build-asset-json '$(buildAssetJsonFile)'
-                    displayName: 📰 Publish announcement details
+                    displayName: Create Pull Request to Update Azure Linux Specfiles
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -19,6 +19,21 @@ parameters:
     displayName: 'The ID of the microsoft-go build pipeline that triggered this pipeline.'
     type: string
 
+  - name: owner
+    displayName: 'GitHub repository owner'
+    type: string
+    default: 'microsoft'
+
+  - name: repo
+    displayName: 'GitHub repository name'
+    type: string
+    default: 'azurelinux'
+
+  - name: updateBranch
+    displayName: 'Branch to update'
+    type: string
+    default: ''
+
 trigger: none
 pr: none
 
@@ -70,5 +85,8 @@ extends:
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)'
                         -build-asset-json '$(buildAssetJsonFile)'
+                        -owner '$(owner)'
+                        -repo '$(repo)'
+                        -update-branch '$(updateBranch)'
                     displayName: Create Pull Request to Update Azure Linux Specfiles
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -65,7 +65,6 @@ extends:
         jobs:
           - template: /eng/pipelines/jobs/releasego.yml@self
             parameters:
-              retryInstructionsFlags: '-preapproval'
               steps:
                 # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
                 # retry build will have a non-nil value in one of these parameters. Only the value of the last

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -27,7 +27,7 @@ parameters:
   - name: pipelineBuildID
     displayName: 'The ID of the microsoft-go build pipeline that triggered this pipeline.'
     type: string
-    default: '2516760' # TODO: Remove default value
+    default: '2515771' # TODO: Remove default value
 trigger: none
 pr: none
 
@@ -35,8 +35,6 @@ variables:
   - group: Microsoft-GoLang-bot
   # Import config group. This may direct the build to use secrets from the other groups.
   - group: ${{ parameters.goReleaseConfigVariableGroup }}
-  - name: assetJsonPath
-    value: $(Pipeline.Workspace)/build/BuildAssets/assets.json
 resources:
   repositories:
     - repository: 1ESPipelineTemplates
@@ -98,6 +96,6 @@ extends:
                   - script: |
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)'
-                        -build-asset-json '$(assetJsonPath)'
+                        -build-asset-json '$(buildAssetJsonFile)'
                     displayName: 📰 Publish announcement details
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -48,27 +48,11 @@ extends:
         configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
 
     stages:
-      - stage: WaitForApproval
-        jobs:
-          - job: Approve
-            pool: server
-            timeoutInMinutes: 1440 # 1 day
-            steps:
-              - task: ManualValidation@0
-                inputs:
-                  instructions: >
-                    Once the microsoft/go build is complete, approve this step to automatically update 
-                    the Azure Linux specfiles and create a pull request.
-                  onTimeout: 'reject'
-
       - stage: Release
         jobs:
           - template: /eng/pipelines/jobs/releasego.yml@self
             parameters:
               steps:
-                # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
-                # retry build will have a non-nil value in one of these parameters. Only the value of the last
-                # step's parameter matters.
                 # Download build asset JSON from completed internal build to update Azure Linux specfiles with. 
                 - task: DownloadPipelineArtifact@2 
                   displayName: Download Build Asset JSON 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -3,13 +3,6 @@
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:
-  - name: releaseVersions
-    displayName: >
-      List of versions to release. Include Microsoft revision suffix (-1) and boring/FIPS suffix
-      (-fips) if they apply. Write in YAML format: write one version number per line with '-' and a
-      space at the beginning of each line.
-    type: object
-
   # If someone's manually queueing this build, let them skip the approval stage. It takes time to
   # acquire a serverless agent to present the approval step, so the dev has to pay attention and
   # catch it. Instead, let them approve it ahead of time by skipping it. The default is always used
@@ -21,16 +14,8 @@ parameters:
 
   # Allow disabling specific parts of the internal build release. These can be used to re-run
   # specific parts of a release if necessary, e.g. if a step silently failed.
-  - name: runMirrorPipeline
-    displayName: Remotely trigger mirror pipeline
-    type: boolean
-    default: true
   - name: runCreatePullRequest
     displayName: Create Pull Request on Azure Linux repo
-    type: boolean
-    default: true
-  - name: runBuddyBuildPipeline
-    displayName: Remotely trigger buddy build pipeline
     type: boolean
     default: true
 
@@ -46,8 +31,6 @@ variables:
   - group: Microsoft-GoLang-bot
   # Import config group. This may direct the build to use secrets from the other groups.
   - group: ${{ parameters.goReleaseConfigVariableGroup }}
-  - name: SourceTarballPublishingPipelineID
-    value: '2284'
   - name: assetJsonPath
     value: $(Pipeline.Workspace)/build/BuildAssets/assets.json
 resources:
@@ -98,48 +81,9 @@ extends:
                 - download: build
                   artifact: BuildAssets
 
-                - ${{ if eq(parameters.runMirrorPipeline, true) }}:
-                  - script: |
-                      releasego build-pipeline \
-                        -id '$(SourceTarballPublishingPipelineID)' \
-                        -org 'https://dev.azure.com/mariner-org/' \
-                        -proj 'mariner' \
-                        -azdopat '$(System.AccessToken)' \
-                        -set-azdo-variable poll2SourceTarballPublishingBuildID \
-                        p fileName
-                        p tarballUrl
-                        # TODO
-                    displayName: 🚀 Start go-images build/publish
-                  - template: ../steps/report.yml
-                    parameters:
-                      releaseIssueß: ${{ parameters.releaseIssue }}
-                      condition: succeeded()
-                      buildPipeline: Source Tarball Publishing
-                      buildID: $(poll2SourceTarballPublishingBuildID)
-                      buildStatus: '?'
-                      start: true
-                      reason: queued build
-                  # Now we have poll2SourceTarballPublishingBuildID
-                  - script: |
-                      releasego wait-build \
-                        -id '$(poll2SourceTarballPublishingBuildID)' \
-                        -org 'https://dev.azure.com/mariner-org/' \
-                        -proj 'mariner' \
-                        -azdopat '$(System.AccessToken)'
-                    displayName: ⌚ Wait for Azure Linux Source Tarball Publishing
-                    timeoutInMinutes: 120
-
                 - ${{ if eq(parameters.runCreatePullRequest, true) }}:
                   - script: |
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)'
                     displayName: 📰 Publish announcement details
 
-                - template: ../steps/report.yml
-                  parameters:
-                    releaseIssue: ${{ parameters.releaseIssue }}
-                    condition: succeeded()
-                    buildPipeline: Source Tarball Publishing
-                    buildID: $(poll2SourceTarballPublishingBuildID)
-                    buildStatus: Succeeded
-                    reason: completed internal build

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -18,7 +18,7 @@ parameters:
   - name: pipelineBuildID
     displayName: 'The ID of the microsoft-go build pipeline that triggered this pipeline.'
     type: string
-    default: '2515771' # TODO: Remove default value
+
 trigger: none
 pr: none
 

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -1,0 +1,145 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
+parameters:
+  - name: releaseVersions
+    displayName: >
+      List of versions to release. Include Microsoft revision suffix (-1) and boring/FIPS suffix
+      (-fips) if they apply. Write in YAML format: write one version number per line with '-' and a
+      space at the beginning of each line.
+    type: object
+
+  # If someone's manually queueing this build, let them skip the approval stage. It takes time to
+  # acquire a serverless agent to present the approval step, so the dev has to pay attention and
+  # catch it. Instead, let them approve it ahead of time by skipping it. The default is always used
+  # by automation, so this is only used for dev builds and retries.
+  - name: approveAheadOfTime
+    displayName: Approve right now, skipping the approval stage.
+    type: boolean
+    default: false
+
+  # Allow disabling specific parts of the internal build release. These can be used to re-run
+  # specific parts of a release if necessary, e.g. if a step silently failed.
+  - name: runMirrorPipeline
+    displayName: Remotely trigger mirror pipeline
+    type: boolean
+    default: true
+  - name: runCreatePullRequest
+    displayName: Create Pull Request on Azure Linux repo
+    type: boolean
+    default: true
+  - name: runBuddyBuildPipeline
+    displayName: Remotely trigger buddy build pipeline
+    type: boolean
+    default: true
+
+  # This parameter intentionally has no default: see release-go-pipeline.yml
+  - name: goReleaseConfigVariableGroup
+    displayName: '[Use "go-release-config" for a real release] Variable group that specifies release target locations and auth.'
+    type: string
+
+trigger: none
+pr: none
+
+variables:
+  - group: Microsoft-GoLang-bot
+  # Import config group. This may direct the build to use secrets from the other groups.
+  - group: ${{ parameters.goReleaseConfigVariableGroup }}
+  - name: SourceTarballPublishingPipelineID
+    value: '2284'
+  - name: assetJsonPath
+    value: $(Pipeline.Workspace)/build/BuildAssets/assets.json
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-ubuntu-2004
+        os: linux
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
+
+    stages:
+      - ${{ if eq(parameters.approveAheadOfTime, false) }}:
+        - stage: WaitForApproval
+          jobs:
+            - job: Approve
+              pool: server
+              timeoutInMinutes: 1440 # 1 day
+              steps:
+                - task: ManualValidation@0
+                  inputs:
+                    instructions: >
+                      Once the microsoft/go build is complete, approve this step to automatically update 
+                      the Azure Linux specfiles and create a pull request.
+                    onTimeout: 'reject'
+
+      - stage: Release
+        jobs:
+          - template: /eng/pipelines/jobs/releasego.yml@self
+            parameters:
+              retryInstructionsFlags: '-preapproval'
+              steps:
+                # Resume the build at the furthest step based on the inputs. A fresh build has all 'nil', a
+                # retry build will have a non-nil value in one of these parameters. Only the value of the last
+                # step's parameter matters.
+                - download: build
+                  artifact: BuildAssets
+
+                - ${{ if eq(parameters.runMirrorPipeline, true) }}:
+                  - script: |
+                      releasego build-pipeline \
+                        -id '$(SourceTarballPublishingPipelineID)' \
+                        -org 'https://dev.azure.com/mariner-org/' \
+                        -proj 'mariner' \
+                        -azdopat '$(System.AccessToken)' \
+                        -set-azdo-variable poll2SourceTarballPublishingBuildID \
+                        p fileName
+                        p tarballUrl
+                        # TODO
+                    displayName: 🚀 Start go-images build/publish
+                  - template: ../steps/report.yml
+                    parameters:
+                      releaseIssueß: ${{ parameters.releaseIssue }}
+                      condition: succeeded()
+                      buildPipeline: Source Tarball Publishing
+                      buildID: $(poll2SourceTarballPublishingBuildID)
+                      buildStatus: '?'
+                      start: true
+                      reason: queued build
+                  # Now we have poll2SourceTarballPublishingBuildID
+                  - script: |
+                      releasego wait-build \
+                        -id '$(poll2SourceTarballPublishingBuildID)' \
+                        -org 'https://dev.azure.com/mariner-org/' \
+                        -proj 'mariner' \
+                        -azdopat '$(System.AccessToken)'
+                    displayName: ⌚ Wait for Azure Linux Source Tarball Publishing
+                    timeoutInMinutes: 120
+
+                - ${{ if eq(parameters.runCreatePullRequest, true) }}:
+                  - script: |
+                      releasego update-azure-linux \
+                        -pat '$(GitHubPAT)'
+                    displayName: 📰 Publish announcement details
+
+                - template: ../steps/report.yml
+                  parameters:
+                    releaseIssue: ${{ parameters.releaseIssue }}
+                    condition: succeeded()
+                    buildPipeline: Source Tarball Publishing
+                    buildID: $(poll2SourceTarballPublishingBuildID)
+                    buildStatus: Succeeded
+                    reason: completed internal build

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -92,7 +92,7 @@ extends:
                     pipeline: $(GoPipelineID) 
                     runVersion: specific 
                     runId: ${{ parameters.pipelineBuildID }}
-                    path: $(assetJsonPath) 
+                    path: $(assetsDir)
 
                 - ${{ if eq(parameters.runCreatePullRequest, true) }}:
                   - script: |

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -32,7 +32,7 @@ parameters:
   - name: updateBranch
     displayName: 'Branch to update'
     type: string
-    default: ''
+    default: nil
 
 trigger: none
 pr: none


### PR DESCRIPTION
This PR adds a new azurelinux pipeline to the go-infra repository, enhancing CI/CD for Azure Linux environments.

Changes
- Added: new update-azure-linux pipeline for automatically opening a pull request on Azure Linux for updating spec files

Test Pipeline Run 
https://dev.azure.com/dnceng/internal/_build/results?buildId=2525925&view=results