### PR TITLE
Add appinsights prefix to the default telemetry error logger

### DIFF
--- a/telemetry/internal/appinsights/client.go
+++ b/telemetry/internal/appinsights/client.go
@@ -72,7 +72,12 @@ func (c *Client) init() {
 		batchSize := cmp.Or(c.MaxBatchSize, 1024)
 		batchInterval := cmp.Or(c.MaxBatchInterval, 10*time.Second)
 		httpClient := cmp.Or(c.HTTPClient, http.DefaultClient)
-		c.channel = newInMemoryChannel(endpoint, batchSize, batchInterval, httpClient, c.ErrorLog)
+		errorLog := c.ErrorLog
+		if errorLog == nil {
+			std := log.Default()
+			errorLog = log.New(std.Writer(), std.Prefix()+"appinsights: ", std.Flags())
+		}
+		c.channel = newInMemoryChannel(endpoint, batchSize, batchInterval, httpClient, errorLog)
 		c.context = setupContext(c.InstrumentationKey, c.Tags)
 		if err := contracts.SanitizeTags(c.context.Tags); err != nil {
 			c.channel.logf("Warning sanitizing tags: %v", err)

--- a/telemetry/internal/appinsights/inmemorychannel.go
+++ b/telemetry/internal/appinsights/inmemorychannel.go
@@ -81,11 +81,7 @@ func newInMemoryChannel(endpointUrl string, batchSize int, batchInterval time.Du
 }
 
 func (channel *inMemoryChannel) logf(format string, args ...any) {
-	if channel.errorLog != nil {
-		channel.errorLog.Printf(format, args...)
-	} else {
-		log.Printf(format, args...)
-	}
+	channel.errorLog.Printf(format, args...)
 }
 
 // Queues a single telemetry item


### PR DESCRIPTION
Having the error logs prefixed with `appinsights` by default is useful to see the lines related to this module at a first sight.