### PR TITLE
fix:add missing comment field to update-azure-linux command

### DIFF
--- a/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
+++ b/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
@@ -23,6 +23,7 @@
       {
         "component": {
           "type": "other",
+          "comment": "This is a comment2",
           "other": {
             "name": "accountsservice",
             "version": "0.6.55",

--- a/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
+++ b/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
@@ -23,6 +23,7 @@
     {
       "component": {
         "type": "other",
+        "comment": "This is a comment2",
         "other": {
           "name": "accountsservice",
           "version": "0.6.55",

--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -364,8 +364,9 @@ type CGManifest struct {
 
 type Registration struct {
 	Component struct {
-		Type  string `json:"type"`
-		Other struct {
+		Type    string `json:"type"`
+		Comment string `json:"comment,omitempty"`
+		Other   struct {
 			Name        string `json:"name"`
 			Version     string `json:"version"`
 			DownloadURL string `json:"downloadUrl"`


### PR DESCRIPTION
Adds missing comment field to update-azure-linux. Fixes [this](https://github.com/microsoft/go-lab/issues/102)