### PR TITLE
Add git go-patch review

### DIFF
--- a/cmd/git-go-patch/README.md
+++ b/cmd/git-go-patch/README.md
@@ -88,6 +88,22 @@ Then, you can create new commits to try the rebase again.
 
 The [Reset Demystified](https://git-scm.com/book/en/v2/Git-Tools-Reset-Demystified) chapter of the Pro Git book may be helpful to understand the state of the Git repository, the index, and the working directory during each step of the recovery process.
 
+## Review a PR's patch file changes
+
+When reviewing a pull request that modifies patch files, it can be difficult to understand what the actual changes are by just looking at the diff in GitHub.
+The `git go-patch review` subcommand helps by setting up the changes locally for easier review.
+
+This command:
+1. Prompts for a GitHub PR URL
+1. Fetches PR information from GitHub
+1. Applies the base branch patches with a special "before" marker
+1. Applies the PR branch patches with a special "after" marker
+1. Sets up a diff in the Git stage that shows exactly what changes the PR introduces
+
+After running the command, you can review the changes using `git diff --cached` in the submodule directory or your IDE's Git tools to see a clean presentation of what the PR changes in context.
+
+For more control over each part of the process, or to review changes that aren't in a GitHub PR, use the `git go-patch apply` `-before` and `-after` flags, then `git go-patch stage-diff`.
+
 ## Fix up patch files after a submodule update
 
 Every so often, you need to update your submodule to the latest version of the upstream repo.

--- a/cmd/git-go-patch/apply.go
+++ b/cmd/git-go-patch/apply.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/microsoft/go-infra/executil"
+	"github.com/microsoft/go-infra/gitcmd"
 	"github.com/microsoft/go-infra/patch"
 	"github.com/microsoft/go-infra/subcmd"
 	"github.com/microsoft/go-infra/submodule"
@@ -136,18 +136,7 @@ func getCurrentCommit(goDir string) (string, error) {
 }
 
 func getTargetSubmoduleCommit(rootDir, submoduleDir string) (string, error) {
-	cmd := exec.Command("git", "ls-tree", "HEAD", submoduleDir)
-	cmd.Dir = rootDir
-	// Format, from Git docs: "<mode> SP <type> SP <object> TAB <file>"
-	lsOut, err := executil.SpaceTrimmedCombinedOutput(cmd)
-	if err != nil {
-		return "", err
-	}
-	treeData := strings.Fields(lsOut)
-	if len(treeData) <= 2 {
-		return "", fmt.Errorf("output from git ls-tree doesn't contain enough fields: %v", lsOut)
-	}
-	return treeData[2], nil
+	return gitcmd.GetSubmoduleCommitAtRev(rootDir, submoduleDir, "HEAD")
 }
 
 func ensureSubmoduleCommitNotDirty(config *patch.FoundConfig) error {

--- a/cmd/git-go-patch/review.go
+++ b/cmd/git-go-patch/review.go
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v65/github"
+	"github.com/microsoft/go-infra/gitcmd"
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/patch"
+	"github.com/microsoft/go-infra/subcmd"
+	"github.com/microsoft/go-infra/submodule"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "review",
+		Summary: "Review a GitHub PR's patch changes locally.",
+		Description: `
+This command helps review a PR's patch file changes. It takes a GitHub PR URL (like 
+https://github.com/microsoft/go/pull/1234), and sets up a stage diff to review the changes.
+
+Auth is not required. Attempts to use anonymous access if auth isn't specified.
+
+Under the hood, it:
+1. Gets the PR details from GitHub (base branch and PR branch)
+2. Fetches the specific commits
+3. Uses Git to check out the patch files to a temporary directory
+3. Runs "git go-patch apply -before" using the merge base commit
+4. Runs "git go-patch apply -after" using the PR branch commit
+5. Runs "git go-patch stage-diff" to prepare the changes for review
+
+(It doesn't literally execute shell commands, but uses the same logic.)
+
+Note that this command doesn't check out commits in the outer repository. However, it does
+modify the state of your submodule, like the "stage-diff" command.
+
+The result is that the submodule will be in a state where the staged changes represent 
+the patch modifications introduced by the PR, ready for review using Git tools like 
+"git diff --cached" or IDE diff viewers.
+` + repoRootSearchDescription,
+		Handle: handleReviewGH,
+	})
+}
+
+func handleReviewGH(p subcmd.ParseFunc) error {
+	prURL := flag.String(
+		"url", "",
+		"The GitHub PR URL to review, format https://github.com/microsoft/go/pull/<number>[extraneous].\n"+
+			"If not provided, interactively prompts. The prompt may make it easier to avoid shell quoting/escaping issues.\n"+
+			"In the last segment, anything starting with / or # is ignored, for more flexibility when copying PR URLs.")
+	authFlags := githubutil.BindGitHubAuthFlags("")
+	force := flag.Bool("f", false, "Force apply: throw away changes in the submodule.")
+	yes := flag.Bool("y", false, "Skip confirmation prompt.")
+	keepWork := flag.Bool("w", false, "Keep the temporary work directory with patch files.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	urlToUse := *prURL
+	if urlToUse == "" {
+		fmt.Print("Enter GitHub PR URL: ")
+		var err error
+		urlToUse, err = readStdinLine()
+		if err != nil {
+			return fmt.Errorf("failed to read PR URL: %v", err)
+		}
+		if urlToUse == "" {
+			return fmt.Errorf("PR URL cannot be empty")
+		}
+	}
+
+	owner, repo, prNum, err := parsePRURL(urlToUse)
+	if err != nil {
+		return fmt.Errorf("invalid PR URL format: %v\nExpected format: https://github.com/owner/repo/pull/number", err)
+	}
+
+	// Create a GitHub client
+	ctx := context.Background()
+
+	var client *github.Client
+	client, err = authFlags.NewClient(ctx)
+	if err != nil {
+		if errors.Is(err, githubutil.ErrNoAuthProvided) {
+			client = github.NewClient(nil)
+		} else {
+			return fmt.Errorf("failed to create GitHub client: %v", err)
+		}
+	}
+
+	// Get PR information from GitHub
+	pr, _, err := client.PullRequests.Get(ctx, owner, repo, prNum)
+	if err != nil {
+		return fmt.Errorf("failed to get PR information: %v", err)
+	}
+
+	// Extract base and head branch information
+	baseBranch := pr.GetBase().GetRef()
+	baseSHA := pr.GetBase().GetSHA()
+	headBranch := pr.GetHead().GetRef()
+	headSHA := pr.GetHead().GetSHA()
+
+	fmt.Printf("\nFound %v/%v PR #%d: %s\n", owner, repo, prNum, pr.GetTitle())
+	fmt.Printf("Base branch: %q %s\n", baseBranch, baseSHA)
+	fmt.Printf("Head branch: %q %s\n", headBranch, headSHA)
+
+	if !*yes {
+		fmt.Printf("Are you sure you want to stage the changes? (y/N): ")
+		var confirmation string
+		fmt.Scanln(&confirmation)
+		if strings.ToLower(confirmation) != "y" {
+			log.Println("Review aborted by user.")
+			return nil
+		}
+	}
+
+	config, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	rootDir, goDir := config.FullProjectRoots()
+
+	log.Println("Fetching PR branch commits...")
+
+	ownerRemoteURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	// Fetch the actual commits without creating refs. Both commits are
+	// available through the base repo because a PR must have come from another
+	// repo in the repository fork network.
+	if err := gitcmd.Run(rootDir, "fetch", ownerRemoteURL, baseSHA, headSHA); err != nil {
+		return fmt.Errorf("failed to fetch commits: %v", err)
+	}
+
+	baseSubmoduleSHA, err := gitcmd.GetSubmoduleCommitAtRev(rootDir, goDir, baseSHA)
+	if err != nil {
+		return fmt.Errorf("failed to get base submodule commit: %v", err)
+	}
+	headSubmoduleSHA, err := gitcmd.GetSubmoduleCommitAtRev(rootDir, goDir, headSHA)
+	if err != nil {
+		return fmt.Errorf("failed to get head submodule commit: %v", err)
+	}
+	log.Printf("Base submodule commit: %s\n", baseSubmoduleSHA)
+	log.Printf("Head submodule commit: %s\n", headSubmoduleSHA)
+
+	// The base branch is just the target. We need to find the actual merge-base
+	// to avoid adding unrelated changes to the staged review. Now that we've
+	// pulled both commits locally, we must also have the shared base, and we
+	// don't need to use another GitHub API call to get this done.
+	mergeBaseCommit, err := gitcmd.CombinedOutput(
+		rootDir,
+		"merge-base",
+		pr.GetBase().GetSHA(),
+		pr.GetHead().GetSHA(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to find merge base between head and base branches: %v", err)
+	}
+	mergeBaseCommit = strings.TrimSpace(mergeBaseCommit)
+
+	// Create a temporary directory to store before/after patch files.
+	tempDir, err := os.MkdirTemp("", "git-go-patch-review-patches-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory for patches: %v", err)
+	}
+	if !*keepWork {
+		defer os.RemoveAll(tempDir) // Best effort cleanup.
+	}
+
+	headPatchDir := filepath.Join(tempDir, "head")
+	os.MkdirAll(headPatchDir, 0o755)
+
+	basePatchDir := filepath.Join(tempDir, "base")
+	os.MkdirAll(basePatchDir, 0o755)
+
+	// Check out patch files into temp dir.
+	//
+	// Small assumption: the layout of the repository hasn't changed between the
+	// commit the user happens to have checked out and the PR to review.
+	if err := gitcmd.CheckoutRevToTargetDir(rootDir, mergeBaseCommit, config.PatchesDir, basePatchDir); err != nil {
+		return fmt.Errorf("failed to check out base patch files into temp directory: %v", err)
+	}
+	if err := gitcmd.CheckoutRevToTargetDir(rootDir, headSHA, config.PatchesDir, headPatchDir); err != nil {
+		return fmt.Errorf("failed to check out head patch files into temp directory: %v", err)
+	}
+
+	log.Println("Applying base branch patches...")
+	if err := resetSubmoduleTo(rootDir, goDir, baseSubmoduleSHA, *force); err != nil {
+		return err
+	}
+	if err := applyPatchCommits(goDir, filepath.Join(basePatchDir, config.PatchesDir)); err != nil {
+		return fmt.Errorf("failed to apply base branch patches: %v", err)
+	}
+	if err := createBranch(goDir, stageDiffBeforeBranch); err != nil {
+		return err
+	}
+
+	log.Println("Applying PR branch patches...")
+	if err := resetSubmoduleTo(rootDir, goDir, headSubmoduleSHA, *force); err != nil {
+		return err
+	}
+	if err := applyPatchCommits(goDir, filepath.Join(headPatchDir, config.PatchesDir)); err != nil {
+		return fmt.Errorf("failed to apply PR branch patches: %v", err)
+	}
+	if err := createBranch(goDir, stageDiffAfterBranch); err != nil {
+		return err
+	}
+
+	// Delete the status files. (Best effort.) This will make sure the rebase
+	// and extract subcommands won't run: it isn't clear what that should really
+	// do in this state.
+	_ = os.RemoveAll(config.FullStatusFileDir())
+
+	log.Println("Setting up diff for review...")
+	if err := runStageDiff(goDir, stageDiffBeforeBranch, stageDiffAfterBranch); err != nil {
+		return fmt.Errorf("failed to set up stage diff for review: %v", err)
+	}
+
+	fmt.Println("\nReview setup complete!")
+	fmt.Println("You can now review the changes using:")
+	fmt.Println("  - git diff --cached (in the submodule)")
+	fmt.Println("  - Your IDE's Git diff viewer")
+	fmt.Printf("  - cd %s && git status (to see affected files)\n", goDir)
+	fmt.Printf("\nWhen you're done, run 'git go-patch apply -f' to reset the submodule.\n")
+
+	if baseSubmoduleSHA != headSubmoduleSHA {
+		fmt.Printf("\nWARNING: The submodule commit has changed from %s to %s.\n", baseSubmoduleSHA, headSubmoduleSHA)
+		fmt.Println("The staged changes may not all be caused by the patch differences.")
+	}
+
+	return nil
+}
+
+// resetSubmoduleTo resets the submodule (or fails if dirty) then checks out the
+// target commit.
+func resetSubmoduleTo(rootDir, goDir, commit string, force bool) error {
+	if err := submodule.Reset(rootDir, goDir, force); err != nil {
+		return fmt.Errorf("failed to reset submodule: %v", err)
+	}
+	if err := gitcmd.Run(goDir, "checkout", commit); err != nil {
+		return fmt.Errorf("failed to check out commit in submodule: %v", err)
+	}
+	return nil
+}
+
+func applyPatchCommits(goDir, patchDir string) error {
+	args := []string{"am", "--whitespace=nowarn"}
+	patch.WalkPatches(patchDir, func(file string) error {
+		args = append(args, file)
+		return nil
+	})
+	return gitcmd.Run(goDir, args...)
+}
+
+func parsePRURL(urlStr string) (owner, repo string, prNum int, err error) {
+	fail := func(err error) (string, string, int, error) {
+		return "", "", 0, fmt.Errorf("invalid PR URL: %s", err)
+	}
+	// Clean up: trim whitespace and trailing slashes.
+	urlStr = strings.TrimSpace(urlStr)
+	urlStr = strings.TrimRight(urlStr, "/")
+
+	suffix, ok := strings.CutPrefix(urlStr, "https://github.com/")
+	if !ok {
+		return fail(fmt.Errorf("URL must start with https://github.com/"))
+	}
+	owner, suffix, ok = strings.Cut(suffix, "/")
+	if !ok {
+		return fail(fmt.Errorf("URL must contain owner name"))
+	}
+	repo, suffix, ok = strings.Cut(suffix, "/")
+	if !ok {
+		return fail(fmt.Errorf("URL must contain repository name"))
+	}
+	suffix, ok = strings.CutPrefix(suffix, "pull/")
+	if !ok {
+		return fail(fmt.Errorf("URL must contain 'pull/' before PR number: %v", suffix))
+	}
+	// Ignore anything after another / (.../files) or # (...#issuecomment...).
+	suffix, _, _ = strings.Cut(suffix, "/")
+	suffix, _, _ = strings.Cut(suffix, "#")
+
+	prNum, err = strconv.Atoi(suffix)
+	if err != nil {
+		return fail(fmt.Errorf("PR number must be an integer: %v", err))
+	}
+	return owner, repo, prNum, nil
+}
+
+func readStdinLine() (string, error) {
+	var line string
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		line = scanner.Text()
+	} else {
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("failed to read input: %v", err)
+		}
+		return "", fmt.Errorf("no input provided")
+	}
+	if line == "" {
+		return "", fmt.Errorf("input cannot be empty")
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", fmt.Errorf("input cannot be just whitespace")
+	}
+	return line, nil
+}

--- a/cmd/git-go-patch/stage-diff.go
+++ b/cmd/git-go-patch/stage-diff.go
@@ -54,11 +54,15 @@ func handleStageDiff(p subcmd.ParseFunc) error {
 	}
 	_, goDir := config.FullProjectRoots()
 
+	return runStageDiff(goDir, stageDiffBeforeBranch, stageDiffAfterBranch)
+}
+
+func runStageDiff(goDir, beforeBranch, afterBranch string) error {
 	// Set up stage.
-	if err := executil.Run(executil.Dir(goDir, "git", "checkout", "--detach", stageDiffAfterBranch)); err != nil {
+	if err := executil.Run(executil.Dir(goDir, "git", "checkout", "--detach", afterBranch)); err != nil {
 		return err
 	}
 
 	// Move to the "before" commit, but keep the "after" stage.
-	return executil.Run(executil.Dir(goDir, "git", "reset", "--soft", stageDiffBeforeBranch))
+	return executil.Run(executil.Dir(goDir, "git", "reset", "--soft", beforeBranch))
 }

--- a/executil/executil.go
+++ b/executil/executil.go
@@ -21,7 +21,11 @@ func Run(c *exec.Cmd) error {
 
 // RunQuiet logs the command line and runs the given command, but sends the output to os.DevNull.
 func RunQuiet(c *exec.Cmd) error {
-	fmt.Printf("---- Running command: %v %v\n", c.Path, c.Args)
+	var in string
+	if c.Dir != "" {
+		in = fmt.Sprintf(" in %#q", c.Dir)
+	}
+	fmt.Printf("---- Running command: %v %v%s\n", c.Path, c.Args, in)
 	return c.Run()
 }
 

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -6,7 +6,11 @@
 package gitcmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -57,6 +61,68 @@ func Show(dir, rev string) (string, error) {
 // See https://git-scm.com/docs/git-show#_pretty_formats
 func ShowQuietPretty(dir, format, rev string) (string, error) {
 	return CombinedOutput(dir, "show", "--quiet", "--pretty=format:"+format, strings.TrimSpace(rev))
+}
+
+// GetSubmoduleCommitAtRev returns the commit hash of the submodule at the given
+// revision. submoduleDir may be absolute or relative to dir.
+func GetSubmoduleCommitAtRev(dir, submoduleDir, rev string) (string, error) {
+	output, err := CombinedOutput(dir, "ls-tree", rev, submoduleDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get submodule commit at %q: %v", rev, err)
+	}
+
+	// Format, from Git docs: "<mode> SP <type> SP <object> TAB <file>"
+	fields := strings.Fields(output)
+	if len(fields) <= 2 {
+		return "", fmt.Errorf("output from git ls-tree doesn't contain enough fields: %q", output)
+	}
+	return fields[2], nil
+}
+
+// CheckoutRevToTargetDir checks out the given path/subdir of the repository at
+// the given revision into the target directory.
+func CheckoutRevToTargetDir(dir, rev, path, targetDir string) error {
+	data, err := executil.Dir(dir, "git", "archive", "--format=tar", rev, "--", path).Output()
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %v", err)
+	}
+	r := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := r.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break // End of archive.
+			}
+			return fmt.Errorf("failed to read next tar entry: %v", err)
+		}
+		if !filepath.IsLocal(hdr.Name) {
+			continue
+		}
+		// Don't create dirs when specified, just make them when necessary.
+		if hdr.FileInfo().IsDir() {
+			continue
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		targetPath := filepath.Join(targetDir, hdr.Name)
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return fmt.Errorf("failed to create directory for %q: %v", targetPath, err)
+		}
+		f, err := os.Create(targetPath)
+		if err != nil {
+			return fmt.Errorf("failed to create file %q: %v", targetPath, err)
+		}
+		_, err = io.Copy(f, r)
+		closeErr := f.Close()
+		if err != nil {
+			return fmt.Errorf("failed to copy data to %q: %v", targetPath, err)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("failed to close file %q: %v", targetPath, closeErr)
+		}
+	}
+	return nil
 }
 
 // GetGlobalAuthor returns the author that a new Git commit would be written by, based (only!) on

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -95,7 +95,8 @@ func CheckoutRevToTargetDir(dir, rev, path, targetDir string) error {
 			}
 			return fmt.Errorf("failed to read next tar entry: %v", err)
 		}
-		if !filepath.IsLocal(hdr.Name) {
+		name := hdr.Name
+		if !filepath.IsLocal(name) {
 			continue
 		}
 		// Don't create dirs when specified, just make them when necessary.
@@ -105,7 +106,7 @@ func CheckoutRevToTargetDir(dir, rev, path, targetDir string) error {
 		if hdr.Typeflag != tar.TypeReg {
 			continue
 		}
-		targetPath := filepath.Join(targetDir, hdr.Name)
+		targetPath := filepath.Join(targetDir, name)
 		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 			return fmt.Errorf("failed to create directory for %q: %v", targetPath, err)
 		}


### PR DESCRIPTION
Add `git go-patch review`, a tool to stage patch PRs locally for in-context code review.

Streamlines a process I've been doing recently of checking out the merge-base commit manually, `git go-patch apply -before`, check out the PR, `git go-patch apply -after`, and `git go-patch stage-diff`. This new command also doesn't touch your outer repository state (other than the submodule status).

Not the cleanest code, but it seems worth having. For anyone who is used to the safeguards of not passing `-f`, needing to pass `-f` to clear the stage after finishing a review (or manually clearing it) might be jarring. A new status file that specifically allows `git go-patch apply` to overwrite staged changes might be useful in that situation, as a future improvement.