### PR TITLE
telemetry: add target goos and goarch to the upload config

### DIFF
--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -57,6 +57,12 @@
 				},
 				{
 					"Name": "go/subcommand:{build,install,run}"
+				},
+				{
+					"Name": "go/platform/target/goos:{aix,android,darwin,dragonfly,freebsd,hurd,illumos,ios,js,linux,nacl,netbsd,openbsd,plan9,solaris,wasip1,windows,zos}"
+				},
+				{
+					"Name": "go/platform/target/goarch:{386,amd64,amd64p32,arm,arm64,arm64be,armbe,loong64,mips,mips64,mips64le,mips64p32,mips64p32le,mipsle,ppc,ppc64,ppc64le,riscv,riscv64,s390,s390x,sparc,sparc64,wasm}"
 				}
 			]
 		}


### PR DESCRIPTION
We want to know which ports are being targeted by the Microsoft build of Go.