### PR TITLE
telemetry: run test cleanups before synctest bubbles finishes

### DIFF
--- a/telemetry/internal/appinsights/client_test.go
+++ b/telemetry/internal/appinsights/client_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build goexperiment.synctest
+//go:build (go1.24 && goexperiment.synctest) || go1.25
 
 package appinsights_test
 
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net/http"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/microsoft/go-infra/telemetry/internal/appinsights"
@@ -29,7 +28,7 @@ type testPlan struct {
 }
 
 func (plan testPlan) run(t *testing.T) {
-	synctest.Run(func() {
+	syncRun(t, func(t *testing.T) {
 		client := appinsightstest.New(t, plan.actions, plan.responses...)
 		client.SetMaxBatchSize(plan.maxBatchSize)
 		client.SetMaxBatchInterval(plan.maxBatchInterval)
@@ -44,6 +43,7 @@ func TestClientNoUpload(t *testing.T) {
 		maxBatchSize: 2,
 		actions: []appinsightstest.Action{
 			{Type: appinsightstest.TrackAction},
+			{Type: appinsightstest.StopAction},
 		},
 	}
 	plan.run(t)

--- a/telemetry/internal/appinsights/go1.24_test.go
+++ b/telemetry/internal/appinsights/go1.24_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build goexperiment.synctest && !go1.25
+
+package appinsights_test
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func syncRun(t *testing.T, f func(*testing.T)) {
+	synctest.Run(func() {
+		// We need that t.Cleanup is called after the test function
+		// has finished, but before sync.Run finishes.
+		// This is because sync.Run will wait for all goroutines to finish,
+		// and we want to ensure that the cleanup is done before that.
+		// TODO: remove this file once go1.24 is no longer supported.
+		t.Run(t.Name(), func(t *testing.T) {
+			f(t)
+		})
+	})
+}

--- a/telemetry/internal/appinsights/go1.25_test.go
+++ b/telemetry/internal/appinsights/go1.25_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//go:build go1.25
+
+package appinsights_test
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func syncRun(t *testing.T, f func(*testing.T)) {
+	synctest.Test(t, f)
+}

--- a/telemetry/internal/appinsights/internal/appinsightstest/appinsightstest.go
+++ b/telemetry/internal/appinsights/internal/appinsightstest/appinsightstest.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//go:build goexperiment.synctest
+//go:build goexperiment.synctest || go1.25
 
 // This package contains test utilities for the Application Insights SDK.
 package appinsightstest


### PR DESCRIPTION
Go 1.24 synctest experiment doesn't work well with `t.Cleanup` callback. If not used with care, it is likely that they are called after the synctest bubble has finished, which will likely produce a panic with the following error message: `panic: deadlock: all goroutines in bubble are blocked`.

To fix this we need to create a subtest inside the bubble, and attach the cleanup callbacks to that subtest.

Fortunately, Go 1.25 fixed this flaw by deprecating `synctest.Run` in favor of `synctest.Test`, which plays nicely with cleanup callbacks. Also, Go 1.25 graduated the `synctest` experiment, so there is no need to gate it behind a goexperiment tag.

Fixes https://github.com/microsoft/go-lab/issues/219.