### PR TITLE
Support two Azure Linux golang major versions

### DIFF
--- a/cmd/releasego/testdata/update-azure-linux/assets.json
+++ b/cmd/releasego/testdata/update-azure-linux/assets.json
@@ -1,7 +1,7 @@
 {
     "branch": "release-branch.go1.23",
     "buildId": "2487096",
-    "version": "1.23.0-2",
+    "version": "1.23.3-2",
     "arches": [
       {
         "env": {
@@ -9,7 +9,7 @@
           "GOOS": "linux"
         },
         "sha256": "59963327dc86e8a5f48d9485ed800c26f80b9975c9331736c33005947a02686f",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.0-20240708.2.linux-amd64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.3-20240708.2.linux-amd64.tar.gz"
       },
       {
         "env": {
@@ -17,7 +17,7 @@
           "GOOS": "linux"
         },
         "sha256": "92078bdb0a2cbe1a5c175b3046427eca30f137b57106157d0696099254bbe03d",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.0-20240708.2.linux-arm64.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.3-20240708.2.linux-arm64.tar.gz"
       },
       {
         "env": {
@@ -26,7 +26,7 @@
           "GOOS": "linux"
         },
         "sha256": "c641ce883b1967fb5df679ee652ebd2482dcbc14e528b36fea942ab69b4ca2f2",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.0-20240708.2.linux-armv6l.tar.gz"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.3-20240708.2.linux-armv6l.tar.gz"
       },
       {
         "env": {
@@ -34,9 +34,9 @@
           "GOOS": "windows"
         },
         "sha256": "8310ad1878f1420c36a67145e26ac3163c8be65fd93e61b09eca5544a21120d5",
-        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.0-20240708.2.windows-amd64.zip"
+        "url": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.3-20240708.2.windows-amd64.zip"
       }
     ],
-    "goSrcURL": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.0-20240708.2.src.tar.gz",
+    "goSrcURL": "https://dotnetbuildoutput.blob.core.windows.net/golang/microsoft/release-branch.go1.22/20240702.3/go1.23.3-20240708.2.src.tar.gz",
     "goSrcSHA256":"b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
 }

--- a/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
+++ b/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
@@ -6,7 +6,7 @@
         "other": {
           "name": "golang",
           "version": "1.22.2",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.2-1/go1.22.2-20240225.5.src.tar.gz"
         }
       }
     },
@@ -16,7 +16,7 @@
         "other": {
           "name": "golang",
           "version": "1.23.0",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.0-1/go1.23.0-20240507.3.src.tar.gz"
         }
       }
     },

--- a/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
+++ b/cmd/releasego/testdata/update-azure-linux/cgmanifest.json
@@ -1,35 +1,45 @@
 {
   "Registrations": [
-      {
-        "component": {
-          "type": "other",
-          "other": {
-            "name": "golang",
-            "version": "1.22.3",
-            "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
-          }
-        }
-      },
-      {
-        "component": {
-          "type": "other",
-          "other": {
-            "name": "abseil-cpp",
-            "version": "20240116.0",
-            "downloadUrl": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.tar.gz"
-          }
-        }
-      },
-      {
-        "component": {
-          "type": "other",
-          "comment": "This is a comment2",
-          "other": {
-            "name": "accountsservice",
-            "version": "0.6.55",
-            "downloadUrl": "http://www.freedesktop.org/software/accountsservice/accountsservice-0.6.55.tar.xz"
-          }
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "golang",
+          "version": "1.22.2",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
         }
       }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "golang",
+          "version": "1.23.0",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "abseil-cpp",
+          "version": "20240116.0",
+          "downloadUrl": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "comment": "This is a comment2",
+        "other": {
+          "name": "accountsservice",
+          "version": "0.6.55",
+          "downloadUrl": "http://www.freedesktop.org/software/accountsservice/accountsservice-0.6.55.tar.xz"
+        }
+      }
+    }
   ]
 }

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-essential.golden.md
@@ -1,8 +1,8 @@
-golang: bump Go version to 1.23.0-2
+golang: bump Go version to 1.23.3-2
 
 ---
 
-Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.3-2](https://github.com/microsoft/go/releases/tag/v1.23.3-2).
 
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
@@ -10,11 +10,11 @@ Finalization steps:
 - Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
   Full Name:  
   ```
-  go1.23.0-20240708.2.src.tar.gz
+  go1.23.3-20240708.2.src.tar.gz
   ```
   URL:  
   ```
-  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  https://github.com/microsoft/go/releases/download/v1.23.3-2/go1.23.3-20240708.2.src.tar.gz
   ```
 - Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
   First field: `PR-` then the number of this PR.  

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-no-dev.golden.md
@@ -1,8 +1,8 @@
-golang: bump Go version to 1.23.0-2
+golang: bump Go version to 1.23.3-2
 
 ---
 
-Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.3-2](https://github.com/microsoft/go/releases/tag/v1.23.3-2).
 
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR.
 
@@ -10,11 +10,11 @@ Finalization steps:
 - Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
   Full Name:  
   ```
-  go1.23.0-20240708.2.src.tar.gz
+  go1.23.3-20240708.2.src.tar.gz
   ```
   URL:  
   ```
-  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  https://github.com/microsoft/go/releases/download/v1.23.3-2/go1.23.3-20240708.2.src.tar.gz
   ```
 - Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
   First field: `PR-` then the number of this PR.  

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-non-latest.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-non-latest.golden.md
@@ -1,10 +1,8 @@
-(security) golang: bump Go version to 1.23.3-2
+golang: bump Go version to 1.23.3-2
 
 ---
 
 Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.3-2](https://github.com/microsoft/go/releases/tag/v1.23.3-2).
-
-**This update contains security fixes.**
 
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
@@ -22,7 +20,7 @@ Finalization steps:
   First field: `PR-` then the number of this PR.  
   Core spec:  
   ```
-  golang
+  golang-1.23
   ```
 - Post a PR comment with the URL of the triggered Buddy Build.
 - Mark this draft PR as ready for review.

--- a/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
+++ b/cmd/releasego/testdata/update-azure-linux/pr/pr-description-pr-number.golden.md
@@ -1,8 +1,8 @@
-golang: bump Go version to 1.23.0-2
+golang: bump Go version to 1.23.3-2
 
 ---
 
-Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.0-2](https://github.com/microsoft/go/releases/tag/v1.23.0-2).
+Hi! 👋 I'm the Microsoft Go team's bot. This is an automated pull request I generated to bump the Go version to [1.23.3-2](https://github.com/microsoft/go/releases/tag/v1.23.3-2).
 
 I'm not able to run the Azure Linux pipelines yet, so the Microsoft Go release runner will need to finalize this PR. @a-go-developer
 
@@ -10,11 +10,11 @@ Finalization steps:
 - Trigger [Source Tarball Publishing](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2284) with:  
   Full Name:  
   ```
-  go1.23.0-20240708.2.src.tar.gz
+  go1.23.3-20240708.2.src.tar.gz
   ```
   URL:  
   ```
-  https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz
+  https://github.com/microsoft/go/releases/download/v1.23.3-2/go1.23.3-20240708.2.src.tar.gz
   ```
 - Trigger [the Buddy Build](https://dev.azure.com/mariner-org/mariner/_build?definitionId=2190) with:  
   First field:  

--- a/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
+++ b/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
@@ -6,7 +6,7 @@
         "other": {
           "name": "golang",
           "version": "1.22.2",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.2-1/go1.22.2-20240225.5.src.tar.gz"
         }
       }
     },

--- a/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
+++ b/cmd/releasego/testdata/update-azure-linux/updated_cgmanifest.golden.json
@@ -5,8 +5,18 @@
         "type": "other",
         "other": {
           "name": "golang",
-          "version": "1.23.0",
-          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.0-2/go1.23.0-20240708.2.src.tar.gz"
+          "version": "1.22.2",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.22.3-1/go1.22.3-20240507.3.src.tar.gz"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "golang",
+          "version": "1.23.3",
+          "downloadUrl": "https://github.com/microsoft/go/releases/download/v1.23.3-2/go1.23.3-20240708.2.src.tar.gz"
         }
       }
     },

--- a/cmd/releasego/testdata/update-azure-linux/updated_golang.golden.spec
+++ b/cmd/releasego/testdata/update-azure-linux/updated_golang.golden.spec
@@ -1,6 +1,6 @@
 %global goroot          %{_libdir}/golang
 %global gopath          %{_datadir}/gocode
-%global ms_go_filename  go1.23.0-20240708.2.src.tar.gz
+%global ms_go_filename  go1.23.3-20240708.2.src.tar.gz
 %global ms_go_revision  2
 %ifarch aarch64
 %global gohostarch      arm64
@@ -14,7 +14,7 @@
 %define __find_requires %{nil}
 Summary:        Go
 Name:           golang
-Version:        1.23.0
+Version:        1.23.3
 Release:        1%{?dist}
 License:        BSD-3-Clause
 Vendor:         Microsoft Corporation
@@ -153,8 +153,8 @@ fi
 %{_bindir}/*
 
 %changelog
-* Mon Aug 12 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.23.0-1
-- Bump version to 1.23.0-2
+* Mon Aug 12 2024 Microsoft Golang Bot <microsoft-golang-bot@users.noreply.github.com> - 1.23.3-1
+- Bump version to 1.23.3-2
 
 * Tue Jun 04 2024 Davis Goodin <dagood@microsoft.com> - 1.22.4-1
 - Bump version to 1.22.4-1

--- a/cmd/releasego/testdata/update-azure-linux/updated_signatures.golden.json
+++ b/cmd/releasego/testdata/update-azure-linux/updated_signatures.golden.json
@@ -2,7 +2,7 @@
   "Signatures": {
     "go.20230802.5.src.tar.gz": "56b9e0e0c3c13ca95d5efa6de4e7d49a9d190eca77919beff99d33cd3fa74e95",
     "go.20240206.2.src.tar.gz": "7982e0011aa9ab95fd0530404060410af4ba57326d26818690f334fdcb6451cd",
-    "go1.23.0-20240708.2.src.tar.gz": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+    "go1.23.3-20240708.2.src.tar.gz": "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
     "go1.4-bootstrap-20171003.tar.gz": "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
   }
 }

--- a/cmd/releasego/update-azure-linux_test.go
+++ b/cmd/releasego/update-azure-linux_test.go
@@ -166,24 +166,26 @@ func TestPRBody(t *testing.T) {
 	}
 
 	type args struct {
-		security bool
-		notify   string
-		prNumber int
+		latestMajor bool
+		security    bool
+		notify      string
+		prNumber    int
 	}
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"essential", args{false, "a-go-developer", 0}},
-		{"security", args{true, "a-go-developer", 0}},
-		{"no-dev", args{false, "", 0}},
-		{"pr-number", args{false, "a-go-developer", 1234}},
+		{"essential", args{true, false, "a-go-developer", 0}},
+		{"non-latest", args{false, false, "a-go-developer", 0}},
+		{"security", args{true, true, "a-go-developer", 0}},
+		{"no-dev", args{true, false, "", 0}},
+		{"pr-number", args{true, false, "a-go-developer", 1234}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := generatePRTitleFromAssets(assets, tt.args.security)
 			got += "\n\n---\n\n"
-			got += GeneratePRDescription(assets, tt.args.security, tt.args.notify, tt.args.prNumber)
+			got += GeneratePRDescription(assets, tt.args.latestMajor, tt.args.security, tt.args.notify, tt.args.prNumber)
 			goldentest.Check(
 				t, "go test ./cmd/releasego -run "+t.Name(),
 				filepath.Join("testdata", "update-azure-linux", "pr", "pr-description-"+tt.name+".golden.md"),

--- a/docs/release-process/azurelinux-spec-update.md
+++ b/docs/release-process/azurelinux-spec-update.md
@@ -2,6 +2,8 @@
 
 This document describes how to update the Azure Linux 3.0 spec file to use a new version of Go.
 
+For each version released:
+
 1. Find and open the [microsoft-go](https://dev.azure.com/dnceng/internal/_build?definitionId=958) build that produced the new Microsoft Go release.
 1. From the URL, copy the build ID.
    * For example, in `[...]results?buildId=2535309&view=results`, it is `2535309`.

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -35,9 +35,14 @@ parameters:
     default: 'azurelinux'
 
   - name: updateBranch
-    displayName: 'Branch to update'
+    displayName: 'Branch to update (include "refs/heads/" prefix if specified) or nil to automatically choose a name'
     type: string
     default: nil
+
+  - name: latestMajor
+    displayName: 'This is the latest major version, so update "golang.spec" instead of "golang-1.<N>.spec"'
+    type: boolean
+    default: true
 
   - name: notify
     displayName: >
@@ -115,6 +120,7 @@ extends:
                         -owner ${{ parameters.owner }} \
                         -repo ${{ parameters.repo }} \
                         -update-branch ${{ parameters.updateBranch }} \
+                        -latest-major=${{ parameters.latestMajor }} \
                         -notify ${{ parameters.notify }} \
                         -security=${{ parameters.isSecurityRelease }}
                     displayName: Create Pull Request to Update Azure Linux Specfiles


### PR DESCRIPTION
* Resolves https://github.com/microsoft/go-lab/issues/146

Support the split between `golang.spec` (1.23) and `golang-1.22.spec`.

* Created https://github.com/microsoft/azurelinux/pull/11013 from test run https://dev.azure.com/dnceng/internal/_build/results?buildId=2579903&view=results

* (Also created https://github.com/microsoft/azurelinux/pull/11010 before I fixed the "core spec" text.)