### PR TITLE
telemetry: trim test sufix in program name

### DIFF
--- a/telemetry/internal/telemetry/proginfo.go
+++ b/telemetry/internal/telemetry/proginfo.go
@@ -17,7 +17,7 @@ import (
 // the Go version, and will typically be of the form "go1.2.3", not a semantic
 // version of the form "v1.2.3". Go versions may also include spaces and
 // special characters.
-func ProgramInfo(info *debug.BuildInfo) (goVers, progPath string) {
+func ProgramInfo(info *debug.BuildInfo, trimTestuffix bool) (goVers, progPath string) {
 	goVers = info.GoVersion
 	if strings.Contains(goVers, "devel") || strings.Contains(goVers, "-") || !version.IsValid(goVers) {
 		if v, rest, ok := strings.Cut(goVers, "-microsoft"); ok &&
@@ -37,6 +37,9 @@ func ProgramInfo(info *debug.BuildInfo) (goVers, progPath string) {
 	progPath = info.Path
 	if progPath == "" {
 		progPath = strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
+	}
+	if trimTestuffix {
+		progPath, _ = strings.CutSuffix(progPath, ".test") // Remove ".test" suffix added by "go test"
 	}
 
 	return goVers, progPath

--- a/telemetry/internal/telemetry/proginfo.go
+++ b/telemetry/internal/telemetry/proginfo.go
@@ -17,7 +17,7 @@ import (
 // the Go version, and will typically be of the form "go1.2.3", not a semantic
 // version of the form "v1.2.3". Go versions may also include spaces and
 // special characters.
-func ProgramInfo(info *debug.BuildInfo, trimTestuffix bool) (goVers, progPath string) {
+func ProgramInfo(info *debug.BuildInfo, trimTestSuffix bool) (goVers, progPath string) {
 	goVers = info.GoVersion
 	if strings.Contains(goVers, "devel") || strings.Contains(goVers, "-") || !version.IsValid(goVers) {
 		if v, rest, ok := strings.Cut(goVers, "-microsoft"); ok &&
@@ -38,7 +38,7 @@ func ProgramInfo(info *debug.BuildInfo, trimTestuffix bool) (goVers, progPath st
 	if progPath == "" {
 		progPath = strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
 	}
-	if trimTestuffix {
+	if trimTestSuffix {
 		progPath, _ = strings.CutSuffix(progPath, ".test") // Remove ".test" suffix added by "go test"
 	}
 

--- a/telemetry/internal/telemetry/proginfo_test.go
+++ b/telemetry/internal/telemetry/proginfo_test.go
@@ -76,7 +76,7 @@ func TestProgramInfoVersion(t *testing.T) {
 		t.Run(tt.version, func(t *testing.T) {
 			gotGoVers, _ := telemetry.ProgramInfo(&debug.BuildInfo{
 				GoVersion: tt.version,
-			})
+			}, false)
 
 			if gotGoVers != tt.want {
 				t.Errorf("ProgramInfo() goVers = %v, want %v", gotGoVers, tt.want)
@@ -118,7 +118,39 @@ func TestProgramInfoPath(t *testing.T) {
 			_, gotProgPath := telemetry.ProgramInfo(&debug.BuildInfo{
 				GoVersion: "go1.21.0",
 				Path:      "",
-			})
+			}, false)
+
+			if gotProgPath != tt.wantProgPath {
+				t.Errorf("ProgramInfo() progPath = %v, want %v", gotProgPath, tt.wantProgPath)
+			}
+		})
+	}
+}
+
+func TestProgramInfoTrimTestSuffix(t *testing.T) {
+	tests := []struct {
+		name         string
+		buildPath    string
+		wantProgPath string
+	}{
+		{
+			name:         "trim suffix",
+			buildPath:    "example.com/mod/cmd.test",
+			wantProgPath: "example.com/mod/cmd",
+		},
+		{
+			name:         "ignore non-suffix match",
+			buildPath:    "example.com/mod/cmd.test.binary",
+			wantProgPath: "example.com/mod/cmd.test.binary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, gotProgPath := telemetry.ProgramInfo(&debug.BuildInfo{
+				GoVersion: "go1.21.0",
+				Path:      tt.buildPath,
+			}, true)
 
 			if gotProgPath != tt.wantProgPath {
 				t.Errorf("ProgramInfo() progPath = %v, want %v", gotProgPath, tt.wantProgPath)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -46,6 +46,9 @@ type Config struct {
 	// upload configuration does not explicitly include them.
 	AllowGoDevel bool
 
+	// If true, remove ".test" suffix from program name when running tests.
+	TrimTestSuffix bool
+
 	// Logger specifies a structured logger.
 	// If nil nothing is logged.
 	Logger *slog.Logger
@@ -73,7 +76,7 @@ func Start(cfg Config) {
 	if !ok {
 		panic("failed to read build info for telemetry")
 	}
-	ver, prog := telemetry.ProgramInfo(bi)
+	ver, prog := telemetry.ProgramInfo(bi, cfg.TrimTestSuffix)
 	if ver == "devel" {
 		if !cfg.AllowGoDevel {
 			// If the Go version is a development version and we are not allowing

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -141,7 +141,7 @@ func baseUploadConfig(t *testing.T) config.UploadConfig {
 	if !ok {
 		t.Fatal("failed to read build info")
 	}
-	_, prog := itelemetry.ProgramInfo(bi)
+	_, prog := itelemetry.ProgramInfo(bi, false)
 	return config.UploadConfig{
 		GOOS:   []string{runtime.GOOS},
 		GOARCH: []string{runtime.GOARCH},


### PR DESCRIPTION
This is necessary to nunblock https://github.com/microsoft/go/pull/2180. Upstream Go recently started to add the `.test` suffix to the `cmd/go/TestScript` tests, so our default config -which only matches `cmd/go`-, doesn't trigger any appinsight request anymore. 