### PR TITLE
tsa: programatically define tsa options for rolling-internal-validation pipeline

### DIFF
--- a/eng/pipelines/rolling-internal-validation-pipeline.yml
+++ b/eng/pipelines/rolling-internal-validation-pipeline.yml
@@ -72,7 +72,17 @@ extends:
         suppressionFile: $(Build.SourcesDirectory)/.config/guardian/.gdnsuppress
       tsa:
         enabled: ${{ not(parameters.disableTSA) }}
-        configFile: $(Build.SourcesDirectory)/.config/tsa/tsaoptions.json
+        config:
+          codebaseName: 'Go'
+          notificationAliases:
+            - 'golangdev@microsoft.com'
+          codebaseAdmins:
+            - 'redmond\golangdev'
+          instanceUrl: 'https://devdiv.visualstudio.com/'
+          projectName: 'DEVDIV'
+          areaPath: 'DevDiv\GoLang'
+          iterationPath: 'DevDiv'
+          allTools: true
       sourceRepositoriesToScan:
         include:
           - repository: GoMirror


### PR DESCRIPTION
fixes: https://github.com/microsoft/go-lab/issues/229

We can't create a `.config/tsa/tsaoptions.json` file in the go-mirror repo so it makes sense to define the config programatically. 

Test pipeline: https://dev.azure.com/dnceng/internal/_build/results?buildId=2764284&view=logs&j=01e604db-8465-5451-86dd-345721db2731