### PR TITLE
Add update-dl subcommand to generate go-lab dl packages

### DIFF
--- a/cmd/releasego/templates/dl.template.go.tmpl
+++ b/cmd/releasego/templates/dl.template.go.tmpl
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// The msgo{{.Version}} command runs the go command from Microsoft Go {{.Version}}.
+// The msgo{{.Version}} command runs the go command from Microsoft build of Go {{.Version}}.
 //
 // To install, run:
 //

--- a/cmd/releasego/templates/dl.template.go.tmpl
+++ b/cmd/releasego/templates/dl.template.go.tmpl
@@ -8,7 +8,7 @@
 //	$ go install github.com/microsoft/go-lab/dl/msgo{{.Version}}@latest
 //	$ msgo{{.Version}} download
 //
-// And then use the go{{.Version}} command as if it were your normal go
+// And then use the msgo{{.Version}} command as if it were your normal go
 // command.
 //
 // See the release notes at https://github.com/microsoft/go/releases/tag/v{{.Version}}.

--- a/cmd/releasego/templates/dl.template.go.tmpl
+++ b/cmd/releasego/templates/dl.template.go.tmpl
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The msgo{{.Version}} command runs the go command from Microsoft Go {{.Version}}.
+//
+// To install, run:
+//
+//	$ go install github.com/microsoft/go-lab/dl/msgo{{.Version}}@latest
+//	$ msgo{{.Version}} download
+//
+// And then use the go{{.Version}} command as if it were your normal go
+// command.
+//
+// See the release notes at https://github.com/microsoft/go/releases/tag/v{{.Version}}.
+//
+// File bugs at https://github.com/microsoft/go/issues/new.
+package main
+
+import "github.com/microsoft/go-lab/dl/internal/version"
+
+func main() {
+	version.Run("msgo{{.Version}}", "{{.SHA256}}")
+}

--- a/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
+++ b/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// The msgo1.25.8-1 command runs the go command from Microsoft Go 1.25.8-1.
+// The msgo1.25.8-1 command runs the go command from Microsoft build of Go 1.25.8-1.
 //
 // To install, run:
 //

--- a/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
+++ b/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
@@ -8,7 +8,7 @@
 //	$ go install github.com/microsoft/go-lab/dl/msgo1.25.8-1@latest
 //	$ msgo1.25.8-1 download
 //
-// And then use the go1.25.8-1 command as if it were your normal go
+// And then use the msgo1.25.8-1 command as if it were your normal go
 // command.
 //
 // See the release notes at https://github.com/microsoft/go/releases/tag/v1.25.8-1.

--- a/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
+++ b/cmd/releasego/testdata/Test_dlTemplate/single-version/single-version.golden.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The msgo1.25.8-1 command runs the go command from Microsoft Go 1.25.8-1.
+//
+// To install, run:
+//
+//	$ go install github.com/microsoft/go-lab/dl/msgo1.25.8-1@latest
+//	$ msgo1.25.8-1 download
+//
+// And then use the go1.25.8-1 command as if it were your normal go
+// command.
+//
+// See the release notes at https://github.com/microsoft/go/releases/tag/v1.25.8-1.
+//
+// File bugs at https://github.com/microsoft/go/issues/new.
+package main
+
+import "github.com/microsoft/go-lab/dl/internal/version"
+
+func main() {
+	version.Run("msgo1.25.8-1", "3ff0e9fa6b16675d373521d805ead46e3fa74a70e8aadeb97848d30d5e19e562")
+}

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -6,8 +6,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/go-github/v65/github"
-	"github.com/microsoft/go-infra/buildmodel/buildassets"
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/gitpr"
 	"github.com/microsoft/go-infra/goversion"
@@ -90,15 +89,15 @@ func updateDL(p subcmd.ParseFunc) error {
 		}
 
 		version := gv.Full()
-		log.Printf("Fetching SHA256 for version %s...\n", version)
-		sha256, err := fetchGoSrcSHA256(ctx, client, *goOrg, *goRepo, "v"+version)
+		log.Printf("Fetching assets.json SHA256 for version %s...\n", version)
+		assetsJSONSHA256, err := fetchAssetsJSONSHA256(ctx, client, *goOrg, *goRepo, "v"+version)
 		if err != nil {
-			return fmt.Errorf("error fetching SHA256 for version %s: %w", version, err)
+			return fmt.Errorf("error fetching assets.json SHA256 for version %s: %w", version, err)
 		}
-		log.Printf("SHA256 for %s: %s\n", version, sha256)
+		log.Printf("assets.json SHA256 for %s: %s\n", version, assetsJSONSHA256)
 		dlVersions = append(dlVersions, dlVersionData{
 			Version: version,
-			SHA256:  sha256,
+			SHA256:  assetsJSONSHA256,
 		})
 	}
 	if len(dlVersions) == 0 {
@@ -217,8 +216,10 @@ func updateDL(p subcmd.ParseFunc) error {
 	return nil
 }
 
-// fetchGoSrcSHA256 downloads the assets.json from a GitHub release and returns the GoSrcSHA256.
-func fetchGoSrcSHA256(ctx context.Context, client *github.Client, owner, repo, tag string) (string, error) {
+// fetchAssetsJSONSHA256 downloads the assets.json from a GitHub release and returns its content SHA256.
+// The dl tool in go-lab uses this hash to verify the integrity of assets.json before extracting
+// platform-specific download URLs and hashes from it.
+func fetchAssetsJSONSHA256(ctx context.Context, client *github.Client, owner, repo, tag string) (string, error) {
 	var release *github.RepositoryRelease
 	if err := githubutil.Retry(func() error {
 		var err error
@@ -257,16 +258,8 @@ func fetchGoSrcSHA256(ctx context.Context, client *github.Client, owner, repo, t
 		return "", fmt.Errorf("error reading assets.json: %w", err)
 	}
 
-	var assets buildassets.BuildAssets
-	if err := json.Unmarshal(data, &assets); err != nil {
-		return "", fmt.Errorf("error parsing assets.json: %w", err)
-	}
-
-	if assets.GoSrcSHA256 == "" {
-		return "", fmt.Errorf("GoSrcSHA256 is empty in assets.json for release %s", tag)
-	}
-
-	return assets.GoSrcSHA256, nil
+	hash := sha256.Sum256(data)
+	return fmt.Sprintf("%x", hash[:]), nil
 }
 
 // dlFilePath returns the path for a dl package's main.go file within the go-lab repo.

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -29,7 +29,7 @@ import (
 	"github.com/microsoft/go-infra/subcmd"
 )
 
-var downloadHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var downloadHTTPClient = http.Client{Timeout: 30 * time.Second}
 
 func init() {
 	subcommands = append(subcommands, subcmd.Option{
@@ -294,7 +294,7 @@ func fetchAssetsJSONSHA256(ctx context.Context, client *github.Client, owner, re
 	var rc io.ReadCloser
 	if err := githubutil.Retry(func() error {
 		var err error
-		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), downloadHTTPClient)
+		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), &downloadHTTPClient)
 		return err
 	}); err != nil {
 		return "", fmt.Errorf("error downloading assets.json from release %s: %w", tag, err)

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -28,6 +29,8 @@ import (
 	"github.com/microsoft/go-infra/subcmd"
 )
 
+var downloadHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 func init() {
 	subcommands = append(subcommands, subcmd.Option{
 		Name:    "update-dl",
@@ -35,7 +38,7 @@ func init() {
 		Description: `
 The update-dl command generates dl/msgo<version>/main.go files for each specified
 Go release version and creates a pull request on the go-lab repository. It fetches
-the source archive SHA256 hash from the GitHub release's assets.json file.
+the assets.json SHA256 hash from the GitHub release.
 `,
 		Handle: updateDL,
 	})
@@ -53,10 +56,8 @@ var dlTemplate string
 func updateDL(p subcmd.ParseFunc) error {
 	releaseVersions := flag.String("versions", "", "Comma-separated list of version numbers for the Go release (e.g. 1.25.8-1,1.26.1-1).")
 	dryRun := flag.Bool("n", false, "Enable dry run: do not push changes to GitHub.")
-	org := flag.String("org", "microsoft", "The GitHub organization for the go-lab repository.")
-	repo := flag.String("repo", "go-lab", "The GitHub repository name for the dl packages.")
-	goOrg := flag.String("go-org", "microsoft", "The GitHub organization for the Go releases repository.")
-	goRepo := flag.String("go-repo", "go", "The GitHub repository name for Go releases.")
+	dlRepo := flag.String("repo", "microsoft/go-lab", "The GitHub repository for the dl packages, in '{owner}/{repo}' form.")
+	goRepo := flag.String("go-repo", "microsoft/go", "The GitHub repository for Go releases, in '{owner}/{repo}' form.")
 	gitHubAuthFlags := githubutil.BindGitHubAuthFlags("")
 	gitHubReviewerAuthFlags := githubutil.BindGitHubAuthFlags("reviewer")
 
@@ -66,6 +67,15 @@ func updateDL(p subcmd.ParseFunc) error {
 
 	if *releaseVersions == "" {
 		return fmt.Errorf("no versions specified; use -versions flag")
+	}
+
+	labOwner, labName, err := githubutil.ParseRepoFlag(dlRepo)
+	if err != nil {
+		return fmt.Errorf("invalid -repo: %w", err)
+	}
+	goOwner, goName, err := githubutil.ParseRepoFlag(goRepo)
+	if err != nil {
+		return fmt.Errorf("invalid -go-repo: %w", err)
 	}
 
 	ctx := context.Background()
@@ -90,7 +100,7 @@ func updateDL(p subcmd.ParseFunc) error {
 
 		version := gv.Full()
 		log.Printf("Fetching assets.json SHA256 for version %s...\n", version)
-		assetsJSONSHA256, err := fetchAssetsJSONSHA256(ctx, client, *goOrg, *goRepo, "v"+version)
+		assetsJSONSHA256, err := fetchAssetsJSONSHA256(ctx, client, goOwner, goName, "v"+version)
 		if err != nil {
 			return fmt.Errorf("error fetching assets.json SHA256 for version %s: %w", version, err)
 		}
@@ -105,7 +115,7 @@ func updateDL(p subcmd.ParseFunc) error {
 	}
 	// Sort descending so PR title lists versions in a consistent order.
 	sort.Slice(dlVersions, func(i, j int) bool {
-		return infrasort.GoVersionDesc(goversion.New(dlVersions[i].Version), goversion.New(dlVersions[j].Version))
+		return infrasort.GoVersionLess(goversion.New(dlVersions[i].Version), goversion.New(dlVersions[j].Version))
 	})
 
 	// Generate file contents from the template.
@@ -142,18 +152,8 @@ func updateDL(p subcmd.ParseFunc) error {
 		return nil
 	}
 
-	auther, err := gitHubAuthFlags.NewAuther()
-	if err != nil {
-		return fmt.Errorf("failed to get GitHub auther: %w", err)
-	}
-
-	reviewAuther, err := gitHubReviewerAuthFlags.NewAuther()
-	if err != nil {
-		return fmt.Errorf("failed to get GitHub review auther: %w", err)
-	}
-
 	// Check that none of the files already exist.
-	refFS := githubutil.NewRefFS(ctx, client, *org, *repo, "main")
+	refFS := githubutil.NewRefFS(ctx, client, labOwner, labName, "main")
 	filePaths := make([]string, len(files))
 	for i, f := range files {
 		filePaths[i] = f.path
@@ -169,47 +169,96 @@ func updateDL(p subcmd.ParseFunc) error {
 	}
 	title := generateDLPRTitle(versionStrings)
 
-	// Create a feature branch and upload all files.
+	prBody := "**Automated Pull Request:** Adds dl packages for new Microsoft build of Go releases.\n" +
+		"This PR was generated automatically using the [`update-dl.go`](https://github.com/microsoft/go-infra/blob/main/cmd/releasego/update-dl.go) script."
+
+	// Use the tree API to create a single commit with all files, avoiding noisy history
+	// and simplifying retries. If anything fails, retry from the beginning with a fresh base.
 	slug := "msgo-" + strings.Join(versionStrings, "-")
-	prSet := gitpr.PRRefSet{Name: "main", Purpose: fmt.Sprintf("dl/%s/%d", slug, time.Now().Unix())}
-	branchName := prSet.PRBranch()
+	branchName := "dev/dl/" + slug + "/" + fmt.Sprintf("%d", time.Now().Unix())
 
-	if err := githubutil.CreateBranch(ctx, client, *org, *repo, branchName, "main"); err != nil {
-		return fmt.Errorf("error creating branch %s: %w", branchName, err)
-	}
-
-	for _, f := range files {
-		log.Printf("Uploading %s...\n", f.path)
-		if err := githubutil.UploadFile(
-			ctx,
-			client,
-			*org,
-			*repo,
-			branchName,
-			f.path,
-			fmt.Sprintf("Add dl package: msgo%s", f.version),
-			f.content,
-		); err != nil {
-			return fmt.Errorf("error uploading file %s to branch %s: %w", f.path, branchName, err)
+	var pr *github.PullRequest
+	if err := githubutil.Retry(func() error {
+		// Get the base branch ref and commit to pin the tree base.
+		baseRef, _, err := client.Git.GetRef(ctx, labOwner, labName, "heads/main")
+		if err != nil {
+			return fmt.Errorf("error getting main ref: %w", err)
 		}
-	}
+		baseCommitSHA := baseRef.Object.GetSHA()
+		baseCommit, _, err := client.Git.GetCommit(ctx, labOwner, labName, baseCommitSHA)
+		if err != nil {
+			return fmt.Errorf("error getting commit %s: %w", baseCommitSHA, err)
+		}
 
-	ownerRepo := fmt.Sprintf("%s/%s", *org, *repo)
-	prReq := prSet.CreateGitHubPR(
-		*org,
-		title,
-		"**Automated Pull Request:** Adds dl packages for new Microsoft build of Go releases.\n"+
-			"This PR was generated automatically using the [`update-dl.go`](https://github.com/microsoft/go-infra/blob/main/cmd/releasego/update-dl.go) script.")
-	createdPR, err := gitpr.PostGitHub(ownerRepo, prReq, auther)
-	if err != nil {
-		return fmt.Errorf("error creating pull request with gitpr: %w", err)
-	}
+		// Build tree entries for all files.
+		treeEntries := make([]*github.TreeEntry, 0, len(files))
+		for _, f := range files {
+			treeEntries = append(treeEntries, &github.TreeEntry{
+				Path:    github.String(f.path),
+				Content: github.String(string(f.content)),
+				Mode:    github.String(githubutil.TreeModeFile),
+			})
+		}
 
-	if err = gitpr.EnablePRAutoMerge(createdPR.NodeID, reviewAuther); err != nil {
+		createTree, _, err := client.Git.CreateTree(ctx, labOwner, labName, baseCommit.Tree.GetSHA(), treeEntries)
+		if err != nil {
+			return fmt.Errorf("error creating tree: %w", err)
+		}
+
+		createCommit, _, err := client.Git.CreateCommit(ctx, labOwner, labName, &github.Commit{
+			Message: github.String(title),
+			Parents: []*github.Commit{baseCommit},
+			Tree:    createTree,
+		}, &github.CreateCommitOptions{})
+		if err != nil {
+			return fmt.Errorf("error creating commit: %w", err)
+		}
+
+		newRef := &github.Reference{
+			Ref:    github.String("refs/heads/" + branchName),
+			Object: &github.GitObject{SHA: createCommit.SHA},
+		}
+		if _, _, err = client.Git.CreateRef(ctx, labOwner, labName, newRef); err != nil {
+			return fmt.Errorf("error creating ref %s: %w", branchName, err)
+		}
+		// Ref is created; can't retry from here (name is taken).
+		return nil
+	}); err != nil {
 		return err
 	}
 
-	if err = gitpr.ApprovePR(createdPR.NodeID, reviewAuther); err != nil {
+	// Create the pull request.
+	if err := githubutil.Retry(func() error {
+		pr, _, err = client.PullRequests.Create(ctx, labOwner, labName, &github.NewPullRequest{
+			Title: github.String(title),
+			Head:  github.String(branchName),
+			Base:  github.String("main"),
+			Body:  github.String(prBody),
+		})
+		if err != nil {
+			return fmt.Errorf("error creating pull request: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	log.Printf("Pull request created: %s\n", pr.GetHTMLURL())
+
+	reviewAuther, err := gitHubReviewerAuthFlags.NewAuther()
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub review auther: %w", err)
+	}
+
+	if err := githubutil.Retry(func() error {
+		return gitpr.EnablePRAutoMerge(pr.GetNodeID(), reviewAuther)
+	}); err != nil {
+		return err
+	}
+
+	if err := githubutil.Retry(func() error {
+		return gitpr.ApprovePR(pr.GetNodeID(), reviewAuther)
+	}); err != nil {
 		return err
 	}
 
@@ -242,11 +291,10 @@ func fetchAssetsJSONSHA256(ctx context.Context, client *github.Client, owner, re
 	}
 
 	// Download the assets.json file.
-	downloadClient := &http.Client{Timeout: 30 * time.Second}
 	var rc io.ReadCloser
 	if err := githubutil.Retry(func() error {
 		var err error
-		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), downloadClient)
+		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), downloadHTTPClient)
 		return err
 	}); err != nil {
 		return "", fmt.Errorf("error downloading assets.json from release %s: %w", tag, err)
@@ -275,7 +323,7 @@ func checkDLFilesNotExist(fsys githubutil.SimplifiedFS, paths []string) error {
 		if err == nil {
 			return fmt.Errorf("file %s already exists", path)
 		}
-		if !errors.Is(err, githubutil.ErrFileNotExists) && !errors.Is(err, os.ErrNotExist) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("error checking if file %s exists: %w", path, err)
 		}
 	}

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -52,19 +52,12 @@ type dlVersionData struct {
 var dlTemplate string
 
 func updateDL(p subcmd.ParseFunc) error {
-	var releaseVersions string
-	var dryRun bool
-	var org string
-	var repo string
-	var goOrg string
-	var goRepo string
-
-	flag.StringVar(&releaseVersions, "versions", "", "Comma-separated list of version numbers for the Go release (e.g. 1.25.8-1,1.26.1-1).")
-	flag.BoolVar(&dryRun, "n", false, "Enable dry run: do not push changes to GitHub.")
-	flag.StringVar(&org, "org", "microsoft", "The GitHub organization for the go-lab repository.")
-	flag.StringVar(&repo, "repo", "go-lab", "The GitHub repository name for the dl packages.")
-	flag.StringVar(&goOrg, "go-org", "microsoft", "The GitHub organization for the Go releases repository.")
-	flag.StringVar(&goRepo, "go-repo", "go", "The GitHub repository name for Go releases.")
+	releaseVersions := flag.String("versions", "", "Comma-separated list of version numbers for the Go release (e.g. 1.25.8-1,1.26.1-1).")
+	dryRun := flag.Bool("n", false, "Enable dry run: do not push changes to GitHub.")
+	org := flag.String("org", "microsoft", "The GitHub organization for the go-lab repository.")
+	repo := flag.String("repo", "go-lab", "The GitHub repository name for the dl packages.")
+	goOrg := flag.String("go-org", "microsoft", "The GitHub organization for the Go releases repository.")
+	goRepo := flag.String("go-repo", "go", "The GitHub repository name for Go releases.")
 	gitHubAuthFlags := githubutil.BindGitHubAuthFlags("")
 	gitHubReviewerAuthFlags := githubutil.BindGitHubAuthFlags("reviewer")
 
@@ -72,7 +65,7 @@ func updateDL(p subcmd.ParseFunc) error {
 		return err
 	}
 
-	if releaseVersions == "" {
+	if *releaseVersions == "" {
 		return fmt.Errorf("no versions specified; use -versions flag")
 	}
 
@@ -83,9 +76,9 @@ func updateDL(p subcmd.ParseFunc) error {
 		return err
 	}
 
-	// Parse, validate, and sort versions in descending order.
-	rawVersions := strings.Split(releaseVersions, ",")
-	goVersions := make(infrasort.GoVersions, 0, len(rawVersions))
+	// Parse and validate versions, fetching the SHA256 for each from the release's assets.json.
+	rawVersions := strings.Split(*releaseVersions, ",")
+	dlVersions := make([]dlVersionData, 0, len(rawVersions))
 	for _, v := range rawVersions {
 		v = strings.TrimSpace(v)
 		if v == "" {
@@ -95,19 +88,10 @@ func updateDL(p subcmd.ParseFunc) error {
 		if gv.Major == "" || gv.Minor == "" {
 			return fmt.Errorf("invalid version string: %q", v)
 		}
-		goVersions = append(goVersions, gv)
-	}
-	if len(goVersions) == 0 {
-		return fmt.Errorf("no valid versions found in -versions flag")
-	}
-	sort.Sort(goVersions)
 
-	// For each version, fetch the SHA256 from the release's assets.json.
-	dlVersions := make([]dlVersionData, 0, len(goVersions))
-	for _, gv := range goVersions {
 		version := gv.Full()
 		log.Printf("Fetching SHA256 for version %s...\n", version)
-		sha256, err := fetchGoSrcSHA256(ctx, client, goOrg, goRepo, "v"+version)
+		sha256, err := fetchGoSrcSHA256(ctx, client, *goOrg, *goRepo, "v"+version)
 		if err != nil {
 			return fmt.Errorf("error fetching SHA256 for version %s: %w", version, err)
 		}
@@ -117,6 +101,13 @@ func updateDL(p subcmd.ParseFunc) error {
 			SHA256:  sha256,
 		})
 	}
+	if len(dlVersions) == 0 {
+		return fmt.Errorf("no valid versions found in -versions flag")
+	}
+	// Sort descending so PR title lists versions in a consistent order.
+	sort.Slice(dlVersions, func(i, j int) bool {
+		return infrasort.GoVersionDesc(goversion.New(dlVersions[i].Version), goversion.New(dlVersions[j].Version))
+	})
 
 	// Generate file contents from the template.
 	tmpl, err := template.New("dl").Parse(dlTemplate)
@@ -140,7 +131,7 @@ func updateDL(p subcmd.ParseFunc) error {
 		files = append(files, fileEntry{path: filePath, version: dv.Version, content: buf.Bytes()})
 	}
 
-	if dryRun {
+	if *dryRun {
 		for _, f := range files {
 			fmt.Printf("Would create %s\n", f.path)
 			fmt.Println("=====")
@@ -163,16 +154,13 @@ func updateDL(p subcmd.ParseFunc) error {
 	}
 
 	// Check that none of the files already exist.
-	for _, f := range files {
-		if _, err := githubutil.DownloadFile(ctx, client, org, repo, "main", f.path); err != nil {
-			if errors.Is(err, githubutil.ErrFileNotExists) {
-				// Good.
-			} else {
-				return fmt.Errorf("error checking if file %s exists: %w", f.path, err)
-			}
-		} else {
-			return fmt.Errorf("file %s already exists in %s/%s", f.path, org, repo)
-		}
+	refFS := githubutil.NewRefFS(ctx, client, *org, *repo, "main")
+	filePaths := make([]string, len(files))
+	for i, f := range files {
+		filePaths[i] = f.path
+	}
+	if err := checkDLFilesNotExist(refFS, filePaths); err != nil {
+		return err
 	}
 
 	// Generate the PR title.
@@ -187,7 +175,7 @@ func updateDL(p subcmd.ParseFunc) error {
 	prSet := gitpr.PRRefSet{Name: "main", Purpose: fmt.Sprintf("dl/%s/%d", slug, time.Now().Unix())}
 	branchName := prSet.PRBranch()
 
-	if err := githubutil.CreateBranch(ctx, client, org, repo, branchName, "main"); err != nil {
+	if err := githubutil.CreateBranch(ctx, client, *org, *repo, branchName, "main"); err != nil {
 		return fmt.Errorf("error creating branch %s: %w", branchName, err)
 	}
 
@@ -196,8 +184,8 @@ func updateDL(p subcmd.ParseFunc) error {
 		if err := githubutil.UploadFile(
 			ctx,
 			client,
-			org,
-			repo,
+			*org,
+			*repo,
 			branchName,
 			f.path,
 			fmt.Sprintf("Add dl package: msgo%s", f.version),
@@ -207,11 +195,11 @@ func updateDL(p subcmd.ParseFunc) error {
 		}
 	}
 
-	ownerRepo := fmt.Sprintf("%s/%s", org, repo)
+	ownerRepo := fmt.Sprintf("%s/%s", *org, *repo)
 	prReq := prSet.CreateGitHubPR(
-		org,
+		*org,
 		title,
-		"**Automated Pull Request:** Adds dl packages for new Microsoft Go releases.\n"+
+		"**Automated Pull Request:** Adds dl packages for new Microsoft build of Go releases.\n"+
 			"This PR was generated automatically using the [`update-dl.go`](https://github.com/microsoft/go-infra/blob/main/cmd/releasego/update-dl.go) script.")
 	createdPR, err := gitpr.PostGitHub(ownerRepo, prReq, auther)
 	if err != nil {
@@ -286,18 +274,22 @@ func dlFilePath(version string) string {
 	return fmt.Sprintf("dl/msgo%s/main.go", version)
 }
 
+// checkDLFilesNotExist checks that none of the given file paths already exist in the filesystem.
+// fsys can be a githubutil.NewRefFS (remote GitHub) or os.DirFS (local).
+func checkDLFilesNotExist(fsys githubutil.SimplifiedFS, paths []string) error {
+	for _, path := range paths {
+		_, err := fsys.ReadFile(path)
+		if err == nil {
+			return fmt.Errorf("file %s already exists", path)
+		}
+		if !errors.Is(err, githubutil.ErrFileNotExists) && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("error checking if file %s exists: %w", path, err)
+		}
+	}
+	return nil
+}
+
 // generateDLPRTitle generates a human-readable PR title for the dl update.
 func generateDLPRTitle(versions []string) string {
-	count := len(versions)
-	switch count {
-	case 0:
-		return ""
-	case 1:
-		return fmt.Sprintf("Add dl package for Go %s", versions[0])
-	case 2:
-		return fmt.Sprintf("Add dl packages for Go %s and %s", versions[0], versions[1])
-	default:
-		allExceptLast := strings.Join(versions[:count-1], ", ")
-		return fmt.Sprintf("Add dl packages for Go %s, and %s", allExceptLast, versions[count-1])
-	}
+	return "Update dl for Go " + strings.Join(versions, ", ")
 }

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -83,11 +83,22 @@ func updateDL(p subcmd.ParseFunc) error {
 		return err
 	}
 
-	// Parse and sort versions in descending order.
-	versionsList := strings.Split(releaseVersions, ",")
-	goVersions := make(infrasort.GoVersions, 0, len(versionsList))
-	for _, v := range versionsList {
-		goVersions = append(goVersions, goversion.New(v))
+	// Parse, validate, and sort versions in descending order.
+	rawVersions := strings.Split(releaseVersions, ",")
+	goVersions := make(infrasort.GoVersions, 0, len(rawVersions))
+	for _, v := range rawVersions {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		gv := goversion.New(v)
+		if gv.Major == "" || gv.Minor == "" {
+			return fmt.Errorf("invalid version string: %q", v)
+		}
+		goVersions = append(goVersions, gv)
+	}
+	if len(goVersions) == 0 {
+		return fmt.Errorf("no valid versions found in -versions flag")
 	}
 	sort.Sort(goVersions)
 
@@ -115,6 +126,7 @@ func updateDL(p subcmd.ParseFunc) error {
 
 	type fileEntry struct {
 		path    string
+		version string
 		content []byte
 	}
 	files := make([]fileEntry, 0, len(dlVersions))
@@ -125,7 +137,7 @@ func updateDL(p subcmd.ParseFunc) error {
 			return fmt.Errorf("error executing dl template for version %s: %w", dv.Version, err)
 		}
 		filePath := dlFilePath(dv.Version)
-		files = append(files, fileEntry{path: filePath, content: buf.Bytes()})
+		files = append(files, fileEntry{path: filePath, version: dv.Version, content: buf.Bytes()})
 	}
 
 	if dryRun {
@@ -188,7 +200,7 @@ func updateDL(p subcmd.ParseFunc) error {
 			repo,
 			branchName,
 			f.path,
-			fmt.Sprintf("Add dl package: msgo%s", f.path),
+			fmt.Sprintf("Add dl package: msgo%s", f.version),
 			f.content,
 		); err != nil {
 			return fmt.Errorf("error uploading file %s to branch %s: %w", f.path, branchName, err)
@@ -241,10 +253,11 @@ func fetchGoSrcSHA256(ctx context.Context, client *github.Client, owner, repo, t
 	}
 
 	// Download the assets.json file.
+	downloadClient := &http.Client{Timeout: 30 * time.Second}
 	var rc io.ReadCloser
 	if err := githubutil.Retry(func() error {
 		var err error
-		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), http.DefaultClient)
+		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), downloadClient)
 		return err
 	}); err != nil {
 		return "", fmt.Errorf("error downloading assets.json from release %s: %w", tag, err)

--- a/cmd/releasego/update-dl.go
+++ b/cmd/releasego/update-dl.go
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/google/go-github/v65/github"
+	"github.com/microsoft/go-infra/buildmodel/buildassets"
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/gitpr"
+	"github.com/microsoft/go-infra/goversion"
+	"github.com/microsoft/go-infra/internal/infrasort"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "update-dl",
+		Summary: "Add dl packages to the go-lab repository for new Go releases.",
+		Description: `
+The update-dl command generates dl/msgo<version>/main.go files for each specified
+Go release version and creates a pull request on the go-lab repository. It fetches
+the source archive SHA256 hash from the GitHub release's assets.json file.
+`,
+		Handle: updateDL,
+	})
+}
+
+// dlVersionData holds the data needed to generate a dl package file.
+type dlVersionData struct {
+	Version string
+	SHA256  string
+}
+
+//go:embed templates/dl.template.go.tmpl
+var dlTemplate string
+
+func updateDL(p subcmd.ParseFunc) error {
+	var releaseVersions string
+	var dryRun bool
+	var org string
+	var repo string
+	var goOrg string
+	var goRepo string
+
+	flag.StringVar(&releaseVersions, "versions", "", "Comma-separated list of version numbers for the Go release (e.g. 1.25.8-1,1.26.1-1).")
+	flag.BoolVar(&dryRun, "n", false, "Enable dry run: do not push changes to GitHub.")
+	flag.StringVar(&org, "org", "microsoft", "The GitHub organization for the go-lab repository.")
+	flag.StringVar(&repo, "repo", "go-lab", "The GitHub repository name for the dl packages.")
+	flag.StringVar(&goOrg, "go-org", "microsoft", "The GitHub organization for the Go releases repository.")
+	flag.StringVar(&goRepo, "go-repo", "go", "The GitHub repository name for Go releases.")
+	gitHubAuthFlags := githubutil.BindGitHubAuthFlags("")
+	gitHubReviewerAuthFlags := githubutil.BindGitHubAuthFlags("reviewer")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	if releaseVersions == "" {
+		return fmt.Errorf("no versions specified; use -versions flag")
+	}
+
+	ctx := context.Background()
+
+	client, err := gitHubAuthFlags.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Parse and sort versions in descending order.
+	versionsList := strings.Split(releaseVersions, ",")
+	goVersions := make(infrasort.GoVersions, 0, len(versionsList))
+	for _, v := range versionsList {
+		goVersions = append(goVersions, goversion.New(v))
+	}
+	sort.Sort(goVersions)
+
+	// For each version, fetch the SHA256 from the release's assets.json.
+	dlVersions := make([]dlVersionData, 0, len(goVersions))
+	for _, gv := range goVersions {
+		version := gv.Full()
+		log.Printf("Fetching SHA256 for version %s...\n", version)
+		sha256, err := fetchGoSrcSHA256(ctx, client, goOrg, goRepo, "v"+version)
+		if err != nil {
+			return fmt.Errorf("error fetching SHA256 for version %s: %w", version, err)
+		}
+		log.Printf("SHA256 for %s: %s\n", version, sha256)
+		dlVersions = append(dlVersions, dlVersionData{
+			Version: version,
+			SHA256:  sha256,
+		})
+	}
+
+	// Generate file contents from the template.
+	tmpl, err := template.New("dl").Parse(dlTemplate)
+	if err != nil {
+		return fmt.Errorf("error parsing dl template: %w", err)
+	}
+
+	type fileEntry struct {
+		path    string
+		content []byte
+	}
+	files := make([]fileEntry, 0, len(dlVersions))
+
+	for _, dv := range dlVersions {
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, dv); err != nil {
+			return fmt.Errorf("error executing dl template for version %s: %w", dv.Version, err)
+		}
+		filePath := dlFilePath(dv.Version)
+		files = append(files, fileEntry{path: filePath, content: buf.Bytes()})
+	}
+
+	if dryRun {
+		for _, f := range files {
+			fmt.Printf("Would create %s\n", f.path)
+			fmt.Println("=====")
+			if _, err := os.Stdout.Write(f.content); err != nil {
+				return err
+			}
+			fmt.Println("=====")
+		}
+		return nil
+	}
+
+	auther, err := gitHubAuthFlags.NewAuther()
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub auther: %w", err)
+	}
+
+	reviewAuther, err := gitHubReviewerAuthFlags.NewAuther()
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub review auther: %w", err)
+	}
+
+	// Check that none of the files already exist.
+	for _, f := range files {
+		if _, err := githubutil.DownloadFile(ctx, client, org, repo, "main", f.path); err != nil {
+			if errors.Is(err, githubutil.ErrFileNotExists) {
+				// Good.
+			} else {
+				return fmt.Errorf("error checking if file %s exists: %w", f.path, err)
+			}
+		} else {
+			return fmt.Errorf("file %s already exists in %s/%s", f.path, org, repo)
+		}
+	}
+
+	// Generate the PR title.
+	versionStrings := make([]string, 0, len(dlVersions))
+	for _, dv := range dlVersions {
+		versionStrings = append(versionStrings, dv.Version)
+	}
+	title := generateDLPRTitle(versionStrings)
+
+	// Create a feature branch and upload all files.
+	slug := "msgo-" + strings.Join(versionStrings, "-")
+	prSet := gitpr.PRRefSet{Name: "main", Purpose: fmt.Sprintf("dl/%s/%d", slug, time.Now().Unix())}
+	branchName := prSet.PRBranch()
+
+	if err := githubutil.CreateBranch(ctx, client, org, repo, branchName, "main"); err != nil {
+		return fmt.Errorf("error creating branch %s: %w", branchName, err)
+	}
+
+	for _, f := range files {
+		log.Printf("Uploading %s...\n", f.path)
+		if err := githubutil.UploadFile(
+			ctx,
+			client,
+			org,
+			repo,
+			branchName,
+			f.path,
+			fmt.Sprintf("Add dl package: msgo%s", f.path),
+			f.content,
+		); err != nil {
+			return fmt.Errorf("error uploading file %s to branch %s: %w", f.path, branchName, err)
+		}
+	}
+
+	ownerRepo := fmt.Sprintf("%s/%s", org, repo)
+	prReq := prSet.CreateGitHubPR(
+		org,
+		title,
+		"**Automated Pull Request:** Adds dl packages for new Microsoft Go releases.\n"+
+			"This PR was generated automatically using the [`update-dl.go`](https://github.com/microsoft/go-infra/blob/main/cmd/releasego/update-dl.go) script.")
+	createdPR, err := gitpr.PostGitHub(ownerRepo, prReq, auther)
+	if err != nil {
+		return fmt.Errorf("error creating pull request with gitpr: %w", err)
+	}
+
+	if err = gitpr.EnablePRAutoMerge(createdPR.NodeID, reviewAuther); err != nil {
+		return err
+	}
+
+	if err = gitpr.ApprovePR(createdPR.NodeID, reviewAuther); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// fetchGoSrcSHA256 downloads the assets.json from a GitHub release and returns the GoSrcSHA256.
+func fetchGoSrcSHA256(ctx context.Context, client *github.Client, owner, repo, tag string) (string, error) {
+	var release *github.RepositoryRelease
+	if err := githubutil.Retry(func() error {
+		var err error
+		release, _, err = client.Repositories.GetReleaseByTag(ctx, owner, repo, tag)
+		return err
+	}); err != nil {
+		return "", fmt.Errorf("error getting release for tag %s: %w", tag, err)
+	}
+
+	// Find assets.json in the release assets.
+	var assetsAsset *github.ReleaseAsset
+	for i := range release.Assets {
+		if release.Assets[i].GetName() == "assets.json" {
+			assetsAsset = release.Assets[i]
+			break
+		}
+	}
+	if assetsAsset == nil {
+		return "", fmt.Errorf("assets.json not found in release %s", tag)
+	}
+
+	// Download the assets.json file.
+	var rc io.ReadCloser
+	if err := githubutil.Retry(func() error {
+		var err error
+		rc, _, err = client.Repositories.DownloadReleaseAsset(ctx, owner, repo, assetsAsset.GetID(), http.DefaultClient)
+		return err
+	}); err != nil {
+		return "", fmt.Errorf("error downloading assets.json from release %s: %w", tag, err)
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return "", fmt.Errorf("error reading assets.json: %w", err)
+	}
+
+	var assets buildassets.BuildAssets
+	if err := json.Unmarshal(data, &assets); err != nil {
+		return "", fmt.Errorf("error parsing assets.json: %w", err)
+	}
+
+	if assets.GoSrcSHA256 == "" {
+		return "", fmt.Errorf("GoSrcSHA256 is empty in assets.json for release %s", tag)
+	}
+
+	return assets.GoSrcSHA256, nil
+}
+
+// dlFilePath returns the path for a dl package's main.go file within the go-lab repo.
+func dlFilePath(version string) string {
+	return fmt.Sprintf("dl/msgo%s/main.go", version)
+}
+
+// generateDLPRTitle generates a human-readable PR title for the dl update.
+func generateDLPRTitle(versions []string) string {
+	count := len(versions)
+	switch count {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("Add dl package for Go %s", versions[0])
+	case 2:
+		return fmt.Sprintf("Add dl packages for Go %s and %s", versions[0], versions[1])
+	default:
+		allExceptLast := strings.Join(versions[:count-1], ", ")
+		return fmt.Sprintf("Add dl packages for Go %s, and %s", allExceptLast, versions[count-1])
+	}
+}

--- a/cmd/releasego/update-dl_test.go
+++ b/cmd/releasego/update-dl_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+	"text/template"
+
+	"github.com/microsoft/go-infra/goldentest"
+)
+
+func Test_dlTemplate(t *testing.T) {
+	tmpl, err := template.New("dl").Parse(dlTemplate)
+	if err != nil {
+		t.Fatalf("error parsing dl template: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		data dlVersionData
+	}{
+		{
+			"single-version",
+			dlVersionData{
+				Version: "1.25.8-1",
+				SHA256:  "3ff0e9fa6b16675d373521d805ead46e3fa74a70e8aadeb97848d30d5e19e562",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, tt.data); err != nil {
+				t.Fatalf("error executing dl template: %v", err)
+			}
+			goldentest.Check(t, tt.name+".golden.go", buf.String())
+		})
+	}
+}
+
+func TestGenerateDLPRTitle(t *testing.T) {
+	tests := []struct {
+		versions []string
+		expected string
+	}{
+		{nil, ""},
+		{[]string{"1.25.8-1"}, "Add dl package for Go 1.25.8-1"},
+		{[]string{"1.25.8-1", "1.26.1-1"}, "Add dl packages for Go 1.25.8-1 and 1.26.1-1"},
+		{[]string{"1.25.8-1", "1.26.1-1", "1.24.3-1"}, "Add dl packages for Go 1.25.8-1, 1.26.1-1, and 1.24.3-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := generateDLPRTitle(tt.versions)
+			if got != tt.expected {
+				t.Errorf("generateDLPRTitle(%v) = %q; want %q", tt.versions, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDLFilePath(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{"1.25.8-1", "dl/msgo1.25.8-1/main.go"},
+		{"1.26.1-1", "dl/msgo1.26.1-1/main.go"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := dlFilePath(tt.version)
+			if got != tt.expected {
+				t.Errorf("dlFilePath(%q) = %q; want %q", tt.version, got, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/releasego/update-dl_test.go
+++ b/cmd/releasego/update-dl_test.go
@@ -46,10 +46,10 @@ func TestGenerateDLPRTitle(t *testing.T) {
 		versions []string
 		expected string
 	}{
-		{nil, ""},
-		{[]string{"1.25.8-1"}, "Add dl package for Go 1.25.8-1"},
-		{[]string{"1.25.8-1", "1.26.1-1"}, "Add dl packages for Go 1.25.8-1 and 1.26.1-1"},
-		{[]string{"1.25.8-1", "1.26.1-1", "1.24.3-1"}, "Add dl packages for Go 1.25.8-1, 1.26.1-1, and 1.24.3-1"},
+		{nil, "Update dl for Go "},
+		{[]string{"1.25.8-1"}, "Update dl for Go 1.25.8-1"},
+		{[]string{"1.25.8-1", "1.26.1-1"}, "Update dl for Go 1.25.8-1, 1.26.1-1"},
+		{[]string{"1.25.8-1", "1.26.1-1", "1.24.3-1"}, "Update dl for Go 1.25.8-1, 1.26.1-1, 1.24.3-1"},
 	}
 
 	for _, tt := range tests {

--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -42,6 +42,10 @@ parameters:
     displayName: Publish announcement details
     type: boolean
     default: true
+  - name: runUpdateDL
+    displayName: Update go dl packages
+    type: boolean
+    default: true
   - name: runGoImageVersionCheck
     displayName: Check Go version in latest MAR images
     type: boolean
@@ -195,6 +199,18 @@ extends:
                         -github-reviewer-app-installation '$(BotAccount-review-bot-for-go-installation)' \
                         -github-reviewer-app-private-key '$(BotAccount-review-bot-for-go-private-key)' 
                     displayName: 📰 Publish announcement details
+
+                - ${{ if eq(parameters.runUpdateDL, true) }}:
+                  - script: |
+                      releasego update-dl \
+                        -versions '${{ join(',', parameters.releaseVersions) }}' \
+                        -github-app-client-id '$(BotAccount-bot-for-go-client-id)' \
+                        -github-app-installation '$(BotAccount-bot-for-go-installation)' \
+                        -github-app-private-key '$(BotAccount-bot-for-go-private-key)' \
+                        -github-reviewer-app-client-id '$(BotAccount-review-bot-for-go-client-id)' \
+                        -github-reviewer-app-installation '$(BotAccount-review-bot-for-go-installation)' \
+                        -github-reviewer-app-private-key '$(BotAccount-review-bot-for-go-private-key)'
+                    displayName: 📦 Update go dl packages
 
                 - ${{ if eq(parameters.runGoImageVersionCheck, true) }}:
                   - script: |

--- a/githubutil/fs.go
+++ b/githubutil/fs.go
@@ -5,6 +5,7 @@ package githubutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"time"
@@ -55,6 +56,9 @@ var _ SimplifiedFS = (*FS)(nil)
 func (r *FS) ReadFile(name string) ([]byte, error) {
 	fileContent, err := DownloadFile(r.ctx, r.client, r.owner, r.repo, r.ref, name)
 	if err != nil {
+		if errors.Is(err, ErrFileNotExists) {
+			return nil, fmt.Errorf("failed to download file %q: %w", name, fs.ErrNotExist)
+		}
 		return nil, fmt.Errorf("failed to download file %q: %w", name, err)
 	}
 	return fileContent, nil

--- a/internal/infrasort/goversions.go
+++ b/internal/infrasort/goversions.go
@@ -14,6 +14,11 @@ type GoVersions []*goversion.GoVersion
 func (versions GoVersions) Len() int      { return len(versions) }
 func (versions GoVersions) Swap(i, j int) { versions[i], versions[j] = versions[j], versions[i] }
 func (versions GoVersions) Less(i, j int) bool {
+	return GoVersionDesc(versions[i], versions[j])
+}
+
+// GoVersionDesc reports whether a should sort before b in descending version order.
+func GoVersionDesc(a, b *goversion.GoVersion) bool {
 	less := func(a, b string) bool {
 		intA, err := strconv.Atoi(a)
 		if err != nil {
@@ -27,7 +32,7 @@ func (versions GoVersions) Less(i, j int) bool {
 		return intA > intB
 	}
 
-	current, next := versions[i], versions[j]
+	current, next := a, b
 
 	if current.Major != next.Major {
 		return less(current.Major, next.Major)

--- a/internal/infrasort/goversions.go
+++ b/internal/infrasort/goversions.go
@@ -14,11 +14,11 @@ type GoVersions []*goversion.GoVersion
 func (versions GoVersions) Len() int      { return len(versions) }
 func (versions GoVersions) Swap(i, j int) { versions[i], versions[j] = versions[j], versions[i] }
 func (versions GoVersions) Less(i, j int) bool {
-	return GoVersionDesc(versions[i], versions[j])
+	return GoVersionLess(versions[i], versions[j])
 }
 
-// GoVersionDesc reports whether a should sort before b in descending version order.
-func GoVersionDesc(a, b *goversion.GoVersion) bool {
+// GoVersionLess reports whether a should sort before b in descending version order.
+func GoVersionLess(a, b *goversion.GoVersion) bool {
 	less := func(a, b string) bool {
 		intA, err := strconv.Atoi(a)
 		if err != nil {


### PR DESCRIPTION
Add a new releasego subcommand "update-dl" that automates creating dl/msgo<version>/main.go files in the microsoft/go-lab repository for new Go releases. For each version, it fetches the source archive SHA256 hash from the GitHub release's assets.json and generates a dl package from a template. It then opens a PR with auto-merge enabled.

Also add the update-dl step to the release-go-images pipeline, running alongside publish-announcement with its own toggle parameter.