### PR TITLE
Make am.threeWay=false for git go-patch

### DIFF
--- a/cmd/git-go-patch/review.go
+++ b/cmd/git-go-patch/review.go
@@ -268,14 +268,14 @@ func resetSubmoduleTo(rootDir, goDir, commit string, force bool) error {
 }
 
 func applyPatchCommits(goDir, patchDir string) error {
-	args := []string{"am", "--whitespace=nowarn"}
+	var args []string
 	if err := patch.WalkPatches(patchDir, func(file string) error {
 		args = append(args, file)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to walk patches: %v", err)
 	}
-	return gitcmd.Run(goDir, args...)
+	return gitcmd.Am(goDir, args...)
 }
 
 func parsePRURL(urlStr string) (owner, repo string, prNum int, err error) {

--- a/gitcmd/gitcmd.go
+++ b/gitcmd/gitcmd.go
@@ -160,6 +160,22 @@ func Run(dir string, args ...string) error {
 	return executil.Run(executil.Dir(dir, "git", args...))
 }
 
+// Am runs "git -c am.threeWay=false am --whitespace=nowarn <args>" in the given directory.
+//
+// It explicitly disables am.threeWay to ensure the result doesn't depend on the user's Git
+// configuration. This is important for internal processes like "git go-patch extract" that use "am"
+// to compare patches: if the user has am.threeWay=true, three-way merge may silently resolve
+// conflicts that would fail in CI (where am.threeWay is not set), causing a mismatch between local
+// and CI behavior. See https://github.com/microsoft/go/issues/1233.
+//
+// It passes --whitespace=nowarn because trailing whitespace may be present in patch files. These
+// warnings should be avoided when authoring each patch file, and emitting warnings at apply time
+// would only be noisy.
+func Am(dir string, args ...string) error {
+	a := append([]string{"-c", "am.threeWay=false", "am", "--whitespace=nowarn"}, args...)
+	return Run(dir, a...)
+}
+
 // NewTempGitRepo creates a gitRepo in temp storage. If desired, clean it up with AttemptDelete.
 func NewTempGitRepo() (string, error) {
 	gitDir, err := os.MkdirTemp("", "releasego-temp-git-*")

--- a/patch/matching.go
+++ b/patch/matching.go
@@ -79,7 +79,7 @@ func (m *MatchCheckRepo) CheckedApply(path string, p *Patch) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if err := gitcmd.Run(m.gitDir, "am", "-q", "--whitespace=nowarn", oldPatchPath); err != nil {
+		if err := gitcmd.Run(m.gitDir, "-c", "am.threeWay=false", "am", "-q", "--whitespace=nowarn", oldPatchPath); err != nil {
 			// If the old patch no longer works at all, it definitely doesn't match the new patch!
 			// Cancel the attempt.
 			log.Printf("Old patch doesn't apply: %v. Disregarding this patch as a match candidate for %q and continuing...\n", err, filepath.Base(absPath))
@@ -99,7 +99,7 @@ func (m *MatchCheckRepo) CheckedApply(path string, p *Patch) (string, error) {
 	}
 
 	// Apply the given "new" patch. Don't undo this: we want future calls of Apply to build on this.
-	if err := gitcmd.Run(m.gitDir, "am", "-q", "--whitespace=nowarn", absPath); err != nil {
+	if err := gitcmd.Run(m.gitDir, "-c", "am.threeWay=false", "am", "-q", "--whitespace=nowarn", absPath); err != nil {
 		return "", err
 	}
 

--- a/patch/matching.go
+++ b/patch/matching.go
@@ -79,7 +79,7 @@ func (m *MatchCheckRepo) CheckedApply(path string, p *Patch) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if err := gitcmd.Run(m.gitDir, "-c", "am.threeWay=false", "am", "-q", "--whitespace=nowarn", oldPatchPath); err != nil {
+		if err := gitcmd.Am(m.gitDir, "-q", oldPatchPath); err != nil {
 			// If the old patch no longer works at all, it definitely doesn't match the new patch!
 			// Cancel the attempt.
 			log.Printf("Old patch doesn't apply: %v. Disregarding this patch as a match candidate for %q and continuing...\n", err, filepath.Base(absPath))
@@ -99,7 +99,7 @@ func (m *MatchCheckRepo) CheckedApply(path string, p *Patch) (string, error) {
 	}
 
 	// Apply the given "new" patch. Don't undo this: we want future calls of Apply to build on this.
-	if err := gitcmd.Run(m.gitDir, "-c", "am.threeWay=false", "am", "-q", "--whitespace=nowarn", absPath); err != nil {
+	if err := gitcmd.Am(m.gitDir, "-q", absPath); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Address issue where local and CI behavior don't match when running git go-patch

- https://github.com/microsoft/go/issues/1233