### PR TITLE
Trigger Go-Canary pipeline as part of default job

### DIFF
--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -41,7 +41,7 @@ parameters:
   - name: runCanary
     displayName: Trigger go-canary pipeline
     type: boolean
-    default: false
+    default: true
   - name: runTag
     displayName: Tag the release.
     type: boolean


### PR DESCRIPTION
This[ PR was reverted this change](https://github.com/microsoft/go-infra/pull/303), but underlying issue is fixed and now go-canary pipeline works as expected.