### PR TITLE
Add arbitrary telemetry client package, properties

### DIFF
--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,3 +1,7 @@
 # telemetry
 
-This directory contains the telemetry transmission code for the Microsoft build of Go.
+This directory, the `telemetry` package, contains the telemetry transmission code for the Microsoft build of Go.
+It is specialized to work similarly to the upstream telemetry counters.
+
+The [`appinsights`](appinsights) package is an alternative client that can send more arbitrary telemetry event data to Application Insights.
+It only supports a few features of Application Insights that are used in other projects maintained by the Microsoft build of Go team.

--- a/telemetry/appinsights/appinsights.go
+++ b/telemetry/appinsights/appinsights.go
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package appinsights provides a client for sending arbitrary telemetry event
+// data to Application Insights.
+package appinsights
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/microsoft/go-infra/telemetry/internal/appinsights"
+	"github.com/microsoft/go-infra/telemetry/internal/telemetry"
+)
+
+// Config holds the configuration for the telemetry client.
+type Config struct {
+	// The instrumentation key used to identify the application.
+	// This key is required and must be set before sending any telemetry.
+	InstrumentationKey string
+
+	// The endpoint URL to which telemetry will be sent.
+	// If empty, it defaults to https://dc.services.visualstudio.com/v2/track.
+	Endpoint string
+
+	// Maximum number of telemetry items that can be submitted in each
+	// request. If this many items are buffered, the buffer will be
+	// flushed before MaxBatchInterval expires.
+	// If zero, it defaults to 1024.
+	MaxBatchSize int
+
+	// Maximum time to wait before sending a batch of telemetry.
+	// If zero, it defaults to 10 seconds.
+	MaxBatchInterval time.Duration
+
+	// ErrorLog specifies an optional logger for errors
+	// that occur when attempting to upload telemetry.
+	// If nil, logging is done via the log package's standard logger.
+	ErrorLog *log.Logger
+}
+
+// Start initializes telemetry using the specified configuration.
+func Start(cfg Config) {
+	telemetry.Init(&appinsights.Client{
+		InstrumentationKey: cfg.InstrumentationKey,
+		Endpoint:           cfg.Endpoint,
+		MaxBatchSize:       cfg.MaxBatchSize,
+		MaxBatchInterval:   cfg.MaxBatchInterval,
+		ErrorLog:           cfg.ErrorLog,
+	})
+}
+
+// Close closes the telemetry client and flushes any remaining telemetry data.
+// It should be called when the application is shutting down to ensure all
+// telemetry data is sent before the program exits.
+func Close(ctx context.Context) {
+	if telemetry.Client != nil {
+		telemetry.Client.Close(ctx)
+	}
+}
+
+// TrackEvent sends a telemetry event with the specified name and properties.
+func TrackEvent(name string, properties map[string]string) {
+	if telemetry.Client != nil {
+		telemetry.Client.TrackEventWithProperties(name, properties)
+	}
+}

--- a/telemetry/internal/appinsights/client.go
+++ b/telemetry/internal/appinsights/client.go
@@ -108,6 +108,14 @@ func (c *Client) TrackEvent(name string) {
 	c.NewEvent(name).Inc()
 }
 
+func (c *Client) TrackEventWithProperties(name string, properties map[string]string) {
+	c.track(contracts.EventData{
+		Name:       name,
+		Ver:        2,
+		Properties: properties,
+	}, 1)
+}
+
 // Forces the current queue to be sent.
 func (c *Client) Flush() {
 	if !c.initialized.Load() {

--- a/telemetry/internal/telemetry/telemetry.go
+++ b/telemetry/internal/telemetry/telemetry.go
@@ -1,9 +1,32 @@
 package telemetry
 
-import "github.com/microsoft/go-infra/telemetry/internal/appinsights"
+import (
+	"crypto/rand"
+	"fmt"
+	"runtime"
+
+	"github.com/microsoft/go-infra/telemetry/internal/appinsights"
+)
 
 // Client is the global telemetry client used to send telemetry data.
 //
 // It is kept in an internal package to prevent direct access
 // from outside the telemetry package.
 var Client *appinsights.Client
+
+// Init adds common tags to the telemetry client then assigns it to [Client].
+func Init(client *appinsights.Client) {
+	if client.Tags == nil {
+		client.Tags = make(map[string]string)
+	}
+
+	// Generate a random session ID to uniquely identify this telemetry session.
+	var sessionID [32]byte
+	rand.Read(sessionID[:])
+
+	// Add common tags to the client.
+	client.Tags["ai.device.osVersion"] = runtime.GOOS + "/" + runtime.GOARCH
+	client.Tags["ai.session.id"] = fmt.Sprintf("%x", sessionID[:])
+
+	Client = client
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -5,7 +5,6 @@ package telemetry
 
 import (
 	"context"
-	"crypto/rand"
 	_ "embed"
 	"fmt"
 	"runtime"
@@ -96,23 +95,17 @@ func Start(cfg Config) {
 		}
 	}
 
-	// Generate a random session ID to uniquely identify this telemetry session.
-	var sessionID [32]byte
-	rand.Read(sessionID[:])
-
-	telemetry.Client = &appinsights.Client{
+	telemetry.Init(&appinsights.Client{
 		InstrumentationKey: cfg.InstrumentationKey,
 		Endpoint:           cfg.Endpoint,
 		MaxBatchSize:       cfg.MaxBatchSize,
 		MaxBatchInterval:   cfg.MaxBatchInterval,
 		Tags: map[string]string{
-			"ai.application.ver":  ver,
-			"ai.device.osVersion": runtime.GOOS + "/" + runtime.GOARCH,
-			"ai.cloud.role":       prog,
-			"ai.session.id":       fmt.Sprintf("%x", sessionID[:]),
+			"ai.application.ver": ver,
+			"ai.cloud.role":      prog,
 		},
 		UploadFilter: uploadFilter,
-	}
+	})
 }
 
 // Close closes the telemetry client and flushes any remaining telemetry data.


### PR DESCRIPTION
Add a package for arbitrary events that can be imported separately, avoiding importing the config system and counter APIs, and avoiding exposing the arbitrary event APIs to the Microsoft build of Go.

Add support for `Properties` to the events. This is pretty simple: just an extra map pointer that's always nil for the Microsoft build of Go cases.

Includes properties map sanitization, copied from the original module. Made a simple test to check that it's working.

Doesn't include features like CommonProperties attached to the Client--this can be done just as well (and perhaps better) by the caller. No metrics, only events.

No effect on the benchmark:

```
goos: windows
goarch: amd64
pkg: github.com/microsoft/go-infra/telemetry/internal/appinsights
cpu: Intel(R) Core(TM) i7-9700 CPU @ 3.00GHz
                         │ before.txt  │           after.txt           │
                         │   sec/op    │   sec/op     vs base          │
ClientBurstPerformance-8   695.6n ± 2%   693.4n ± 2%  ~ (p=0.853 n=10)
```