### PR TITLE
Increase release-build timeouts

### DIFF
--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -46,7 +46,7 @@ steps:
           -pat '$(GitHubPAT)' \
           -set-azdo-variable poll2MicrosoftGoCommitHash
       displayName: ⌚ Get sync PR merged commit hash
-      timeoutInMinutes: 60
+      timeoutInMinutes: 90
       # If no PR is required, then poll2MicrosoftGoCommitHash is already set and we can move on.
       condition: and(succeeded(), ne(variables.poll1MicrosoftGoPRNumber, 'nil'))
 
@@ -140,7 +140,7 @@ steps:
           -proj 'internal' \
           -azdopat '$(System.AccessToken)'
       displayName: ⌚ Wait for internal build
-      timeoutInMinutes: 120
+      timeoutInMinutes: 180
 
     - template: ../steps/report.yml
       parameters:


### PR DESCRIPTION
* microsoft/go PRs are almost exactly 60 minutes now on the Windows jobs. Expand the 60 minute PR poll timeout to 90 minutes.
* The internal build has taken more than 120 minutes a few times recently. Expand to 180 minute timeout.

These timeouts caused some unnecessary retry runs and delays in the recent releases.