### PR TITLE
telemetry: upload go subcommands

### DIFF
--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -54,6 +54,9 @@
 				},
 				{
 					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto}"
+				},
+				{
+					"Name": "go/subcommand:{build,install,run}"
 				}
 			]
 		}


### PR DESCRIPTION
Only add `build`, `install`, and `run`. Other commands won't upload telemetry at all as of today.