### PR TITLE
Include MICROSOFT_REVISION file even if it's 1

### DIFF
--- a/sync/model.go
+++ b/sync/model.go
@@ -89,8 +89,8 @@ type ConfigEntry struct {
 	GoVersionFileContent string
 
 	// GoMicrosoftRevisionFileContent is empty, or the Microsoft revision (1, 2, ...) that the
-	// microsoft/go build should use after the sync. If 1, removes the MICROSOFT_REVISION file if
-	// one exists. If 2 or more, creates a MICROSOFT_REVISION file to specify it.
+	// microsoft/go build should use after the sync. Empty leaves the MICROSOFT_REVISION file alone,
+	// any other value creates/updates the MICROSOFT_REVISION file.
 	GoMicrosoftRevisionFileContent string
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -569,14 +569,8 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 
 			// Ensure the Microsoft revision file is what we expect it to be. If there is no
 			// expected revision, leave it alone.
-			if entry.GoMicrosoftRevisionFileContent != "" {
-				var content string
-				// We only need a MICROSOFT_REVISION file for revisions > 1 (the default/minimum).
-				if entry.GoMicrosoftRevisionFileContent != "1" {
-					content = entry.GoMicrosoftRevisionFileContent
-				}
-
-				if err := updateFile(filepath.Join(dir, "MICROSOFT_REVISION"), content); err != nil {
+			if rev := entry.GoMicrosoftRevisionFileContent; rev != "" {
+				if err := updateFile(filepath.Join(dir, "MICROSOFT_REVISION"), rev); err != nil {
 					return nil, err
 				}
 			}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -96,7 +96,7 @@ func Test_MakeBranchPRs_VersionUpdate(t *testing.T) {
 			true,
 			makeFlags(false),
 			"go1.18.2", "1",
-			"go1.18.2", "",
+			"go1.18.2", "1",
 		},
 		{
 			"update rev1 version (boring branch) with create-branches enabled",
@@ -106,7 +106,7 @@ func Test_MakeBranchPRs_VersionUpdate(t *testing.T) {
 			// flag doesn't cause errors in ordinary cases.
 			makeFlags(true),
 			"go1.18.2", "1",
-			"go1.18.2", "",
+			"go1.18.2", "1",
 		},
 		{
 			"remove version",


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/262

Makes it easier to spot an indicator when poking around `go env GOROOT` without documentation telling you what to look for.

Also improves reliability by making sure the Microsoft build of Go 1.24.5-1 and 1.24.5-2 are more similar. We haven't had a problem caused by this file existing/not existing, but a decent improvement to stave it off.

Essentially, helps with something like `go version`, does nothing for `go version -m <...>`.