### PR TITLE
Wait for CI rather than launching the microsoft/go pipeline

### DIFF
--- a/cmd/releasego/wait-ci-trigger.go
+++ b/cmd/releasego/wait-ci-trigger.go
@@ -105,7 +105,7 @@ func handleWaitCITrigger(p subcmd.ParseFunc) error {
 		if len(statuses) == topLimit {
 			return fmt.Errorf(
 				"found %d statuses for commit %q, which is the maximum number that could be returned. "+
-					"There may be more. It's not expected that there are this many statuses and this is likely a deeper problem.",
+					"There may be more. It's not expected that there are this many statuses and this is likely a deeper problem",
 				topLimit, *commit)
 		}
 

--- a/cmd/releasego/wait-ci-trigger.go
+++ b/cmd/releasego/wait-ci-trigger.go
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/pipelines"
+	"github.com/microsoft/go-infra/azdo"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "wait-ci-trigger",
+		Summary: "Wait for (or find) a build started by a specific commit's CI trigger.",
+		Description: `
+
+Search for a build in the specified pipeline that was started by a CI trigger on
+a specified commit hash. If no build exists matching the criteria, poll until a
+timeout is hit. If a build isn't found, fail.
+`,
+		Handle: handleWaitCITrigger,
+	})
+}
+
+func handleWaitCITrigger(p subcmd.ParseFunc) error {
+	pipelineID := flag.Int("pipeline-id", 0, "[Required] The AzDO pipeline ID to query.")
+	repositoryID := flag.String("repository-id", "", "[Required] The AzDO repository ID to query. GUID or name.")
+	commit := flag.String("commit", "", "[Required] The commit hash.")
+
+	setVariable := flag.String("set-azdo-variable", "", "An AzDO variable name to set to the ID of the discovered build.")
+	timeout := flag.Duration("timeout", 5*time.Minute, "How long to wait for a build to be found before failing.")
+	timeBetween := flag.Duration("time-between-retries", 5*time.Second, "How long to wait between retries.")
+
+	azdoFlags := azdo.BindClientFlags()
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if *pipelineID == 0 {
+		flag.Usage()
+		return errors.New("no pipeline ID specified")
+	}
+	if *commit == "" {
+		flag.Usage()
+		return errors.New("no commit specified")
+	}
+	if err := azdoFlags.EnsureAssigned(); err != nil {
+		flag.Usage()
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	g, err := git.NewClient(ctx, azdoFlags.NewConnection())
+	if err != nil {
+		return err
+	}
+
+	pc := pipelines.NewClient(ctx, azdoFlags.NewConnection())
+	pipeline, err := pc.GetPipeline(ctx, pipelines.GetPipelineArgs{
+		Project:    azdoFlags.Proj,
+		PipelineId: pipelineID,
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("Found pipeline %q (%d)\n", *pipeline.Name, *pipeline.Id)
+
+	trueBool := true
+	topLimit := 1000 // Same as default, but specify to be sure it doesn't change.
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		statusesPtr, err := g.GetStatuses(ctx, git.GetStatusesArgs{
+			Project:      azdoFlags.Proj,
+			RepositoryId: repositoryID,
+			CommitId:     commit,
+			LatestOnly:   &trueBool,
+			Top:          &topLimit,
+		})
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		statuses := *statusesPtr
+		if len(statuses) == topLimit {
+			return fmt.Errorf(
+				"found %d statuses for commit %q, which is the maximum number that could be returned. "+
+					"There may be more. It's not expected that there are this many statuses and this is likely a deeper problem.",
+				topLimit, *commit)
+		}
+
+		statuses = slices.DeleteFunc(statuses, func(s git.GitStatus) bool {
+			if s.Context == nil {
+				return false
+			}
+			return *s.Context.Name != "build/"+*pipeline.Name
+		})
+		if len(statuses) == 0 {
+			log.Printf("No status found. Trying again after %v...", *timeBetween)
+			time.Sleep(*timeBetween)
+			continue
+		}
+
+		status := statuses[0]
+		log.Printf(
+			"Found build status %q for commit %q with targetUrl %q\n",
+			*status.Context.Name, *commit, *status.TargetUrl)
+
+		buildID, ok := strings.CutPrefix(*status.TargetUrl, "vstfs:///Build/Build/")
+		if !ok {
+			return fmt.Errorf("unexpected prefix in targetUrl %q", *status.TargetUrl)
+		}
+
+		log.Printf("Found build ID %q\n", buildID)
+		// For any humans watching, create a clickable link.
+		log.Printf(
+			"Build link: %v%v/_build/results?buildId=%v",
+			*azdoFlags.Org, *azdoFlags.Proj, buildID,
+		)
+		if *setVariable != "" {
+			azdo.LogCmdSetVariable(*setVariable, buildID)
+		}
+
+		return nil
+	}
+}

--- a/cmd/releasego/wait-ci-trigger.go
+++ b/cmd/releasego/wait-ci-trigger.go
@@ -110,8 +110,8 @@ func handleWaitCITrigger(p subcmd.ParseFunc) error {
 		}
 
 		statuses = slices.DeleteFunc(statuses, func(s git.GitStatus) bool {
-			if s.Context == nil {
-				return false
+			if s.Context == nil || s.Context.Name == nil {
+				return true
 			}
 			return *s.Context.Name != "build/"+*pipeline.Name
 		})

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -69,33 +69,22 @@ steps:
       displayName: ⌚ Wait for internal mirror
       timeoutInMinutes: 16 # See https://github.com/microsoft/go-lab/issues/124
 
-    # When queueing a build, AzDO requires the given Commit is reachable from Branch, and the
-    # default Branch is "microsoft/main". So, we need to figure out the release branch name
-    # and save it as a variable to pass it to AzDO.
+    # Wait until a build is automatically started for the merged commit. We
+    # don't trigger the build ourselves because manual builds that do signing
+    # require approval through a manual, time-consuming procedure.
     #
-    # Testing adds a complication: testing commits won't be found in the actual release
-    # branches, so we need a way to override. This is done using BuildPipelineFullBranchName
-    # from the variable group. For actual releases, it should have the value
-    # "refs/heads/microsoft/$(UpstreamTargetBranchName)". But in a testing variable group, it
-    # can point at any ordinary dev branch that has the sync commit.
+    # If a build starts but can't be found by this command, the release runner
+    # can retry the pipeline with the build ID manually filled in.
     - script: |
-        releasego get-target-branch \
-          -version '${{ parameters.releaseVersion }}' \
-          -set-azdo-variable-branch-name UpstreamTargetBranchName
-      displayName: Get target branch containing commit
-
-    - script: |
-        releasego build-pipeline \
+        releasego wait-ci-trigger \
           -commit '$(poll2MicrosoftGoCommitHash)' \
-          -branch '$(BuildPipelineFullBranchName)' \
-          -id '$(GoPipelineID)' \
+          -pipeline-id '$(GoPipelineID)' \
+          -repository-id microsoft-go \
           -org 'https://dev.azure.com/dnceng/' \
           -proj 'internal' \
           -azdopat '$(System.AccessToken)' \
-          -set-azdo-variable poll3MicrosoftGoBuildID \
-          p releaseVersion '${{ parameters.releaseVersion }}' \
-          pOptional publishReleaseStudio true
-      displayName: 🚀 Run microsoft/go internal build
+          -set-azdo-variable poll3MicrosoftGoBuildID
+      displayName: ⌚ Find microsoft/go internal CI build
 
     - template: ../steps/report.yml
       parameters:
@@ -109,7 +98,7 @@ steps:
         reason: queued build
 
     - ${{ if eq(parameters.runInnerloop, true) }}:
-      # Above, we launched the official build. Now launch innerloop tests. We actually
+      # Above, we found the official build. Now launch innerloop tests. We actually
       # don't poll this build here: it's a release pipeline, so it reports its own
       # status to the release issue. This also means it runs in parallel.
       - script: |


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/232
* For https://github.com/microsoft/go-lab/issues/225

Test build (essentially only this step): https://dev.azure.com/dnceng/internal/_build/results?buildId=2768060&view=logs&j=19992227-62fb-5b50-4e29-3b72bd33eea1&t=3d27e4ef-59c0-5b63-2f42-89a3d12e6d9c&l=80