### PR TITLE
Implement telemetry API

### DIFF
--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -20,11 +20,11 @@ jobs:
       - template: steps/set-bot-git-author.yml
 
       - script: |
-          go test -json ./... > $(Build.StagingDirectory)/TestResults.json
+          go test -json ./... >> $(Build.StagingDirectory)/TestResults.json
         displayName: Test
         
       - script: |
-          go test -json -race ./... > $(Build.StagingDirectory)/TestResults.json
+          go test -json -race ./... >> $(Build.StagingDirectory)/TestResults.json
         displayName: Test Telemetry
         workingDirectory: $(Build.SourcesDirectory)/telemetry
         env:

--- a/telemetry/config.json
+++ b/telemetry/config.json
@@ -60,9 +60,6 @@
 			"Counters": [
 				{
 					"Name": "go/invocations"
-				},
-				{
-					"Name": "go/build/flag/buildmode:{archive,c-archive,c-shared,default,exe,pie,shared,plugin}"
 				}
 			]
 		}

--- a/telemetry/config.json
+++ b/telemetry/config.json
@@ -1,0 +1,70 @@
+{
+	"GOOS": [
+		"aix",
+		"android",
+		"darwin",
+		"dragonfly",
+		"freebsd",
+		"hurd",
+		"illumos",
+		"ios",
+		"js",
+		"linux",
+		"nacl",
+		"netbsd",
+		"openbsd",
+		"plan9",
+		"solaris",
+		"wasip1",
+		"windows",
+		"zos"
+	],
+	"GOARCH": [
+		"386",
+		"amd64",
+		"amd64p32",
+		"arm",
+		"arm64",
+		"arm64be",
+		"armbe",
+		"loong64",
+		"mips",
+		"mips64",
+		"mips64le",
+		"mips64p32",
+		"mips64p32le",
+		"mipsle",
+		"ppc",
+		"ppc64",
+		"ppc64le",
+		"riscv",
+		"riscv64",
+		"s390",
+		"s390x",
+		"sparc",
+		"sparc64",
+		"wasm"
+	],
+	"GoVersion": [
+		"go1.24rc1",
+		"go1.24rc2",
+		"go1.24rc3",
+		"go1.24.0",
+		"go1.24.1",
+		"go1.24.2",
+		"go1.24.3"
+	],
+	"Programs": [
+		{
+			"Name": "cmd/go",
+			"Counters": [
+				{
+					"Name": "go/invocations"
+				},
+				{
+					"Name": "go/build/flag/buildmode:{archive,c-archive,c-shared,default,exe,pie,shared,plugin}"
+				}
+			]
+		}
+	]
+}

--- a/telemetry/counter/counter.go
+++ b/telemetry/counter/counter.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package counter
+
+import (
+	"flag"
+	"path"
+	"runtime/debug"
+
+	"github.com/microsoft/go-infra/telemetry/internal/appinsights"
+	"github.com/microsoft/go-infra/telemetry/internal/telemetry"
+)
+
+// A Counter is a single named event counter.
+type Counter = appinsights.Event
+
+// Inc increments the counter with the given name.
+func Inc(name string) {
+	New(name).Inc()
+}
+
+// Add adds n to the counter with the given name.
+func Add(name string, n int64) {
+	New(name).Add(n)
+}
+
+// New returns a counter with the given name.
+func New(name string) *Counter {
+	return telemetry.Client.NewEvent(name)
+}
+
+// CountFlags creates a counter for every flag that is set
+// and increments the counter. The name of the counter is
+// the concatenation of prefix and the flag name.
+//
+//	For instance, CountFlags("gopls/flag:", *flag.CommandLine)
+func CountFlags(prefix string, fs flag.FlagSet) {
+	fs.Visit(func(f *flag.Flag) {
+		New(prefix + f.Name).Inc()
+	})
+}
+
+// CountCommandLineFlags creates a counter for every flag
+// that is set in the default flag.CommandLine FlagSet using
+// the counter name binaryName+"/flag:"+flagName where
+// binaryName is the base name of the Path embedded in the
+// binary's build info. If the binary does not have embedded build
+// info, the "flag:"+flagName counter will be incremented.
+//
+// CountCommandLineFlags must be called after flags are parsed
+// with flag.Parse.
+//
+// For instance, if the -S flag is passed to cmd/compile and
+// CountCommandLineFlags is called after flags are parsed,
+// the "compile/flag:S" counter will be incremented.
+func CountCommandLineFlags() {
+	prefix := "flag:"
+	if buildInfo, ok := debug.ReadBuildInfo(); ok && buildInfo.Path != "" {
+		prefix = path.Base(buildInfo.Path) + "/" + prefix
+	}
+	CountFlags(prefix, *flag.CommandLine)
+}

--- a/telemetry/internal/appinsights/internal/appinsightstest/appinsightstest.go
+++ b/telemetry/internal/appinsights/internal/appinsightstest/appinsightstest.go
@@ -18,7 +18,6 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -31,7 +30,7 @@ import (
 
 const test_ikey = "01234567-0000-89ab-cdef-000000000000"
 
-var envelopeName = "Microsoft.ApplicationInsights." + strings.Replace(test_ikey, "-", "", -1) + ".Event"
+var envelopeName = "Microsoft.ApplicationInsights.Event"
 
 // ActionType represents the type of action to be performed by the client.
 type ActionType int

--- a/telemetry/internal/appinsights/telemetrycontext.go
+++ b/telemetry/internal/appinsights/telemetrycontext.go
@@ -4,7 +4,6 @@
 package appinsights
 
 import (
-	"strings"
 	"time"
 
 	"github.com/microsoft/go-infra/telemetry/internal/appinsights/internal/contracts"
@@ -28,7 +27,7 @@ type telemetryContext struct {
 func newTelemetryContext(ikey string) *telemetryContext {
 	return &telemetryContext{
 		iKey:     ikey,
-		nameIKey: "Microsoft.ApplicationInsights." + strings.Replace(ikey, "-", "", -1) + ".Event",
+		nameIKey: "Microsoft.ApplicationInsights.Event",
 		Tags:     make(contracts.ContextTags),
 	}
 }

--- a/telemetry/internal/appinsights/telemetrycontext.go
+++ b/telemetry/internal/appinsights/telemetrycontext.go
@@ -16,9 +16,6 @@ type telemetryContext struct {
 	// Instrumentation key
 	iKey string
 
-	// Stripped-down instrumentation key used in envelope name
-	nameIKey string
-
 	// Collection of tag data to attach to the telemetry item.
 	Tags contracts.ContextTags
 }
@@ -26,9 +23,8 @@ type telemetryContext struct {
 // newTelemetryContext creates a new, empty telemetryContext.
 func newTelemetryContext(ikey string) *telemetryContext {
 	return &telemetryContext{
-		iKey:     ikey,
-		nameIKey: "Microsoft.ApplicationInsights.Event",
-		Tags:     make(contracts.ContextTags),
+		iKey: ikey,
+		Tags: make(contracts.ContextTags),
 	}
 }
 
@@ -36,7 +32,7 @@ func newTelemetryContext(ikey string) *telemetryContext {
 // context.
 func (context *telemetryContext) envelop(data contracts.EventData) *contracts.Envelope {
 	envelope := contracts.NewEnvelope()
-	envelope.Name = context.nameIKey
+	envelope.Name = "Microsoft.ApplicationInsights.Event"
 	envelope.Data = contracts.Data{
 		BaseType: "EventData",
 		BaseData: data,

--- a/telemetry/internal/config/config.go
+++ b/telemetry/internal/config/config.go
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// An UploadConfig controls what data is uploaded.
+type UploadConfig struct {
+	GOOS      []string
+	GOARCH    []string
+	GoVersion []string
+	Programs  []*ProgramConfig
+}
+
+// A ProgramConfig contains the configuration for a single program.
+type ProgramConfig struct {
+	// the counter names may have to be
+	// repeated for each program. (e.g., if the counters are in a package
+	// that is used in more than one program.)
+	Name     string
+	Counters []CounterConfig `json:",omitempty"`
+}
+
+// A CounterConfig contains the configuration for a single counter.
+type CounterConfig struct {
+	Name string // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
+}
+
+func ReadConfig(file string) (*UploadConfig, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return UnmarshalConfig(data)
+}
+
+func UnmarshalConfig(data []byte) (*UploadConfig, error) {
+	var cfg UploadConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Expand takes a counter defined with buckets and expands it into distinct
+// strings for each bucket.
+func Expand(counter string) []string {
+	prefix, rest, hasBuckets := strings.Cut(counter, "{")
+	var counters []string
+	if hasBuckets {
+		buckets := strings.SplitSeq(strings.TrimSuffix(rest, "}"), ",")
+		for b := range buckets {
+			counters = append(counters, prefix+b)
+		}
+	} else {
+		counters = append(counters, prefix)
+	}
+	return counters
+}

--- a/telemetry/internal/config/config_test.go
+++ b/telemetry/internal/config/config_test.go
@@ -1,6 +1,5 @@
-// Copyright 2023 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 package config
 

--- a/telemetry/internal/config/config_test.go
+++ b/telemetry/internal/config/config_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	_ "embed"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	f, err := os.Open(filepath.FromSlash("../../config.json"))
+	if os.IsNotExist(err) {
+		t.Skip("config file not found")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var cfg UploadConfig
+	d := json.NewDecoder(f)
+	d.DisallowUnknownFields()
+	if err := d.Decode(&cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/telemetry/internal/config/testdata/config.json
+++ b/telemetry/internal/config/testdata/config.json
@@ -1,0 +1,43 @@
+{
+  "Version": "v0.0.1-test",
+  "GOOS": [
+    "linux",
+    "darwin"
+  ],
+  "GOARCH": [
+    "amd64",
+    "arm64"
+  ],
+  "GoVersion": [
+    "go1.20",
+    "go1.20.1"
+  ],
+  "Programs": [
+    {
+      "Name": "golang.org/x/tools/gopls",
+      "Versions": [
+        "v0.10.1",
+        "v0.11.0"
+      ],
+      "Counters": [
+        {
+          "Name": "editor:{emacs,vim,vscode,other}",
+          "Rate": 0.01
+        }
+      ]
+    },
+    {
+      "Name": "cmd/go",
+      "Versions": [
+        "v0.10.1",
+        "v0.11.0"
+      ],
+      "Counters": [
+        {
+          "Name": "go/buildcache/miss:{0,0.1,0.2,0.5,1,10,100,2,20,5,50}",
+          "Rate": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/telemetry/internal/config/testdata/config.json
+++ b/telemetry/internal/config/testdata/config.json
@@ -15,27 +15,17 @@
   "Programs": [
     {
       "Name": "golang.org/x/tools/gopls",
-      "Versions": [
-        "v0.10.1",
-        "v0.11.0"
-      ],
       "Counters": [
         {
-          "Name": "editor:{emacs,vim,vscode,other}",
-          "Rate": 0.01
+          "Name": "editor:{emacs,vim,vscode,other}"
         }
       ]
     },
     {
       "Name": "cmd/go",
-      "Versions": [
-        "v0.10.1",
-        "v0.11.0"
-      ],
       "Counters": [
         {
-          "Name": "go/buildcache/miss:{0,0.1,0.2,0.5,1,10,100,2,20,5,50}",
-          "Rate": 0.01
+          "Name": "go/buildcache/miss:{0,0.1,0.2,0.5,1,10,100,2,20,5,50}"
         }
       ]
     }

--- a/telemetry/internal/telemetry/proginfo.go
+++ b/telemetry/internal/telemetry/proginfo.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry
+
+import (
+	"go/version"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+)
+
+// ProgramInfo extracts the go version and program package path to use for counter files.
+//
+// For programs in the Go toolchain, the program version will be the same as
+// the Go version, and will typically be of the form "go1.2.3", not a semantic
+// version of the form "v1.2.3". Go versions may also include spaces and
+// special characters.
+func ProgramInfo(info *debug.BuildInfo) (goVers, progPath string) {
+	goVers = info.GoVersion
+	if strings.Contains(goVers, "devel") || strings.Contains(goVers, "-") || !version.IsValid(goVers) {
+		goVers = "devel"
+	}
+
+	progPath = info.Path
+	if progPath == "" {
+		progPath = strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+	}
+
+	return goVers, progPath
+}

--- a/telemetry/internal/telemetry/telemetry.go
+++ b/telemetry/internal/telemetry/telemetry.go
@@ -1,0 +1,9 @@
+package telemetry
+
+import "github.com/microsoft/go-infra/telemetry/internal/appinsights"
+
+// Client is the global telemetry client used to send telemetry data.
+//
+// It is kept in an internal package to prevent direct access
+// from outside the telemetry package.
+var Client *appinsights.Client

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -94,8 +94,8 @@ func Start(cfg Config) {
 		MaxBatchSize:       cfg.MaxBatchSize,
 		MaxBatchInterval:   cfg.MaxBatchInterval,
 		Tags: map[string]string{
-			"ai.application.ver": ver,
-			"ai.device.model":    runtime.GOOS + "/" + runtime.GOARCH,
+			"ai.application.ver":  ver,
+			"ai.device.osVersion": runtime.GOOS + "/" + runtime.GOARCH,
 		},
 		UploadFilter: uploadFilter,
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -96,6 +96,7 @@ func Start(cfg Config) {
 		Tags: map[string]string{
 			"ai.application.ver":  ver,
 			"ai.device.osVersion": runtime.GOOS + "/" + runtime.GOARCH,
+			"ai.cloud.role":       prog,
 		},
 		UploadFilter: uploadFilter,
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -94,9 +94,8 @@ func Start(cfg Config) {
 		MaxBatchSize:       cfg.MaxBatchSize,
 		MaxBatchInterval:   cfg.MaxBatchInterval,
 		Tags: map[string]string{
-			"msgo.go.goos":    runtime.GOOS,
-			"msgo.go.goarch":  runtime.GOARCH,
-			"msgo.go.version": ver,
+			"ai.application.ver": ver,
+			"ai.device.model":    runtime.GOOS + "/" + runtime.GOARCH,
 		},
 		UploadFilter: uploadFilter,
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"slices"
+	"time"
+
+	"github.com/microsoft/go-infra/telemetry/internal/appinsights"
+	"github.com/microsoft/go-infra/telemetry/internal/config"
+	"github.com/microsoft/go-infra/telemetry/internal/telemetry"
+)
+
+// Config holds the configuration for the telemetry client.
+type Config struct {
+	// The instrumentation key used to identify the application.
+	// This key is required and must be set before sending any telemetry.
+	InstrumentationKey string
+
+	// The endpoint URL to which telemetry will be sent.
+	// If empty, it defaults to https://dc.services.visualstudio.com/v2/track.
+	Endpoint string
+
+	// Maximum number of telemetry items that can be submitted in each
+	// request. If this many items are buffered, the buffer will be
+	// flushed before MaxBatchInterval expires.
+	// If zero, it defaults to 1024.
+	MaxBatchSize int
+
+	// Maximum time to wait before sending a batch of telemetry.
+	// If zero, it defaults to 10 seconds.
+	MaxBatchInterval time.Duration
+
+	// UploadConfigPath is the path to the telemetry upload configuration file.
+	// If empty, the default configuration embedded in the binary will be used.
+	UploadConfigPath string
+}
+
+//go:embed config.json
+var uploadConfigData []byte
+
+var countersToUpload map[string]struct{}
+
+// Start initializes telemetry using the specified configuration.
+func Start(cfg Config) {
+	var uploadConfig *config.UploadConfig
+	var err error
+	if cfg.UploadConfigPath != "" {
+		uploadConfig, err = config.ReadConfig(cfg.UploadConfigPath)
+	} else {
+		uploadConfig, err = config.UnmarshalConfig(uploadConfigData)
+	}
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal telemetry config: %v", err))
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		panic("failed to read build info for telemetry")
+	}
+	ver, prog := telemetry.ProgramInfo(bi)
+	if !slices.Contains(uploadConfig.GOOS, runtime.GOOS) ||
+		!slices.Contains(uploadConfig.GOARCH, runtime.GOARCH) ||
+		!slices.Contains(uploadConfig.GoVersion, ver) {
+		// Only start telemetry if the current GOOS, GOARCH, and Go version
+		// are supported by the telemetry configuration.
+		return
+	}
+
+	progIdx := slices.IndexFunc(uploadConfig.Programs, func(p *config.ProgramConfig) bool {
+		return p.Name == prog
+	})
+	if progIdx == -1 {
+		return // Program not configured for telemetry
+	}
+	countersToUpload = make(map[string]struct{})
+	for _, c := range uploadConfig.Programs[progIdx].Counters {
+		if c.Name == "" {
+			continue // Skip empty counter names
+		}
+		for _, e := range config.Expand(c.Name) {
+			countersToUpload[e] = struct{}{}
+		}
+	}
+
+	telemetry.Client = &appinsights.Client{
+		InstrumentationKey: cfg.InstrumentationKey,
+		Endpoint:           cfg.Endpoint,
+		MaxBatchSize:       cfg.MaxBatchSize,
+		MaxBatchInterval:   cfg.MaxBatchInterval,
+		Tags: map[string]string{
+			"msgo.go.goos":    runtime.GOOS,
+			"msgo.go.goarch":  runtime.GOARCH,
+			"msgo.go.version": ver,
+		},
+		UploadFilter: uploadFilter,
+	}
+}
+
+// Close closes the telemetry client and flushes any remaining telemetry data.
+// It should be called when the application is shutting down to ensure all
+// telemetry data is sent before the program exits.
+func Close(ctx context.Context) {
+	if telemetry.Client != nil {
+		telemetry.Client.Close(ctx)
+	}
+}
+
+func uploadFilter(name string) bool {
+	_, ok := countersToUpload[name]
+	return ok
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"fmt"
 	"runtime"
@@ -88,6 +89,10 @@ func Start(cfg Config) {
 		}
 	}
 
+	// Generate a random session ID to uniquely identify this telemetry session.
+	var sessionID [32]byte
+	rand.Read(sessionID[:])
+
 	telemetry.Client = &appinsights.Client{
 		InstrumentationKey: cfg.InstrumentationKey,
 		Endpoint:           cfg.Endpoint,
@@ -97,6 +102,7 @@ func Start(cfg Config) {
 			"ai.application.ver":  ver,
 			"ai.device.osVersion": runtime.GOOS + "/" + runtime.GOARCH,
 			"ai.cloud.role":       prog,
+			"ai.session.id":       fmt.Sprintf("%x", sessionID[:]),
 		},
 		UploadFilter: uploadFilter,
 	}

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -111,7 +111,7 @@ func startTelemetry(t *testing.T, cfg config.UploadConfig, uploads int) {
 		t.Fatal(err)
 	}
 	cfgFilePath := filepath.Join(t.TempDir(), "config.json")
-	if err := os.WriteFile(cfgFilePath, cfgData, 0644); err != nil {
+	if err := os.WriteFile(cfgFilePath, cfgData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	telemetry.Start(telemetry.Config{

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/microsoft/go-infra/telemetry"
+	"github.com/microsoft/go-infra/telemetry/counter"
+	"github.com/microsoft/go-infra/telemetry/internal/config"
+	itelemetry "github.com/microsoft/go-infra/telemetry/internal/telemetry"
+)
+
+func TestTelemetry(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+
+	testTelemetry(t, uploadConfig, 4)
+}
+
+func TestTelemetryWrongGOOS(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	uploadConfig.GOOS = []string{"not-a-real-os"} // intentionally wrong
+
+	testTelemetry(t, uploadConfig, 0)
+}
+
+func TestTelemetryWrongGOARCH(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	uploadConfig.GOARCH = []string{"not-a-real-arch"} // intentionally wrong
+
+	testTelemetry(t, uploadConfig, 0)
+}
+
+func TestTelemetryWrongGoVersion(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	uploadConfig.GoVersion = []string{"not-a-real-go-version"} // intentionally wrong
+
+	testTelemetry(t, uploadConfig, 0)
+}
+
+func TestTelemetryWrongGoProgram(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	uploadConfig.Programs[0].Name = "not-a-real-program" // intentionally wrong
+
+	testTelemetry(t, uploadConfig, 0)
+}
+
+func testTelemetry(t *testing.T, config config.UploadConfig, uploads int) {
+	startTelemetry(t, config, uploads)
+
+	counter.Inc("test_counter")
+	counter.Inc("go:0") // skipped
+	counter.Inc("go:1")
+	counter.Inc("go:2")
+	counter.Inc("go:3")
+	counter.Inc("go:4") // skipped
+
+	telemetry.Close(t.Context())
+}
+
+func baseUploadConfig(t *testing.T) config.UploadConfig {
+	t.Helper()
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		t.Fatal("failed to read build info")
+	}
+	ver, prog := itelemetry.ProgramInfo(bi)
+	return config.UploadConfig{
+		GOOS:      []string{runtime.GOOS},
+		GOARCH:    []string{runtime.GOARCH},
+		GoVersion: []string{ver},
+		Programs: []*config.ProgramConfig{
+			{
+				Name: prog,
+				Counters: []config.CounterConfig{
+					{Name: "test_counter"},
+					{Name: "go:{1,2,3}"},
+				},
+			},
+		},
+	}
+}
+
+func startTelemetry(t *testing.T, cfg config.UploadConfig, uploads int) {
+	t.Helper()
+	var got int
+	httptestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got++
+		if got > uploads {
+			t.Errorf("too many uploads: got %d, want %d", got, uploads)
+		}
+		fmt.Fprintf(w, `{"itemsReceived": %d, "itemsAccepted": %d}`, uploads, uploads)
+	}))
+	t.Cleanup(func() {
+		if got < uploads {
+			t.Errorf("expected %d uploads, got %d", uploads, got)
+		}
+		httptestServer.Close()
+	})
+	cfgData, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgFilePath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(cfgFilePath, cfgData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	telemetry.Start(telemetry.Config{
+		InstrumentationKey: "fake-key",
+		Endpoint:           httptestServer.URL,
+		MaxBatchSize:       1,
+		UploadConfigPath:   cfgFilePath,
+	})
+}


### PR DESCRIPTION
This PR exposes the necessary APIs to upload telemetry from the Microsoft build of Go. The API is modeled in a way that can easily be used together with https://github.com/golang/telemetry so that both can coexist.

Usage example:

```go
import (
  "context"

  "github.com/microsoft/go-infra/telemetry"
  "github.com/microsoft/go-infra/telemetry/counter"
)

func main(
  telemetry.Start(telemetry.Config{
    InstrumentationKey: "fake_key",
  })
  counter.Inc("fake_counter")
  telemetry.Close(context.Background())
)
```

Only counters that exist in the `telemetry/config.json` file will be uploaded (the file will be embedded in any binary importing `telemetry`). Each counter comes with 5 metadata entries: GOOS, GOARCH, Go version, program name, and a unique session id.

The philosophy here is the same as in upstream Go: we don't upload data that does not appear verbatim in the config file. This means that the config file should contain all supported GOOs, GOARCHs, Go versions, and program names. It will simplify the CELA approval request.

For now, the list only includes one counters: the number of `cmd/go` invocations (which is the Go toolchain entry point). We can extend this list as we find other counters that are valuable for us. Note that this will make the telemetry upload work almost unnoticeable given that it will only upload one counter at the beginning of the program execution.

For https://github.com/microsoft/go/issues/1672.