### PR TITLE
Adjust PR after real use: optional labels, copiable params

### DIFF
--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
@@ -7,8 +7,22 @@ Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I ge
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
 Finalization steps:
-- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
-- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
+  Full Name:  
+  ```
+  go1.23.0-20240708.2.src.tar.gz
+  ```
+  URL:  
+  ```
+  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  ```
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
+  First field: `PR-` then the number of this PR.  
+  Core spec:  
+  ```
+  golang
+  ```
+- Post a PR comment with the URL of the triggered Buddy Build.
 - Mark this draft PR as ready for review.
 
 Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
@@ -7,8 +7,22 @@ Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I ge
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR.
 
 Finalization steps:
-- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
-- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
+  Full Name:  
+  ```
+  go1.23.0-20240708.2.src.tar.gz
+  ```
+  URL:  
+  ```
+  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  ```
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
+  First field: `PR-` then the number of this PR.  
+  Core spec:  
+  ```
+  golang
+  ```
+- Post a PR comment with the URL of the triggered Buddy Build.
 - Mark this draft PR as ready for review.
 
 Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
@@ -7,8 +7,25 @@ Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I ge
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
 Finalization steps:
-- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
-- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-1234` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
+  Full Name:  
+  ```
+  go1.23.0-20240708.2.src.tar.gz
+  ```
+  URL:  
+  ```
+  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  ```
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
+  First field:  
+  ```
+  PR-1234
+  ```
+  Core spec:  
+  ```
+  golang
+  ```
+- Post a PR comment with the URL of the triggered Buddy Build.
 - Mark this draft PR as ready for review.
 
 Thanks!

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-security.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-security.golden.md
@@ -9,8 +9,22 @@ Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I ge
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
 Finalization steps:
-- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with Full Name `go1.23.0-20240708.2.src.tar.gz` and URL `https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz`
-- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with `PR-XXXX` and core spec `golang` then post a PR comment with the URL of the triggered build.
+- Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
+  Full Name:  
+  ```
+  go1.23.0-20240708.2.src.tar.gz
+  ```
+  URL:  
+  ```
+  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  ```
+- Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
+  First field: `PR-` then the number of this PR.  
+  Core spec:  
+  ```
+  golang
+  ```
+- Post a PR comment with the URL of the triggered Buddy Build.
 - Mark this draft PR as ready for review.
 
 Thanks!


### PR DESCRIPTION
The bot wasn't able to apply labels to its first PRs: https://github.com/microsoft/azurelinux/pulls/microsoft-golang-bot. So, make it optional. Applying labels requires permission, and if Azure Linux wants the labels, we can ask for it, but until then I don't see any reason to push for it.

When I was triggering the pipelines I remembered that on GitHub, code-fence formatting has a copy button to make the human's job just that little bit easier. Switch to that.

Example: https://github.com/dagood/azurelinux/pull/17