### PR TITLE
codeql: switch to autobuild task

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,7 @@ jobs:
         uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         with:
           languages: go
-          build-mode: manual
-
-      - run: go build ./...
+          build-mode: autobuild
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5


### PR DESCRIPTION
For some reason we were using the manual build process which I don't think is neccessary here