### PR TITLE
fix typo github-pat-reviewer -> github-reviewer-pat

### DIFF
--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -29,7 +29,7 @@ steps:
           -git-auth pat \
           -github-user '$(GitHubUser)' \
           -github-pat '$(GitHubPAT)' \
-          -github-pat-reviewer '$(GitHubPATReviewer)' \
+          -github-reviewer-pat '$(GitHubPATReviewer)' \
           -azdo-dnceng-pat '$(AzDODncengPAT)' \
           -create-branches \
           -set-azdo-variable-pr-number poll1MicrosoftGoPRNumber \
@@ -277,7 +277,7 @@ steps:
           go run ./cmd/dockerupdatepr \
             -origin 'https://_:$(GitHubPAT)@github.com/$(TargetGoImagesGitHubRepo)' \
             -github-pat '$(GitHubPAT)' \
-            -github-pat-reviewer '$(GitHubPATReviewer)' \
+            -github-reviewer-pat '$(GitHubPATReviewer)' \
             -build-asset-json '$(buildAssetJsonFile)' \
             -manual-branch '$(TargetGoImagesBranch)' \
             -set-azdo-variable-pr-number poll4MicrosoftGoImagesPRNumber

--- a/eng/pipelines/update-images-pipeline.yml
+++ b/eng/pipelines/update-images-pipeline.yml
@@ -75,6 +75,6 @@ extends:
                   go run ./cmd/dockerupdatepr `
                     -origin https://microsoft-golang-bot:$(BotAccount-microsoft-golang-bot-PAT)@github.com/microsoft/go-images `
                     -github-pat $(BotAccount-microsoft-golang-bot-PAT) `
-                    -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT) `
+                    -github-reviewer-pat $(BotAccount-microsoft-golang-review-bot-PAT) `
                     -build-asset-json "$(assetJsonPath)"
                 displayName: Update go-images

--- a/eng/pipelines/upstream-sync-pipeline.yml
+++ b/eng/pipelines/upstream-sync-pipeline.yml
@@ -59,6 +59,6 @@ extends:
                     -github-app-client-id $(BotAccount-bot-for-go-client-id) `
                     -github-app-installation $(BotAccount-bot-for-go-installation) `
                     -github-app-private-key '$(BotAccount-bot-for-go-private-key)' `
-                    -github-pat-reviewer $(BotAccount-microsoft-golang-review-bot-PAT) `
+                    -github-reviewer-pat $(BotAccount-microsoft-golang-review-bot-PAT) `
                     -azdo-dnceng-pat $(dn-bot-dnceng-build-rw-code-rw)
                 displayName: Sync


### PR DESCRIPTION
Because of the new logic added in https://github.com/microsoft/go-infra/blob/1f5b6a9562325e43c167639b49be553225018966/githubutil/githubutil.go#L80-L100, the naming convention for the reviewer PAT has changed. This PR fixes the parameter name that we pass to GitHub auth.

See the usage readme:

```output
Usage:
  -azdo-dnceng-pat string
    	Use this Azure DevOps PAT to authenticate to dnceng project HTTPS Git URLs.
  -c string
    	The sync configuration file to run. (default "eng/sync-config.json")
  -create-branches
    	Before running sync, check that each target branch exists in the target repo.
    	If not, push it to the target repo as a fork from the configured MainBranch.
  -git-auth string
    	The type of Git auth to inject into URLs for fetch/push access. String options:
    	 none - Leave GitHub URLs as they are. Git may use HTTPS authentication in this case.
    	 ssh - Change the GitHub URL to SSH format.
    	 api - Use 'github-*' flags for authentication.
    	 (default "none")
  -github-app-client-id string
    	Use this GitHub App Client ID to authenticate to GitHub. If specified, all github-app-* flags must be specified.
  -github-app-installation int
    	Use this GitHub App Installation ID to authenticate to GitHub. If specified, all github-app-* flags must be specified.
  -github-app-private-key string
    	Use this GitHub App Private Key to authenticate to GitHub, provided in base64 PEM format. If specified, all github-app-* flags must be specified.
  -github-pat string
    	The GitHub PAT to use. Exclusive with github-app-*
  -github-reviewer-app-client-idreviewer string
    	Use this GitHub App Client ID to authenticate to GitHub. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-app-installationreviewer int
    	Use this GitHub App Installation ID to authenticate to GitHub. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-app-private-keyreviewer string
    	Use this GitHub App Private Key to authenticate to GitHub, provided in base64 PEM format. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-pat string

```