### PR TITLE
Modernize pass

### DIFF
--- a/azdo/azdo.go
+++ b/azdo/azdo.go
@@ -54,11 +54,11 @@ func (c *ClientFlags) NewConnection() *azuredevops.Connection {
 
 // GetBuildWebURL finds the web/UI URL (not API endpoint URL) in the given AzDO Build, if it exists.
 func GetBuildWebURL(b *build.Build) (string, bool) {
-	links, ok := b.Links.(map[string]interface{})
+	links, ok := b.Links.(map[string]any)
 	if !ok {
 		return "", false
 	}
-	web, ok := links["web"].(map[string]interface{})
+	web, ok := links["web"].(map[string]any)
 	if !ok {
 		return "", false
 	}

--- a/buildmodel/buildmodel.go
+++ b/buildmodel/buildmodel.go
@@ -132,8 +132,8 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 			// because CI splits up platform builds onto independent machines based on Windows
 			// version, and the nanoserver image build needs to access the windowsservercore image.
 			nanoserverPrefix := "nanoserver-"
-			if strings.HasPrefix(osVersion, nanoserverPrefix) {
-				windowsVersion := strings.TrimPrefix(osVersion, nanoserverPrefix)
+			if after, ok := strings.CutPrefix(osVersion, nanoserverPrefix); ok {
+				windowsVersion := after
 				buildArgs = map[string]string{
 					// nanoserver doesn't have good download capability, so it copies the Go install
 					// from the windowsservercore image.
@@ -214,7 +214,7 @@ func UpdateManifest(manifest *dockermanifest.Manifest, versions dockerversions.V
 		manifest = &dockermanifest.Manifest{
 			Readme:    "README.md",
 			Registry:  "mcr.microsoft.com",
-			Variables: map[string]interface{}{},
+			Variables: map[string]any{},
 			Includes:  []string{},
 		}
 	}
@@ -348,7 +348,7 @@ func joinTag(s ...string) string {
 	}
 	var b strings.Builder
 	first := true
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		if s[i] == "" {
 			continue
 		}

--- a/buildmodel/dockermanifest/dockermanifest.go
+++ b/buildmodel/dockermanifest/dockermanifest.go
@@ -15,11 +15,11 @@ type Manifest struct {
 	// Readme can be an object with more details, or a string path. This was recently changed from a
 	// string to an object in the .NET Docker infra's model. For now, be flexible in the go-images
 	// model: we only need to persist the value, not manipulate it.
-	Readme    interface{}            `json:"readme"`
-	Registry  string                 `json:"registry"`
-	Variables map[string]interface{} `json:"variables"`
-	Includes  []string               `json:"includes"`
-	Repos     []*Repo                `json:"repos"`
+	Readme    any            `json:"readme"`
+	Registry  string         `json:"registry"`
+	Variables map[string]any `json:"variables"`
+	Includes  []string       `json:"includes"`
+	Repos     []*Repo        `json:"repos"`
 }
 
 // Repo is a Docker repository: the 'oss/go/microsoft/golang' part of a tag name.

--- a/cmd/getmingw/diagnose.go
+++ b/cmd/getmingw/diagnose.go
@@ -31,7 +31,7 @@ func diagnose(p subcmd.ParseFunc) error {
 	fmt.Println(strings.Repeat("-", 80))
 	fmt.Println("PATH entries:")
 	var pathDirs []string
-	for _, p := range strings.Split(os.Getenv("PATH"), string(os.PathListSeparator)) {
+	for p := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
 		fmt.Println("  " + p)
 		pathDirs = append(pathDirs, p)
 	}

--- a/cmd/getmingw/main.go
+++ b/cmd/getmingw/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -91,15 +92,9 @@ func filter(builds map[string]build) []*build {
 		if len(msf.Values) == 0 {
 			return true
 		}
-		for _, s := range msf.Values {
-			if s == v {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(msf.Values, v)
 	}
 	for _, b := range builds {
-		b := b
 		if match(&sources, b.Source) &&
 			match(&versions, b.Version) &&
 			match(&arches, b.Arch) &&

--- a/cmd/getmingw/run.go
+++ b/cmd/getmingw/run.go
@@ -84,7 +84,6 @@ func run(p subcmd.ParseFunc) error {
 	// Download (if necessary) up front.
 	var wg sync.WaitGroup
 	for _, b := range matches {
-		b := b
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/getmingw/updatejson.go
+++ b/cmd/getmingw/updatejson.go
@@ -173,7 +173,6 @@ func updateJson(p subcmd.ParseFunc) error {
 	}
 	var wg sync.WaitGroup
 	for _, b := range newBuilds {
-		b := b
 		log.Printf("Creating checksum for %v", b.URL)
 		wg.Add(1)
 		go func() {

--- a/cmd/gomoddependabot/main.go
+++ b/cmd/gomoddependabot/main.go
@@ -143,7 +143,7 @@ func findGoModuleDirs(root string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, line := range strings.Split(out, "\x00") {
+	for line := range strings.SplitSeq(out, "\x00") {
 		// Normalize paths like "go.mod" and "foo/bar/go.mod" to what dependabot
 		// expects: "/" and "foo/bar" respectively.
 		line = "/" + line

--- a/cmd/releaseagent/main.go
+++ b/cmd/releaseagent/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"slices"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/releasesteps"
 	"github.com/microsoft/go-infra/goversion"
@@ -39,10 +40,8 @@ func BindInputFlags() *releasesteps.Input {
 			if v.Major != "1" {
 				return fmt.Errorf("major version must be 1, got %q in %q", v.Major, v)
 			}
-			for _, existing := range i.Versions {
-				if existing == s {
-					return fmt.Errorf("duplicate version passed: %q", s)
-				}
+			if slices.Contains(i.Versions, s) {
+				return fmt.Errorf("duplicate version passed: %q", s)
 			}
 
 			i.Versions = append(i.Versions, v.Full())

--- a/cmd/releasego/build-pipeline.go
+++ b/cmd/releasego/build-pipeline.go
@@ -195,8 +195,8 @@ func sendBuildPipelineRunRequest(ctx context.Context, client *http.Client, azdoF
 	if err != nil {
 		return nil, err
 	}
-	body := map[string]interface{}{
-		"definition": map[string]interface{}{
+	body := map[string]any{
+		"definition": map[string]any{
 			"id": request.DefinitionID,
 		},
 		"sourceBranch":       request.SourceBranch,

--- a/cmd/releasego/wait-latest-mar-go-version.go
+++ b/cmd/releasego/wait-latest-mar-go-version.go
@@ -50,7 +50,7 @@ func waitMarGoVersion(p subcmd.ParseFunc) error {
 	}
 
 	var checkers []func() (bool, error)
-	for _, version := range strings.Split(*versionList, ",") {
+	for version := range strings.SplitSeq(*versionList, ",") {
 		v := goversion.New(version)
 		tag := marRepo + ":" + v.MajorMinor()
 

--- a/githubutil/githubutil.go
+++ b/githubutil/githubutil.go
@@ -434,7 +434,7 @@ func PATScopes(ctx context.Context, client *github.Client) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		for _, s := range strings.Split(resp.Header.Get("X-OAuth-Scopes"), ",") {
+		for s := range strings.SplitSeq(resp.Header.Get("X-OAuth-Scopes"), ",") {
 			scopes = append(scopes, strings.TrimSpace(s))
 		}
 		return nil

--- a/gitpr/gitpr.go
+++ b/gitpr/gitpr.go
@@ -183,7 +183,7 @@ func (r Remote) GetOwnerSlashRepo() string {
 
 // sendJSONRequest sends a request for JSON information. The JSON response is unmarshalled (parsed)
 // into the 'response' parameter, based on the structure of 'response'.
-func sendJSONRequest(request *http.Request, response interface{}) (status int, err error) {
+func sendJSONRequest(request *http.Request, response any) (status int, err error) {
 	request.Header.Add("Accept", "application/vnd.github.v3+json")
 	fmt.Printf("Sending request: %v %v\n", request.Method, request.URL) // CodeQL [SM03994] Logs are only visible to the user who ran the command.
 
@@ -214,7 +214,7 @@ func sendJSONRequest(request *http.Request, response interface{}) (status int, e
 
 // sendJSONRequestSuccessful sends a request for JSON information via sendJSONRequest and verifies
 // the status code is success.
-func sendJSONRequestSuccessful(request *http.Request, response interface{}) error {
+func sendJSONRequestSuccessful(request *http.Request, response any) error {
 	status, err := sendJSONRequest(request, response)
 	if err != nil {
 		return err
@@ -313,10 +313,10 @@ func PostGitHub(ownerRepo string, request *GitHubRequest, auther githubutil.HTTP
 	return &response.GitHubResponse, nil
 }
 
-func QueryGraphQL(auther githubutil.HTTPRequestAuther, query string, variables map[string]interface{}, result interface{}) error {
+func QueryGraphQL(auther githubutil.HTTPRequestAuther, query string, variables map[string]any, result any) error {
 	queryBytes, err := json.Marshal(&struct {
-		Query     string                 `json:"query"`
-		Variables map[string]interface{} `json:"variables,omitempty"`
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables,omitempty"`
 	}{
 		query,
 		variables,
@@ -337,7 +337,7 @@ func QueryGraphQL(auther githubutil.HTTPRequestAuther, query string, variables m
 	return sendJSONRequestSuccessful(httpRequest, result)
 }
 
-func MutateGraphQL(auther githubutil.HTTPRequestAuther, query string, variables map[string]interface{}) error {
+func MutateGraphQL(auther githubutil.HTTPRequestAuther, query string, variables map[string]any) error {
 	// Queries and mutations use the same API. But with a mutation, the results aren't useful to us.
 	return QueryGraphQL(auther, query, variables, &struct{}{})
 }
@@ -375,7 +375,7 @@ func FindExistingPR(r *GitHubRequest, head, target *Remote, headBranch, submitte
 			}
 		}
 	}`
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoOwner":   target.GetOwner(),
 		"repoName":    target.GetRepo(),
 		"headRefName": headBranch,
@@ -465,7 +465,7 @@ func ApprovePR(nodeID string, auther githubutil.HTTPRequestAuther) error {
 					clientMutationId
 				}
 			}`,
-		map[string]interface{}{"nodeID": nodeID})
+		map[string]any{"nodeID": nodeID})
 }
 
 // EnablePRAutoMerge enables PR automerge on the target GraphQL PR node ID.
@@ -477,7 +477,7 @@ func EnablePRAutoMerge(nodeID string, auther githubutil.HTTPRequestAuther) error
 				clientMutationId
 			}
 		}`,
-		map[string]interface{}{"nodeID": nodeID})
+		map[string]any{"nodeID": nodeID})
 }
 
 // createRefspec makes a refspec that will fetch or push a branch "source" to "dest". The args must

--- a/stringutil/stringutil.go
+++ b/stringutil/stringutil.go
@@ -49,7 +49,7 @@ func CutLast(s, sep string) (before, after string, found bool) {
 }
 
 // ReadJSONFile reads one JSON value from the specified file. Supports BOM.
-func ReadJSONFile(path string, i interface{}) (err error) {
+func ReadJSONFile(path string, i any) (err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("unable to open JSON file %v for reading: %w", path, err)
@@ -69,7 +69,7 @@ func ReadJSONFile(path string, i interface{}) (err error) {
 }
 
 // WriteJSONFile writes one specified value to a file as indented JSON with a trailing newline.
-func WriteJSONFile(path string, i interface{}) (err error) {
+func WriteJSONFile(path string, i any) (err error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("unable to open JSON file %v for writing: %w", path, err)


### PR DESCRIPTION
Run `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...`

Nothing huge, but was curious what it would show for this repo after seeing a handful of upstream issues about this tool, and might as well submit it. Using `strings.SplitSeq` as a modernization is an interesting one that wasn't on my radar.