### PR TITLE
Fix SDL pool in Azure Linux update pipeline

### DIFF
--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -54,8 +54,8 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Svc-Internal
-        image: 1es-ubuntu-2004
-        os: linux
+        image: 1es-windows-2022
+        os: windows
       suppression:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:


### PR DESCRIPTION
We use Windows for the 1ES PT SDL source analysis stage, and either the inconsistency was causing an error, or Linux agents are not supported by the stage: https://dev.azure.com/dnceng/internal/_build/results?buildId=2535561&view=logs&j=bc38e8b8-e027-53cb-48e7-2adbd1070eca&t=588b4ca4-2b7a-588a-b0a7-9e1f56b49aaf&l=27. The exact reason for the failure isn't important--we should change the agent to match our other pipelines in any case.