### PR TITLE
Revert "codeql: mark SM03409 as false positive"

### DIFF
--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -88,7 +88,7 @@ func CheckoutRevToTargetDir(dir, rev, path, targetDir string) error {
 	}
 	r := tar.NewReader(bytes.NewReader(data))
 	for {
-		hdr, err := r.Next() // CodeQL [SM03409] false positive: this will be fixed in the CodeQL CLI (https://github.com/github/codeql/issues/20043)
+		hdr, err := r.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break // End of archive.


### PR DESCRIPTION
Reverts microsoft/go-infra#298