### PR TITLE
telemetry: use version.IsValid instead of hardcoding versions

### DIFF
--- a/telemetry/config.json
+++ b/telemetry/config.json
@@ -45,15 +45,6 @@
 		"sparc64",
 		"wasm"
 	],
-	"GoVersion": [
-		"go1.24rc1",
-		"go1.24rc2",
-		"go1.24rc3",
-		"go1.24.0",
-		"go1.24.1",
-		"go1.24.2",
-		"go1.24.3"
-	],
 	"Programs": [
 		{
 			"Name": "cmd/go",

--- a/telemetry/internal/config/config.go
+++ b/telemetry/internal/config/config.go
@@ -11,10 +11,9 @@ import (
 
 // An UploadConfig controls what data is uploaded.
 type UploadConfig struct {
-	GOOS      []string
-	GOARCH    []string
-	GoVersion []string
-	Programs  []*ProgramConfig
+	GOOS     []string
+	GOARCH   []string
+	Programs []*ProgramConfig
 }
 
 // A ProgramConfig contains the configuration for a single program.

--- a/telemetry/internal/config/testdata/config.json
+++ b/telemetry/internal/config/testdata/config.json
@@ -8,10 +8,6 @@
     "amd64",
     "arm64"
   ],
-  "GoVersion": [
-    "go1.20",
-    "go1.20.1"
-  ],
   "Programs": [
     {
       "Name": "golang.org/x/tools/gopls",

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -40,13 +40,6 @@ func TestTelemetryWrongGOARCH(t *testing.T) {
 	testTelemetry(t, uploadConfig, 0)
 }
 
-func TestTelemetryWrongGoVersion(t *testing.T) {
-	uploadConfig := baseUploadConfig(t)
-	uploadConfig.GoVersion = []string{"not-a-real-go-version"} // intentionally wrong
-
-	testTelemetry(t, uploadConfig, 0)
-}
-
 func TestTelemetryWrongGoProgram(t *testing.T) {
 	uploadConfig := baseUploadConfig(t)
 	uploadConfig.Programs[0].Name = "not-a-real-program" // intentionally wrong
@@ -73,11 +66,10 @@ func baseUploadConfig(t *testing.T) config.UploadConfig {
 	if !ok {
 		t.Fatal("failed to read build info")
 	}
-	ver, prog := itelemetry.ProgramInfo(bi)
+	_, prog := itelemetry.ProgramInfo(bi)
 	return config.UploadConfig{
-		GOOS:      []string{runtime.GOOS},
-		GOARCH:    []string{runtime.GOARCH},
-		GoVersion: []string{ver},
+		GOOS:   []string{runtime.GOOS},
+		GOARCH: []string{runtime.GOARCH},
 		Programs: []*config.ProgramConfig{
 			{
 				Name: prog,
@@ -119,5 +111,6 @@ func startTelemetry(t *testing.T, cfg config.UploadConfig, uploads int) {
 		Endpoint:           httptestServer.URL,
 		MaxBatchSize:       1,
 		UploadConfigPath:   cfgFilePath,
+		AllowGoDevel:       true,
 	})
 }


### PR DESCRIPTION
We currently don't start a telemetry session if the Go version used to build the instrumented binary is not part of the hardcoded supported Go versions. This puts a lot of burden on us, as we need to remember to update that list before shipping a new release and re-vendor go-infra into the Go toolchain.

This is done to avoid putting data that we don't control in the telemetry.

This PR takes another approach: instead of hardcoding the supported Go versions, we use the [`version.IsValid`](https://pkg.go.dev/go/version#IsValid) function to check if the Go version follows the "go1.2.3" spec. If it doesn't, then we don't start the telemetry session by default.

Note that the Go version is ultimately hardcoded in the Go toolchain repository, so it is data that we own.