### PR TITLE
update-azure-linux: add upstream arg for fork workflow, update GitHub client

### DIFF
--- a/buildreport/buildreport.go
+++ b/buildreport/buildreport.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/gitcmd"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/goversion"

--- a/cmd/releasego/check-limits.go
+++ b/cmd/releasego/check-limits.go
@@ -34,7 +34,7 @@ func handleCheckLimits(p subcmd.ParseFunc) error {
 	}
 
 	return githubutil.Retry(func() error {
-		limits, _, err := client.RateLimits(ctx)
+		limits, _, err := client.RateLimit.Get(ctx)
 		if err != nil {
 			return err
 		}

--- a/cmd/releasego/create-release-day-issue.go
+++ b/cmd/releasego/create-release-day-issue.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/azdo"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/subcmd"

--- a/cmd/releasego/get-merged-pr-commit.go
+++ b/cmd/releasego/get-merged-pr-commit.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/azdo"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/subcmd"

--- a/cmd/releasego/publish-announcement.go
+++ b/cmd/releasego/publish-announcement.go
@@ -187,7 +187,7 @@ func publishAnnouncement(p subcmd.ParseFunc) (err error) {
 
 	// check if the file already exists in the go-devblog repository
 	if _, err := githubutil.DownloadFile(ctx, client, "microsoft", "go-devblog", "main", blogFilePath); err != nil {
-		if errors.Is(err, githubutil.ErrNotExists) {
+		if errors.Is(err, githubutil.ErrFileNotExists) {
 			// Good.
 		} else {
 			return fmt.Errorf("error checking if file exists in go-devblog repository : %w", err)

--- a/cmd/releasego/repo-release.go
+++ b/cmd/releasego/repo-release.go
@@ -13,7 +13,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/buildmodel/buildassets"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/stringutil"

--- a/cmd/releasego/tag.go
+++ b/cmd/releasego/tag.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/subcmd"
 )

--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -130,12 +130,12 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 		// working on, making sure our PR won't revert an unfortunately-timed upstream merge.
 		upstreamRef, _, err := client.Git.GetRef(ctx, upstream, repo, baseBranch)
 		if err != nil {
-			return fmt.Errorf("failed to get ref %v: %v", baseBranch, err)
+			return fmt.Errorf("failed to get ref %v: %w", baseBranch, err)
 		}
 		upstreamCommitSHA := upstreamRef.Object.GetSHA()
 		upstreamCommit, _, err := client.Git.GetCommit(ctx, upstream, repo, upstreamCommitSHA)
 		if err != nil {
-			return fmt.Errorf("failed to get commit %v: %v", upstreamCommitSHA, err)
+			return fmt.Errorf("failed to get commit %v: %w", upstreamCommitSHA, err)
 		}
 
 		golangSpecFileBytes, err := downloadFileFromRepo(ctx, client, upstream, repo, upstreamCommitSHA, golangSpecFilepath)
@@ -217,7 +217,7 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 			Object: &github.GitObject{SHA: createCommit.SHA},
 		}
 		if _, _, err = client.Git.CreateRef(ctx, owner, repo, newRef); err != nil {
-			return fmt.Errorf("failed to create ref: %v", err)
+			return fmt.Errorf("failed to create ref: %w", err)
 		}
 		// Now that we've created the ref, we can't retry: the name is taken.
 		// This retry loop is over.
@@ -241,7 +241,7 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 			Draft: github.Bool(true),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to create PR: %v", err)
+			return fmt.Errorf("failed to create PR: %w", err)
 		}
 		// We can't create the PR again (one per ref), so this retry loop is over.
 		return nil

--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -10,8 +10,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -29,10 +31,22 @@ func init() {
 		Name:    "update-azure-linux",
 		Summary: "Create a GitHub PR that updates the Go spec files for Azure Linux.",
 		Description: `
-Updates the golang package spec file in [upstream]/[repo] to build the version of Go specified in
-the provided build asset JSON file. If [upstream] and [owner] differ, the PR will be created in a
-fork of the Azure Linux repo under [owner]. If [owner] user doesn't already have an Azure Linux
-fork, it is created.
+Updates the golang package spec file in the Azure Linux GitHub repository to build the version of
+Go specified in the provided build asset JSON file. Creates a branch in [owner]/[repo] and submits
+the PR to [upstream]/[repo].
+
+If [owner]/[repo] doesn't exist, tries to create the fork in the account associated with the PAT.
+
+Fork creation assumes [owner] matches the PAT user. If the created fork doesn't match
+[owner]/[repo], the command fails.
+
+If the user already has a fork of the repo with a different name, fork creation may fail. For
+example, if the fork was created before the cbl-mariner repository was renamed to azurelinux, it
+may still have the old name.
+
+Note: the PAT must have "repo" scope, and if using a fork, it must also have "workflow" scope.
+Otherwise, GitHub will return "404" when attempting to update the fork if the upstream repo has
+modified any GitHub workflows.
 `,
 		Handle: updateAzureLinux,
 	})
@@ -66,6 +80,38 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 		return err
 	}
 
+	// Set custom user agent to help GitHub identify the bot if necessary.
+	client.UserAgent = "microsoft/go-infra update-azure-linux"
+
+	// Check that the PAT has the necessary scopes.
+	patScopes, err := githubutil.PATScopes(ctx, client)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(patScopes, "repo") {
+		return fmt.Errorf("the PAT must have 'repo' scope, but not found in list: %v", patScopes)
+	}
+
+	if upstream != owner {
+		// Submitting PR via fork. Try to make sure it'll work.
+		if !slices.Contains(patScopes, "workflow") {
+			return fmt.Errorf("the PAT must have 'workflow' scope, but not found in list: %v", patScopes)
+		}
+
+		// Check if fork already exists, or create it.
+		forkRepo, err := githubutil.FetchRepositoryOrNil(ctx, client, owner, repo)
+		if err != nil {
+			return err
+		}
+		if forkRepo == nil {
+			forkRepo, err = githubutil.FullyCreateFork(ctx, client, upstream, repo)
+			if err != nil {
+				return err
+			}
+		}
+		log.Printf("Submitting PR via owner's fork: %s\n", forkRepo.GetHTMLURL())
+	}
+
 	assets, err := loadBuildAssets(buildAssetJSON)
 	if err != nil {
 		return err
@@ -75,109 +121,149 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 		updateBranch = generateUpdateBranchNameFromAssets(assets)
 	}
 
-	golangSpecFileBytes, err := downloadFileFromRepo(ctx, client, owner, repo, baseBranch, golangSpecFilepath)
-	if err != nil {
-		return err
-	}
-
-	golangSpecFileContent := string(golangSpecFileBytes)
-
-	prevGoArchiveName, err := extractGoArchiveNameFromSpecFile(golangSpecFileContent)
-	if err != nil {
-		return err
-	}
-
-	golangSpecFileContent, err = updateSpecFile(assets, start, golangSpecFileContent)
-	if err != nil {
-		return err
-	}
-
-	// Validation (as described in previous response)
-	if assets.GoSrcURL == "" || assets.GoSrcSHA256 == "" {
-		return fmt.Errorf("invalid or missing GoSrcURL or GoSrcSHA256 in assets.json")
-	}
-
-	golangSignaturesFileBytes, err := downloadFileFromRepo(ctx, client, owner, repo, baseBranch, golangSignaturesFilepath)
-	if err != nil {
-		return err
-	}
-
-	golangSignaturesFileBytes, err = updateSignatureFile(golangSignaturesFileBytes, prevGoArchiveName, path.Base(assets.GoSrcURL), assets.GoSrcSHA256)
-	if err != nil {
-		return err
-	}
-
-	cgManifestBytes, err := downloadFileFromRepo(ctx, client, owner, repo, baseBranch, cgManifestFilepath)
-	if err != nil {
-		return err
-	}
-
-	cgManifestBytes, err = updateCGManifest(assets, cgManifestBytes)
-	if err != nil {
-		return err
-	}
-
-	ref, _, err := client.Git.GetRef(ctx, owner, repo, baseBranch)
-	if err != nil {
-		return fmt.Errorf("failed to get ref: %v", err)
-	}
-
-	newRef := &github.Reference{
-		Ref:    github.String(updateBranch),
-		Object: &github.GitObject{SHA: ref.Object.SHA},
-	}
-
-	if _, _, err = client.Git.CreateRef(ctx, owner, repo, newRef); err != nil {
-		return fmt.Errorf("Failed to create ref: %v", err)
-	}
-
-	updatedFiles := map[string][]byte{
-		golangSpecFilepath:       []byte(golangSpecFileContent),
-		golangSignaturesFilepath: golangSignaturesFileBytes,
-		cgManifestFilepath:       cgManifestBytes,
-	}
-
-	for filePath, newContent := range updatedFiles {
-		// Get the file to update
-		file, _, _, err := client.Repositories.GetContents(ctx, owner, repo, filePath, &github.RepositoryContentGetOptions{Ref: updateBranch})
+	// If anything fails here, retry from the beginning to use a fresh base commit.
+	// Some individual steps also have their own retries; this is fine.
+	if err := githubutil.Retry(func() error {
+		// Find details about the state of the upstream base branch. This pins the commit that we're
+		// working on, making sure our PR won't revert an unfortunately-timed upstream merge.
+		upstreamRef, _, err := client.Git.GetRef(ctx, upstream, repo, baseBranch)
 		if err != nil {
-			return fmt.Errorf("Failed to get file %q: %v", filePath, err)
+			return fmt.Errorf("failed to get ref %v: %v", baseBranch, err)
+		}
+		upstreamCommitSHA := upstreamRef.Object.GetSHA()
+		upstreamCommit, _, err := client.Git.GetCommit(ctx, upstream, repo, upstreamCommitSHA)
+		if err != nil {
+			return fmt.Errorf("failed to get commit %v: %v", upstreamCommitSHA, err)
 		}
 
-		// Update the file
-		_, _, err = client.Repositories.UpdateFile(ctx, owner, repo, filePath, &github.RepositoryContentFileOptions{
+		golangSpecFileBytes, err := downloadFileFromRepo(ctx, client, upstream, repo, upstreamCommitSHA, golangSpecFilepath)
+		if err != nil {
+			return err
+		}
+
+		golangSpecFileContent := string(golangSpecFileBytes)
+
+		prevGoArchiveName, err := extractGoArchiveNameFromSpecFile(golangSpecFileContent)
+		if err != nil {
+			return err
+		}
+
+		golangSpecFileContent, err = updateSpecFile(assets, start, golangSpecFileContent)
+		if err != nil {
+			return err
+		}
+
+		// Validation (as described in previous response)
+		if assets.GoSrcURL == "" || assets.GoSrcSHA256 == "" {
+			return fmt.Errorf("invalid or missing GoSrcURL or GoSrcSHA256 in assets.json")
+		}
+
+		golangSignaturesFileBytes, err := downloadFileFromRepo(ctx, client, upstream, repo, upstreamCommitSHA, golangSignaturesFilepath)
+		if err != nil {
+			return err
+		}
+
+		golangSignaturesFileBytes, err = updateSignatureFile(golangSignaturesFileBytes, prevGoArchiveName, path.Base(assets.GoSrcURL), assets.GoSrcSHA256)
+		if err != nil {
+			return err
+		}
+
+		cgManifestBytes, err := downloadFileFromRepo(ctx, client, upstream, repo, upstreamCommitSHA, cgManifestFilepath)
+		if err != nil {
+			return err
+		}
+
+		cgManifestBytes, err = updateCGManifest(assets, cgManifestBytes)
+		if err != nil {
+			return err
+		}
+
+		tree := []*github.TreeEntry{
+			{
+				Path:    github.String(golangSpecFilepath),
+				Content: &golangSpecFileContent,
+				Mode:    github.String(githubutil.TreeModeFile),
+			},
+			{
+				Path:    github.String(golangSignaturesFilepath),
+				Content: github.String(string(golangSignaturesFileBytes)),
+				Mode:    github.String(githubutil.TreeModeFile),
+			},
+			{
+				Path:    github.String(cgManifestFilepath),
+				Content: github.String(string(cgManifestBytes)),
+				Mode:    github.String(githubutil.TreeModeFile),
+			},
+		}
+
+		createTree, _, err := client.Git.CreateTree(ctx, owner, repo, upstreamCommit.Tree.GetSHA(), tree)
+		if err != nil {
+			return err
+		}
+
+		createCommit, _, err := client.Git.CreateCommit(ctx, owner, repo, &github.Commit{
 			Message: github.String(generatePRTitleFromAssets(assets)),
-			Content: newContent,
-			SHA:     file.SHA,
-			Branch:  github.String(updateBranch),
+			Parents: []*github.Commit{upstreamCommit},
+			Tree:    createTree,
+		}, &github.CreateCommitOptions{})
+		if err != nil {
+			return err
+		}
+
+		newRef := &github.Reference{
+			Ref:    github.String(updateBranch),
+			Object: &github.GitObject{SHA: createCommit.SHA},
+		}
+		if _, _, err = client.Git.CreateRef(ctx, owner, repo, newRef); err != nil {
+			return fmt.Errorf("failed to create ref: %v", err)
+		}
+		// Now that we've created the ref, we can't retry: the name is taken.
+		// This retry loop is over.
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	var pr *github.PullRequest
+
+	if err := githubutil.Retry(func() error {
+		prHead := updateBranch
+		if owner != upstream {
+			prHead = owner + ":" + updateBranch
+		}
+		pr, _, err = client.PullRequests.Create(ctx, upstream, repo, &github.NewPullRequest{
+			Title: github.String(generatePRTitleFromAssets(assets)),
+			Head:  &prHead,
+			Base:  github.String(baseBranch),
+			Body:  github.String(GeneratePRDescription(assets)),
+			Draft: github.Bool(true),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to update file %q: %v", filePath, err)
+			return fmt.Errorf("failed to create PR: %v", err)
 		}
-	}
-
-	pr, _, err := client.PullRequests.Create(ctx, owner, repo, &github.NewPullRequest{
-		Title: github.String(generatePRTitleFromAssets(assets)),
-		Head:  github.String(updateBranch),
-		Base:  github.String(baseBranch),
-		Body:  github.String(GeneratePRDescription(assets)),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create PR: %v", err)
-	}
-
-	// This function utilizes the Issues API because in GitHub's API model, pull requests are treated as a special type of issue.
-	// While GitHub provides a dedicated PullRequests API, it doesn't currently offer a method for adding labels directly to pull requests.
-	//
-	// Therefore, we use the Issues.AddLabelsToIssue method, passing the pull request's number (which is equivalent to its issue number)
-	// to apply the labels.
-	//
-	// This approach is a workaround until GitHub potentially adds direct label management for pull requests in their API.
-	if _, _, err := client.Issues.AddLabelsToIssue(ctx, owner, repo, pr.GetNumber(), []string{"3.0-dev", "Automatic PR"}); err != nil {
-		return fmt.Errorf("error adding label to pull request: %w\n", err)
+		// We can't create the PR again (one per ref), so this retry loop is over.
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	fmt.Printf("Pull request created successfully: %s\n", pr.GetHTMLURL())
+
+	if err := githubutil.Retry(func() error {
+		// This function utilizes the Issues API because in GitHub's API model, pull requests are treated as a special type of issue.
+		// While GitHub provides a dedicated PullRequests API, it doesn't currently offer a method for adding labels directly to pull requests.
+		//
+		// Therefore, we use the Issues.AddLabelsToIssue method, passing the pull request's number (which is equivalent to its issue number)
+		// to apply the labels.
+		//
+		// This approach is a workaround until GitHub potentially adds direct label management for pull requests in their API.
+		_, _, err := client.Issues.AddLabelsToIssue(ctx, upstream, repo, pr.GetNumber(), []string{"3.0-dev", "Automatic PR"})
+		return err
+	}); err != nil {
+		return fmt.Errorf("error adding label to pull request: %w\n", err)
+	}
+
+	fmt.Printf("Added labels to pull request.\n")
 
 	return nil
 }
@@ -205,8 +291,8 @@ func loadBuildAssets(assetFilePath string) (*buildassets.BuildAssets, error) {
 	return assets, nil
 }
 
-func downloadFileFromRepo(ctx context.Context, client *github.Client, owner, repo, branch, filePath string) ([]byte, error) {
-	fileContent, err := githubutil.DownloadFile(ctx, client, owner, repo, branch, filePath)
+func downloadFileFromRepo(ctx context.Context, client *github.Client, owner, repo, ref, filePath string) ([]byte, error) {
+	fileContent, err := githubutil.DownloadFile(ctx, client, owner, repo, ref, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file %q: %w", filePath, err)
 	}

--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -98,14 +98,16 @@ func updateAzureLinux(p subcmd.ParseFunc) error {
 			return fmt.Errorf("the PAT must have 'workflow' scope, but not found in list: %v", patScopes)
 		}
 
-		// Check if fork already exists, or create it.
-		forkRepo, err := githubutil.FetchRepositoryOrNil(ctx, client, owner, repo)
+		// Get full details about the fork.
+		forkRepo, err := githubutil.FetchRepository(ctx, client, owner, repo)
 		if err != nil {
-			return err
-		}
-		if forkRepo == nil {
-			forkRepo, err = githubutil.FullyCreateFork(ctx, client, upstream, repo)
-			if err != nil {
+			if errors.Is(err, githubutil.ErrRepositoryNotExists) {
+				// Fork doesn't exist. Try to create it and get the full details.
+				forkRepo, err = githubutil.FullyCreateFork(ctx, client, upstream, repo)
+				if err != nil {
+					return err
+				}
+			} else {
 				return err
 			}
 		}

--- a/cmd/releasego/update-azure-linux.go
+++ b/cmd/releasego/update-azure-linux.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"github.com/microsoft/go-infra/buildmodel/buildassets"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/goversion"
@@ -27,9 +27,12 @@ import (
 func init() {
 	subcommands = append(subcommands, subcmd.Option{
 		Name:    "update-azure-linux",
-		Summary: "Experimental: Update the Go spec files for Azure Linux and print the result without pushing.",
+		Summary: "Create a GitHub PR that updates the Go spec files for Azure Linux.",
 		Description: `
-See https://github.com/microsoft/go-lab/issues/79
+Updates the golang package spec file in [upstream]/[repo] to build the version of Go specified in
+the provided build asset JSON file. If [upstream] and [owner] differ, the PR will be created in a
+fork of the Azure Linux repo under [owner]. If [owner] user doesn't already have an Azure Linux
+fork, it is created.
 `,
 		Handle: updateAzureLinux,
 	})
@@ -38,14 +41,16 @@ See https://github.com/microsoft/go-lab/issues/79
 func updateAzureLinux(p subcmd.ParseFunc) error {
 	var baseBranch string
 	var buildAssetJSON string
+	var upstream string
 	var owner string
 	var repo string
 	var updateBranch string
 
 	flag.StringVar(&baseBranch, "base-branch", "refs/heads/3.0-dev", "The base branch to download files from.")
 	flag.StringVar(&buildAssetJSON, "build-asset-json", "assets.json", "The path of a build asset JSON file describing the Go build to update to.")
-	flag.StringVar(&owner, "owner", "microsoft", "The owner of the repository.")
-	flag.StringVar(&repo, "repo", "azurelinux", "The repository to update.")
+	flag.StringVar(&upstream, "upstream", "microsoft", "The owner of the Azure Linux repository.")
+	flag.StringVar(&owner, "owner", "microsoft", "The owner of the repository to create the dev branch in.")
+	flag.StringVar(&repo, "repo", "azurelinux", "The upstream repository name to update.")
 	flag.StringVar(&updateBranch, "update-branch", "", "The target branch to update files in.")
 
 	pat := githubutil.BindPATFlag()

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -19,13 +19,18 @@ parameters:
     displayName: 'The ID of the microsoft-go build pipeline that triggered this pipeline.'
     type: string
 
+  - name: upstream
+    displayName: 'Azure Linux repository owner'
+    type: string
+    default: 'microsoft'
+
   - name: owner
-    displayName: 'GitHub repository owner'
+    displayName: 'Dev branch repository owner'
     type: string
     default: 'microsoft'
 
   - name: repo
-    displayName: 'GitHub repository name'
+    displayName: 'Azure Linux GitHub repository name'
     type: string
     default: 'azurelinux'
 
@@ -85,6 +90,7 @@ extends:
                       releasego update-azure-linux \
                         -pat '$(GitHubPAT)' \
                         -build-asset-json $(buildAssetJsonFile) \
+                        -upstream ${{ parameters.upstream }} \
                         -owner ${{ parameters.owner }} \
                         -repo ${{ parameters.repo }} \
                         -update-branch ${{ parameters.updateBranch }}

--- a/githubutil/githubutil.go
+++ b/githubutil/githubutil.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v65/github"
 	"golang.org/x/oauth2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.22.0
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2
 	github.com/go-test/deep v1.1.1
-	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v65 v65.0.0
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	golang.org/x/crypto v0.27.0
 	golang.org/x/mod v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVI
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v65 v65.0.0 h1:pQ7BmO3DZivvFk92geC0jB0q2m3gyn8vnYPgV7GSLhQ=
+github.com/google/go-github/v65 v65.0.0/go.mod h1:DvrqWo5hvsdhJvHd4WyVF9ttANN3BniqjP8uTFMNb60=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Adds `-upstream` to the `update-azure-linux` command, and uses a fork contribution approach when upstream != owner.

Creates the fork if necessary so we don't need to log into the bot to pre-create the fork. This also makes it so that if we delete the fork to clean up old data, the next run will create it again automatically.

* Example: https://github.com/dagood/azurelinux/pull/8
* By https://dev.azure.com/dnceng/internal/_build/results?buildId=2542636&view=results

This also implements single-commit PRs using the tree API and makes some parts of the command more robust to transitive failures (e.g. rate limit exceeded) by wrapping more with Retry.

It still works with a non-fork approach: https://github.com/dagood/azurelinux/pull/9

I also updated the version of the GitHub library we're using. This adds some APIs that I ended up using, and it's something we should do anyway. (The old library was from 2018.)

**Turn on "ignore whitespace" to review cmd/releasego/update-azure-linux.go with a better diff.**

* Fixes https://github.com/microsoft/go-lab/issues/103