### PR TITLE
add conditional flag to disable automerge for sync PRs

### DIFF
--- a/eng/pipelines/upstream-sync-pipeline.yml
+++ b/eng/pipelines/upstream-sync-pipeline.yml
@@ -59,5 +59,6 @@ extends:
                     -github-user microsoft-golang-bot `
                     -github-pat $(BotAccount-microsoft-golang-bot-PAT) `
                     -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT) `
+                    -auto-merge false `
                     -azdo-dnceng-pat $(dn-bot-dnceng-build-rw-code-rw)
                 displayName: Sync


### PR DESCRIPTION
We're investigating switching to GitHub workflows to handle this so we can restrict the token permissions on our GitHub bots