### PR TITLE
Include number in blog file path for chronological sort

### DIFF
--- a/cmd/releasego/publish-announcement.go
+++ b/cmd/releasego/publish-announcement.go
@@ -282,5 +282,8 @@ func mapUsernames(githubUsername string) string {
 }
 
 func generateBlogFilePath(releaseDate time.Time, slug string) string {
-	return fmt.Sprintf("%d/%s/%s.md", releaseDate.Year(), releaseDate.Month().String(), slug)
+	// E.g. "2024/01-January/announcing-go-1-23-1-1.md"
+	return fmt.Sprintf(
+		"%d/%02d-%s/%s.md",
+		releaseDate.Year(), releaseDate.Month(), releaseDate.Month().String(), slug)
 }

--- a/cmd/releasego/publish-announcement_test.go
+++ b/cmd/releasego/publish-announcement_test.go
@@ -78,3 +78,31 @@ func TestGoReleaseVersionLink(t *testing.T) {
 		t.Errorf("expected the release link to be %q, but got %q", expected, result)
 	}
 }
+
+func TestGenerateBlogFilePath(t *testing.T) {
+	tests := []struct {
+		releaseDate time.Time
+		slug        string
+		expected    string
+	}{
+		{
+			releaseDate: time.Date(2024, 2, 4, 0, 0, 0, 0, time.UTC),
+			slug:        "go-release-1-21-7-1-and-1-20-14-1",
+			expected:    "2024/02-February/go-release-1-21-7-1-and-1-20-14-1.md",
+		},
+		{
+			releaseDate: time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC),
+			slug:        "go",
+			expected:    "2024/12-December/go.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.slug, func(t *testing.T) {
+			got := generateBlogFilePath(tt.releaseDate, tt.slug)
+			if got != tt.expected {
+				t.Errorf("generateBlogFilePath(%v, %q) = %q; want %q", tt.releaseDate, tt.slug, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is really hard to browse, and it's a stumbling block every time we need to add something to an announcement post:

![image](https://github.com/user-attachments/assets/e0f1dfef-607a-4dc3-9d58-3f6c1418caaa)

And it's not required--any folder structure works: https://teams.microsoft.com/l/message/19:d0efd5331df34362abbd4df1f662130d@thread.skype/1733302980373?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=763d660c-7b8c-48ad-bd91-4b3e6d01c85f&parentMessageId=1733255195703&teamName=Dev%20Bloggers&channelName=General&createdTime=1733302980373

This PR keeps the essence of the current structure but makes it chronologically sorted.

No change is needed in the blog repo to conform to the new structure. It's fine to have both present at once, and in 2025, we'll have a clean slate. (We can move the existing files if we want to at any time, though.)