### PR TITLE
Upgrade windows image version

### DIFF
--- a/.github/workflows/install-script-pwsh-test.yml
+++ b/.github/workflows/install-script-pwsh-test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/mingw-test.yml
+++ b/.github/workflows/mingw-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-2019, windows-2022 ]
+        os: [ windows-2022, windows-2025 ]
         go-version: [ 1.23.x, 1.22.x ]
         mingw-version:
           - '-source nixman -version 13.2.0-rt_v11-rev0 -arch x86_64 -threading posix -exception seh -runtime msvcrt'


### PR DESCRIPTION
Windows 2019 is no longer supported on GHA. Use Windows 2025 instead.