### PR TITLE
Fix GitHub App GetIdentity, add github-who-am-i

### DIFF
--- a/cmd/releasego/github-who-am-i.go
+++ b/cmd/releasego/github-who-am-i.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "github-who-am-i",
+		Summary: "Print the identity of the specified GitHub user. Intended for debugging.",
+		Handle:  handleWhoAmI,
+	})
+}
+
+func handleWhoAmI(p subcmd.ParseFunc) error {
+	auth := githubutil.BindGitHubAuthFlags("")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	log.SetPrefix("github-who-am-i: ")
+	log.SetFlags(0)
+
+	ctx := context.Background()
+	if err := accordingToAuther(auth); err != nil {
+		log.Printf("error in accordingToAuther: %v\n", err)
+	}
+	if err := accordingToUser(ctx, auth); err != nil {
+		log.Printf("error in accordingToUser: %v\n", err)
+	}
+	if err := accordingToApp(ctx, auth); err != nil {
+		log.Printf("error in accordingToApp: %v\n", err)
+	}
+	return nil
+}
+
+func accordingToAuther(f *githubutil.GitHubAuthFlags) error {
+	identity, err := f.NewAuther()
+	if err != nil {
+		return err
+	}
+	id, err := identity.GetIdentity()
+	if err != nil {
+		return err
+	}
+	log.Printf("According to NewAuther: %s\n", id)
+	return nil
+}
+
+func accordingToUser(ctx context.Context, f *githubutil.GitHubAuthFlags) error {
+	client, err := f.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	user, _, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(user, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	log.Printf("According to client.Users.Get: %s\n", data)
+	return nil
+}
+
+func accordingToApp(ctx context.Context, f *githubutil.GitHubAuthFlags) error {
+	client, err := f.NewAppClient(ctx)
+	if err != nil {
+		return err
+	}
+	app, _, err := client.Apps.Get(ctx, "")
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(app, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	log.Printf("According to client.Apps.Get: %s\n", data)
+	return nil
+}

--- a/githubutil/githubutil.go
+++ b/githubutil/githubutil.go
@@ -129,6 +129,8 @@ func BindGitHubAuthFlags(user string) *GitHubAuthFlags {
 }
 
 // NewClient returns a GitHub client based on the flags (e.g. PAT, GitHub App).
+//
+// If not enough information is present in f, returns ErrNoAuthProvided.
 func (f *GitHubAuthFlags) NewClient(ctx context.Context) (*github.Client, error) {
 	if *f.GitHubPat != "" {
 		return NewClient(ctx, *f.GitHubPat)
@@ -145,6 +147,18 @@ func (f *GitHubAuthFlags) NewClient(ctx context.Context) (*github.Client, error)
 				*f.GitHubAppInstallation,
 				*f.GitHubAppPrivateKey)
 		}
+	}
+	return nil, ErrNoAuthProvided
+}
+
+// NewAppClient returns a GitHub client for the GitHub App, not the installation
+// of the app. This client can be used to get information about the app itself,
+// like its name.
+//
+// If not enough information is present in f, returns ErrNoAuthProvided.
+func (f *GitHubAuthFlags) NewAppClient(ctx context.Context) (*github.Client, error) {
+	if *f.GitHubAppClientID != "" && *f.GitHubAppPrivateKey != "" {
+		return newAppClient(ctx, *f.GitHubAppClientID, *f.GitHubAppPrivateKey)
 	}
 	return nil, ErrNoAuthProvided
 }


### PR DESCRIPTION
Fix identity detection by the GitHub App auther.

* Fixes https://github.com/microsoft/go-lab/issues/218

Add a debug releasego subcommand to exercise this flow locally. This could be added to the release pipeline for diagnosis.

Remove cluttering JWT debug logs by default.

```
$ go run ./cmd/releasego github-who-am-i ($ghappargs -split ' ')
github-who-am-i: According to NewAuther: dagood-app
github-who-am-i: error in accordingToUser: Get "https://api.github.com/user": POST ...: 404 Not Found []
github-who-am-i: According to client.Apps.Get: {
    "id": 1162194,
    "slug": "dagood-app",
    "node_id": "A_kwDOAMOcS84AEbvS",
    "owner": {
      "login": "dagood",
...
    },
    "name": "dagood App",
...
    "installations_count": 2
  }
```

```
$ go run ./cmd/releasego github-who-am-i -github-pat $ghpat
github-who-am-i: According to NewAuther: dagood-bot
github-who-am-i: According to client.Users.Get: {
    "login": "dagood-bot",
...
  }
github-who-am-i: error in accordingToApp: no GitHub authentication provided
```