### PR TITLE
Fix auth flags like `-github-reviewer-app-client-idreviewer`

### DIFF
--- a/githubutil/githubutil.go
+++ b/githubutil/githubutil.go
@@ -117,13 +117,13 @@ func BindGitHubAuthFlags(user string) *GitHubAuthFlags {
 			prefix+"-pat", "",
 			"The GitHub PAT to use. Exclusive with "+prefix+"-app-*"),
 		GitHubAppClientID: flag.String(
-			prefix+"-app-client-id"+user, "",
+			prefix+"-app-client-id", "",
 			"Use this GitHub App Client ID to authenticate to GitHub. "+appAuthTogether),
 		GitHubAppInstallation: flag.Int64(
-			prefix+"-app-installation"+user, 0,
+			prefix+"-app-installation", 0,
 			"Use this GitHub App Installation ID to authenticate to GitHub. "+appAuthTogether),
 		GitHubAppPrivateKey: flag.String(
-			prefix+"-app-private-key"+user, "",
+			prefix+"-app-private-key", "",
 			"Use this GitHub App Private Key to authenticate to GitHub, provided in base64 PEM format. "+appAuthTogether),
 	}
 }


### PR DESCRIPTION
The `user` string is erroneously being added as a suffix, when it is already added as part of the flag. Fixes `cmd/sync`, for example:

```
  -github-app-client-id string
        Use this GitHub App Client ID to authenticate to GitHub. If specified, all github-app-* flags must be specified.
  -github-app-installation int
        Use this GitHub App Installation ID to authenticate to GitHub. If specified, all github-app-* flags must be specified.
  -github-app-private-key string
        Use this GitHub App Private Key to authenticate to GitHub, provided in base64 PEM format. If specified, all github-app-* flags must be specified.
  -github-pat string
        The GitHub PAT to use. Exclusive with github-app-*
  -github-reviewer-app-client-idreviewer string
        Use this GitHub App Client ID to authenticate to GitHub. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-app-installationreviewer int
        Use this GitHub App Installation ID to authenticate to GitHub. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-app-private-keyreviewer string
        Use this GitHub App Private Key to authenticate to GitHub, provided in base64 PEM format. If specified, all github-reviewer-app-* flags must be specified.
  -github-reviewer-pat string
        The GitHub PAT to use. Exclusive with github-reviewer-app-*
```

* Fixes bug found while looking at https://github.com/microsoft/go-lab/issues/152