### PR TITLE
Use 16 min mirror timeout, add issue link

### DIFF
--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -143,7 +143,7 @@ extends:
                           -proj 'internal' \
                           -azdopat '$(System.AccessToken)'
                       displayName: ⌚ Wait for internal mirror
-                      timeoutInMinutes: 15 # This should be very quick, and a dev can easily fix it.
+                      timeoutInMinutes: 16 # See https://github.com/microsoft/go-lab/issues/124
                     - script: |
                         releasego build-pipeline \
                           -commit '$(poll1MicrosoftGoImagesCommitHash)' \

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -61,7 +61,7 @@ steps:
           -proj 'internal' \
           -azdopat '$(System.AccessToken)'
       displayName: ⌚ Wait for internal mirror
-      timeoutInMinutes: 15 # This should be very quick, and a dev can easily fix it.
+      timeoutInMinutes: 16 # See https://github.com/microsoft/go-lab/issues/124
 
     # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
     # default Branch is "microsoft/main". So, we need to figure out the release branch name


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/124

We expect this to typically complete in less than 5 minutes, but there is some variability described in https://github.com/microsoft/go-lab/issues/124. I picked 16 minutes rather than 15 just to avoid exactly matching a trigger cadence that the mirroring infra uses.

A 16-minute timeout would have actually avoided the incident according to AzDO timestamps, although it seems like that's just a weird coincidence.