### PR TITLE
Fix inlinerange to produce mapping output in mapping context

### DIFF
--- a/internal/pipelineymlgen/eval.go
+++ b/internal/pipelineymlgen/eval.go
@@ -800,8 +800,9 @@ type evalRange struct {
 	collection any
 	body       *yaml.Node
 	// inSequence is true when this range is inside a mapping that is a
-	// sequence item. In that case each iteration produces a separate sequence
-	// element. When false (mapping value context), iterations that produce
-	// MappingNodes are flattened into a single combined MappingNode.
+	// sequence item. When true, the range always produces a SequenceNode
+	// (preserving list item structure). When false (mapping value context),
+	// iterations that produce MappingNodes are flattened into a single
+	// combined MappingNode.
 	inSequence bool
 }

--- a/internal/pipelineymlgen/eval.go
+++ b/internal/pipelineymlgen/eval.go
@@ -225,6 +225,15 @@ func (e *EvalState) eval(orig *yaml.Node) (any, error) {
 			if err != nil {
 				return fail(fmt.Errorf("evaluating sequence item: %w", err))
 			}
+			// Mark any evalRanges inside mapping sequence items so they know
+			// to produce sequence output rather than mapping output.
+			if m, ok := evalItem.(*evalMapping); ok {
+				for _, c := range m.content {
+					if r, ok := c.(*evalRange); ok {
+						r.inSequence = true
+					}
+				}
+			}
 			s.content = append(s.content, evalItem)
 		}
 		return &s, nil
@@ -561,7 +570,7 @@ func (e *EvalState) evalTemplateResult(t *evalTemplate) (*yaml.Node, error) {
 }
 
 func (e *EvalState) evalRangeResult(r *evalRange) (*yaml.Node, error) {
-	seq := &yaml.Node{Kind: yaml.SequenceNode}
+	result := &yaml.Node{Kind: yaml.SequenceNode}
 
 	// Handle map[string]any directly with sorted keys for determinism.
 	if m, ok := r.collection.(map[string]any); ok {
@@ -575,17 +584,17 @@ func (e *EvalState) evalRangeResult(r *evalRange) (*yaml.Node, error) {
 				return nil, fmt.Errorf("inlinerange iteration key %v: %w", key, err)
 			}
 			if node != nil {
-				seq.Content = append(seq.Content, node.Content...)
+				result.Content = append(result.Content, node.Content...)
 			}
 		}
-		return seq, nil
+		return e.evalRangeFlatten(r, result)
 	}
 
 	// Handle slices and arrays via reflection to support typed slices (e.g. []string).
 	rv := reflect.ValueOf(r.collection)
 	if rv.Kind() == reflect.Interface || rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
-			return seq, nil
+			return result, nil
 		}
 		rv = rv.Elem()
 	}
@@ -603,14 +612,43 @@ func (e *EvalState) evalRangeResult(r *evalRange) (*yaml.Node, error) {
 				return nil, fmt.Errorf("inlinerange iteration %d: %w", i, err)
 			}
 			if node != nil {
-				seq.Content = append(seq.Content, node.Content...)
+				result.Content = append(result.Content, node.Content...)
 			}
 		}
 	default:
 		return nil, fmt.Errorf("inlinerange: cannot range over %T", r.collection)
 	}
 
-	return seq, nil
+	return e.evalRangeFlatten(r, result)
+}
+
+// evalRangeFlatten converts the collected range results into the appropriate
+// YAML node type. When the range is NOT in a sequence context and all body
+// results are MappingNodes, it flattens them into a single MappingNode so the
+// output contains map entries rather than sequence items.
+func (e *EvalState) evalRangeFlatten(r *evalRange, seq *yaml.Node) (*yaml.Node, error) {
+	if r.inSequence {
+		return seq, nil
+	}
+
+	// Check if all items in the sequence are MappingNodes. If so, flatten
+	// their key-value pairs into a single MappingNode.
+	allMappings := len(seq.Content) > 0
+	for _, item := range seq.Content {
+		if item.Kind != yaml.MappingNode {
+			allMappings = false
+			break
+		}
+	}
+	if !allMappings {
+		return seq, nil
+	}
+
+	m := &yaml.Node{Kind: yaml.MappingNode}
+	for _, item := range seq.Content {
+		m.Content = append(m.Content, item.Content...)
+	}
+	return m, nil
 }
 
 func (e *EvalState) iterationData(r *evalRange, key, value any) (any, error) {
@@ -761,4 +799,9 @@ type evalRange struct {
 	valueName  string
 	collection any
 	body       *yaml.Node
+	// inSequence is true when this range is inside a mapping that is a
+	// sequence item. In that case each iteration produces a separate sequence
+	// element. When false (mapping value context), iterations that produce
+	// MappingNodes are flattened into a single combined MappingNode.
+	inSequence bool
 }

--- a/internal/pipelineymlgen/testdata/TestIndividualFiles/inlinerange-map-body.gen.yml
+++ b/internal/pipelineymlgen/testdata/TestIndividualFiles/inlinerange-map-body.gen.yml
@@ -1,0 +1,5 @@
+# Range over a list of maps, producing map entries (not sequence items).
+containers:
+  ${ inlinerange "c" (list (dict "container" "ubuntu2204" "image" "mcr.microsoft.com/ubuntu-22.04") (dict "container" "ubuntu2404" "image" "mcr.microsoft.com/ubuntu-24.04")) }:
+    ${ .c.container }:
+      image: ${ .c.image }

--- a/internal/pipelineymlgen/testdata/TestIndividualFiles/inlinerange-map-body.golden.yml
+++ b/internal/pipelineymlgen/testdata/TestIndividualFiles/inlinerange-map-body.golden.yml
@@ -1,0 +1,6 @@
+# Range over a list of maps, producing map entries (not sequence items).
+containers:
+  ubuntu2204:
+    image: mcr.microsoft.com/ubuntu-22.04
+  ubuntu2404:
+    image: mcr.microsoft.com/ubuntu-24.04


### PR DESCRIPTION
Quick Copilot fix to support some data reuse in our pipelines.

Specifically, lets us unify:

https://github.com/microsoft/go/blob/8b6d5c3ca87e2f493caad3e4eaa86f2ac0384311/eng/pipeline/pr-pipeline.yml#L23-L30

https://github.com/microsoft/go/blob/8b6d5c3ca87e2f493caad3e4eaa86f2ac0384311/eng/pipeline/rolling-innerloop-pipeline.yml#L46-L53

---

`inlinerange` always produces a sequence (list), even when used as a mapping value where map entries are expected:

```yaml
containers:
  ${ inlinerange .containers }:
    ${ .container }:
      image: ${ .image }
```

Produces `- ubuntu2204:` (sequence items) instead of `ubuntu2204:` (map entries).

### Root cause

`evalRangeResult` unconditionally returns a `SequenceNode`. When the parent mapping dissolves into this SequenceNode, map-valued contexts get sequence output.

### Fix

- Added `inSequence` flag on `evalRange`, set when the range's parent mapping is a sequence item (detected during `eval()` of `SequenceNode`)
- Added `evalRangeFlatten`: when `!inSequence` and all body iterations produce `MappingNode`s, flattens them into a single combined `MappingNode`
- Existing sequence-context behavior (`- ${ inlinerange }:`) is unchanged — `inSequence=true` preserves the `SequenceNode` path

### Test

Added `inlinerange-map-body` test case exercising the mapping-value context.