### PR TITLE
ghauth: migrate more tasks to use App-based auth

### DIFF
--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -180,7 +180,9 @@ extends:
                         -author '${{ parameters.notify }}' \
                         -versions '${{ join(',', parameters.releaseVersions) }}' \
                         -security='${{ parameters.isSecurityRelease }}' \
-                        -github-pat '$(GitHubPAT)'
+                        -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+                        -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+                        -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
                     displayName: 📰 Publish announcement details
 
                 - ${{ if eq(parameters.runGoImageVersionCheck, true) }}:

--- a/eng/pipelines/release-go-start-pipeline.yml
+++ b/eng/pipelines/release-go-start-pipeline.yml
@@ -76,7 +76,9 @@ extends:
                       -notify '${{ parameters.notify }}' \
                       -releases '${{ join(',', parameters.releaseVersions) }}' \
                       -repo '$(TargetGitHubRepo)' \
-                      -github-pat '$(GitHubPAT)' \
+                      -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+                      -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+                      -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
                       -set-azdo-variable-name GO_RELEASE_DAY_ISSUE_NUMBER
                   displayName: Create release day tracking issue
 

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -26,9 +26,11 @@ steps:
           -c '$(ReleaseSyncConfigPath)' \
           -commit '$(upstreamReleasedCommit)' \
           -version '${{ parameters.releaseVersion }}' \
-          -git-auth pat \
-          -github-user '$(GitHubUser)' \
-          -github-pat '$(GitHubPAT)' \
+          -git-auth api \
+          -github-user bot-for-go \
+          -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+          -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+          -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
           -github-reviewer-pat '$(GitHubPATReviewer)' \
           -azdo-dnceng-pat '$(AzDODncengPAT)' \
           -create-branches \


### PR DESCRIPTION
We've already confirmed that `releasego/sync` works so I've migrated the other pipeline calling it. I've also switched `releasego/create-release-day-issue` to use an app as I've manually confirmed that that task works correctly (see the generated issue here https://github.com/microsoft/go/issues/1582).

I also switched the publish-announcement pipeline which I've tested here: https://github.com/microsoft/go-devblog/commit/94adeb82253ca77eca5dad70a7c981a9ccfcc598