### PR TITLE
Make Azure Linux PR body more complete

### DIFF
--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
@@ -1,0 +1,14 @@
+golang: bump Go version to 1.23.0-2
+
+---
+
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+
+I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
+
+Finalization steps:
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Mark this draft PR as ready for review.
+
+Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
@@ -1,0 +1,14 @@
+golang: bump Go version to 1.23.0-2
+
+---
+
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+
+I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR.
+
+Finalization steps:
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Mark this draft PR as ready for review.
+
+Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
@@ -1,0 +1,14 @@
+golang: bump Go version to 1.23.0-2
+
+---
+
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+
+I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
+
+Finalization steps:
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-1234` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Mark this draft PR as ready for review.
+
+Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-security.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-security.golden.md
@@ -1,0 +1,16 @@
+(security) golang: bump Go version to 1.23.0-2
+
+---
+
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+
+**This update contains security fixes.**
+
+I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
+
+Finalization steps:
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Mark this draft PR as ready for review.
+
+Thanks!

--- a/cmd/releasego/update-azure-linux_test.go
+++ b/cmd/releasego/update-azure-linux_test.go
@@ -158,3 +158,36 @@ func TestUpdateSpecVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestPRBody(t *testing.T) {
+	assets, err := loadBuildAssets(assetsJsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type args struct {
+		security bool
+		notify   string
+		prNumber int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"essential", args{false, "a-go-developer", 0}},
+		{"security", args{true, "a-go-developer", 0}},
+		{"no-dev", args{false, "", 0}},
+		{"pr-number", args{false, "a-go-developer", 1234}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generatePRTitleFromAssets(assets, tt.args.security)
+			got += "\n\n---\n\n"
+			got += GeneratePRDescription(assets, tt.args.security, tt.args.notify, tt.args.prNumber)
+			goldentest.Check(
+				t, "go test ./cmd/releasego -run "+t.Name(),
+				filepath.Join("testdata", "update-azure-linux", "pr", "pr-description-"+tt.name+".golden.md"),
+				got)
+		})
+	}
+}

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -39,6 +39,23 @@ parameters:
     type: string
     default: nil
 
+  - name: notify
+    displayName: >
+      A GitHub username to @mention in the tracking issue to subscribe them to updates. Do not
+      include '@' below. 'ghost' notifies nobody.
+    type: string
+    default: ghost
+
+  - name: isSecurityRelease
+    displayName: >
+      This release includes security fixes:
+    type: string
+    default: Cancel
+    values:
+      - True
+      - False
+      - Cancel
+
 trigger: none
 pr: none
 
@@ -70,6 +87,10 @@ extends:
     stages:
       - stage: Release
         jobs:
+          # Validation for complex inputs.
+          - ${{ if not(in(parameters.isSecurityRelease, 'True', 'False')) }}:
+            - 'Cancelled run. Please pick an option to indicate whether or not this is a security release.': error
+
           - template: /eng/pipelines/jobs/releasego.yml@self
             parameters:
               steps:
@@ -93,6 +114,8 @@ extends:
                         -upstream ${{ parameters.upstream }} \
                         -owner ${{ parameters.owner }} \
                         -repo ${{ parameters.repo }} \
-                        -update-branch ${{ parameters.updateBranch }}
+                        -update-branch ${{ parameters.updateBranch }} \
+                        -notify ${{ parameters.notify }} \
+                        -security=${{ parameters.isSecurityRelease }}
                     displayName: Create Pull Request to Update Azure Linux Specfiles
 


### PR DESCRIPTION
* Based on https://github.com/microsoft/go-infra/pull/170.
* Fixes https://github.com/microsoft/go-lab/issues/115
* Includes instructions in the PR with how to finish it up, mentioning what to paste where.
  * No need to refer back to https://github.com/microsoft/go-infra/blob/main/docs/release-process/azurelinux-spec-update.md! I'll submit another PR to update that doc to describe the current process.
* Pings the release owner (optionally).

Does not address:

* https://github.com/microsoft/go-lab/issues/79
* https://github.com/microsoft/go-lab/issues/120

This PR significantly reduces how much fiddling is necessary to get the Azure Linux PRs done for each release, so it's a welcome improvement to the release process. (Albeit I'm the one who welcomes it. 😄)

Example PRs:
* https://github.com/dagood/azurelinux/pull/14 (generated locally)
* https://github.com/dagood/azurelinux/pull/15 (generated [by pipeline](https://dev.azure.com/dnceng/internal/_build/results?buildId=2546009&view=results))