### PR TITLE
Trigger Go-Canary pipeline as part of default job

### DIFF
--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -39,7 +39,7 @@ parameters:
   - name: runCanary
     displayName: Trigger go-canary pipeline
     type: boolean
-    default: false
+    default: true
   - name: runTag
     displayName: Tag the release.
     type: boolean


### PR DESCRIPTION
This pull request includes a single change to the `eng/pipelines/release-build-pipeline.yml` file. The change updates the default value of the `runCanary` parameter from `false` to `true`, ensuring that the go-canary pipeline is triggered by default.