### PR TITLE
security: prevent directory traversal in tar extraction

### DIFF
--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -99,6 +99,10 @@ func CheckoutRevToTargetDir(dir, rev, path, targetDir string) error {
 		if !filepath.IsLocal(name) {
 			continue
 		}
+		// Additional check to prevent directory traversal attacks
+		if strings.Contains(name, "..") {
+			continue
+		}
 		// Don't create dirs when specified, just make them when necessary.
 		if hdr.FileInfo().IsDir() {
 			continue


### PR DESCRIPTION
Add check for ".." in tar entry names to fix CodeQL SM03409