### PR TITLE
goinstallscript: clarify instructions, use "tool", help with test case

### DIFF
--- a/goinstallscript/cmd/creategotest/README.md
+++ b/goinstallscript/cmd/creategotest/README.md
@@ -1,0 +1,8 @@
+# creategotest
+
+This command creates a Go test file that checks whether the `go-install.ps1` script is up to date.
+
+See [the module README](../../README.md#adding-a-go-test-to-check-for-updates) for details.
+
+The generated test file is written to `goinstallscript/goinstallscript_test.go` relative to the current directory.
+It's generated in a subdirectory to avoid a name conflict with the `package` declaration of the current directory, and to clearly isolate it.

--- a/goinstallscript/cmd/creategotest/_template/goinstallscript_test.go
+++ b/goinstallscript/cmd/creategotest/_template/goinstallscript_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestMicrosoftBuildOfGoInstallScriptIsUpToDate(t *testing.T) {
+	cmd := exec.Command("go", "run", "github.com/microsoft/go-infra/goinstallscript", "-check")
+	cmd.Dir = ".."
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Errorf("Microsoft build of Go Install Script is out of date:\n%v", string(out))
+	}
+}

--- a/goinstallscript/cmd/creategotest/main.go
+++ b/goinstallscript/cmd/creategotest/main.go
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed _template/goinstallscript_test.go
+var goTestTemplate string
+
+const goTestFilePath = "goinstallscript/goinstallscript_test.go"
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if err := os.MkdirAll(filepath.Dir(goTestFilePath), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(goTestFilePath, []byte(goTestTemplate), 0o644); err != nil {
+		return err
+	}
+	fmt.Println("Created " + goTestFilePath)
+	return nil
+}


### PR DESCRIPTION
* For https://github.com/microsoft/go/issues/1850
* Much more direct help with setting up the test to make sure `go-install.ps1` is up to date.
* Make the error message from a failed check more actionable by showing the dir and command to run.