### PR TITLE
Revert "codeql: switch to autobuild task"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,9 @@ jobs:
         uses: github/codeql-action/init@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
         with:
           languages: go
-          build-mode: autobuild
+          build-mode: manual
+
+      - run: go build ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5


### PR DESCRIPTION
Reverts microsoft/go-infra#299

For some reason it fails like this otherwise:

<img width="934" height="141" alt="Screenshot 2025-08-04 at 18 46 29" src="https://github.com/user-attachments/assets/49c49d75-3391-4902-8e28-215111d27714" />
