### PR TITLE
migrate further commands to use GH app-based auth

### DIFF
--- a/eng/pipelines/jobs/releasego.yml
+++ b/eng/pipelines/jobs/releasego.yml
@@ -71,13 +71,21 @@ jobs:
           buildStatus: InProgress
           start: true
 
-      - script: releasego check-limits -github-pat '$(GitHubPAT)'
+      - script: |
+          releasego check-limits \
+            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+            -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
         displayName: Check GitHub rate limit
 
       - ${{ each step in parameters.steps }}:
         - ${{ step }}
 
-      - script: releasego check-limits -github-pat '$(GitHubPAT)'
+      - script: |
+          releasego check-limits \
+            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+            -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
         displayName: Check GitHub rate limit
 
       - ${{ if ne(parameters.retryInstructionsFlags, '') }}:

--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -131,7 +131,9 @@ extends:
                             -versions '${{ join(',', parameters.releaseVersions) }}' \
                             -branch 'refs/heads/$(TargetGoImagesBranch)' \
                             -repo 'https://github.com/$(TargetGoImagesGitHubRepo)' \
-                            -github-pat '$(GitHubPAT)' \
+                            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+                            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+                            -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
                             -set-azdo-variable poll1MicrosoftGoImagesCommitHash
                         displayName: ⌚ Wait for go-images dependency flow
 
@@ -182,7 +184,7 @@ extends:
                         -security='${{ parameters.isSecurityRelease }}' \
                         -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
                         -github-app-installation '$(BotAccount-bot-for-go-installation)' \
-                        -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
+                        -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
                     displayName: 📰 Publish announcement details
 
                 - ${{ if eq(parameters.runGoImageVersionCheck, true) }}:

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -45,7 +45,9 @@ steps:
         releasego get-merged-pr-commit \
           -repo '$(TargetGitHubRepo)' \
           -pr '$(poll1MicrosoftGoPRNumber)' \
-          -github-pat '$(GitHubPAT)' \
+          -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+          -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+          -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
           -set-azdo-variable poll2MicrosoftGoCommitHash
       displayName: ⌚ Get sync PR merged commit hash
       timeoutInMinutes: 90
@@ -226,7 +228,9 @@ steps:
             -tag 'v$(buildAssetVersion)' \
             -commit '$(BuildInfoSourceVersion)' \
             -repo '$(TargetGitHubRepo)' \
-            -github-pat '$(GitHubPAT)'
+            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+            -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
         displayName: 🎓 Create GitHub tag
 
     - ${{ if eq(parameters.runGitHubRelease, true) }}:
@@ -236,7 +240,9 @@ steps:
             -repo '$(TargetGitHubRepo)' \
             -build-asset-json '$(buildAssetJsonFile)' \
             -build-dir '$(artifactsDir)' \
-            -github-pat '$(GitHubPAT)'
+            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+            -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
         displayName: 🎓 Create GitHub release
 
     - ${{ if eq(parameters.runAkaMSUpdate, true) }}:
@@ -295,7 +301,9 @@ steps:
           releasego get-merged-pr-commit \
             -repo '$(TargetGoImagesGitHubRepo)' \
             -pr '$(poll4MicrosoftGoImagesPRNumber)' \
-            -github-pat '$(GitHubPAT)'
+            -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+            -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+            -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
         displayName: ⌚ Wait for go-images update PR merge
         timeoutInMinutes: 120
         # Skip this task if the PR number isn't set. This might intentionally happen if we have to

--- a/eng/pipelines/steps/report.yml
+++ b/eng/pipelines/steps/report.yml
@@ -51,6 +51,8 @@ steps:
           -build-id '${{ parameters.buildID }}' \
           -build-status '${{ parameters.buildStatus }}' \
           -build-start=${{ parameters.start }} \
-          -github-pat '$(GitHubPAT)'
+          -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+          -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+          -github-app-private-key '$(BotAccount-bot-for-go-private-key)'
       displayName: 📣 Report ${{ parameters.reason }}
       condition: ${{ parameters.condition }}


### PR DESCRIPTION
Migrates further `releasego` commands to use GitHub app-based authentication.