### PR TITLE
Increase timeout for builds causing release interruption

### DIFF
--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -174,7 +174,7 @@ extends:
                           -proj 'internal' \
                           -azdopat '$(System.AccessToken)'
                       displayName: ⌚ Wait for go-images build
-                      timeoutInMinutes: 120
+                      timeoutInMinutes: 180
 
                 - ${{ if eq(parameters.runPublishAnnouncement, true) }}:
                   - script: |

--- a/eng/pipelines/steps/release-build-steps.yml
+++ b/eng/pipelines/steps/release-build-steps.yml
@@ -147,7 +147,7 @@ steps:
           -proj 'internal' \
           -azdopat '$(System.AccessToken)'
       displayName: ⌚ Wait for internal build
-      timeoutInMinutes: 180
+      timeoutInMinutes: 240
 
     - template: ../steps/report.yml
       parameters:


### PR DESCRIPTION
* Fixes https://github.com/microsoft/go-lab/issues/236

In https://github.com/microsoft/go/issues/1807 we observed:
microsoft-go: 3h 26m and 3h 5m, increase to 4h (240m)
microsoft-go-images: 2h 0m 6s (another recent build is 2h 5m), increase to 3h (180m)