### PR TITLE
sync: skip a push that would overwrite another's change

### DIFF
--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -168,6 +168,10 @@ func (r Remote) GetOwner() string {
 	return r.GetOwnerRepo()[0]
 }
 
+func (r Remote) GetRepo() string {
+	return r.GetOwnerRepo()[1]
+}
+
 func (r Remote) GetOwnerSlashRepo() string {
 	return strings.Join(r.GetOwnerRepo(), "/")
 }


### PR DESCRIPTION
Move the existing PR check before the force push. If a PR exists, check that the author of the latest commit is the same as what we're planning to push. If not, skip it.

I tried it out at https://github.com/dagood-bot/go/pull/1.

`---- master -> dev/auto-sync/microsoft/main: skipping submitting PR: PR already exists, but my author name (dagood-bot-2@example.org) is different from the author of the remote commit (dagood-bot@example.org). Skipping PR submission.`

* Fixes https://github.com/microsoft/go/issues/68
* Making the bot add a comment might be interesting, but that should be looked at in the broader context of https://github.com/microsoft/go/issues/541.
* There is a race here that `--force-with-lease=<refname>:<expect>` could prevent, but the syntax isn't clear to me. Also, it's not clear if you can use this when pushing multiple refs at the same time. Would need some experimentation. IMO this is fine to leave as a potential later improvement.