### PR TITLE
Add warning for truncation

### DIFF
--- a/json2junit/json2junit.go
+++ b/json2junit/json2junit.go
@@ -17,6 +17,26 @@ import (
 	"time"
 )
 
+const (
+	// azdoMaxChars is the approximate maximum number of characters the AzDO
+	// test viewer displays before silently truncating test failure content.
+	azdoMaxChars = 32000
+)
+
+var azdoWarning = []byte("[json2junit: Output is ~32000+ characters and may be truncated by AzDO. See raw test output for full content.]\n\n")
+
+// warnLongContent prepends a warning to test output that exceeds AzDO's display
+// limit. The content itself is not modified or truncated.
+func warnLongContent(content []byte) []byte {
+	if len(content) <= azdoMaxChars {
+		return content
+	}
+	result := make([]byte, 0, len(azdoWarning)+len(content))
+	result = append(result, azdoWarning...)
+	result = append(result, content...)
+	return result
+}
+
 // Options configures the conversion behavior.
 type Options struct {
 	// IncludePackageInTestName prefixes each test case name with its package path,
@@ -270,7 +290,7 @@ func (c *Converter) processJSONEntry(entry jsonEntry) error {
 				// In case of success, we don't care about the output.
 				suite.SystemOut = nil
 			} else if suite.SystemOut != nil {
-				suite.SystemOut.Content = bytes.TrimSuffix(suite.SystemOut.Content, []byte{'\n'})
+				suite.SystemOut.Content = warnLongContent(bytes.TrimSuffix(suite.SystemOut.Content, []byte{'\n'}))
 			}
 			err := c.writeXMLTestSuite(suite)
 			if err != nil {
@@ -292,14 +312,14 @@ func (c *Converter) processJSONEntry(entry jsonEntry) error {
 			testCase.Result = &junitResult{
 				XMLName: xml.Name{Space: "", Local: "skipped"},
 				Message: "skipped",
-				Content: testCase.systemOut,
+				Content: warnLongContent(testCase.systemOut),
 			}
 		case "fail":
 			suite.Failures++
 			testCase.Result = &junitResult{
 				XMLName: xml.Name{Space: "", Local: "failure"},
 				Message: "failed",
-				Content: testCase.systemOut,
+				Content: warnLongContent(testCase.systemOut),
 			}
 		}
 		// Clear systemOut, it's already in the event.

--- a/json2junit/json2junit.go
+++ b/json2junit/json2junit.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"slices"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -23,12 +24,12 @@ const (
 	azdoMaxChars = 32000
 )
 
-var azdoWarning = []byte("[json2junit: Output is ~32000+ characters and may be truncated by AzDO. See raw test output for full content.]\n\n")
+var azdoWarning = []byte(fmt.Sprintf("[json2junit: Output is ~%d+ characters and may be truncated by AzDO. See raw test output for full content.]\n\n", azdoMaxChars))
 
 // warnLongContent prepends a warning to test output that exceeds AzDO's display
 // limit. The content itself is not modified or truncated.
 func warnLongContent(content []byte) []byte {
-	if len(content) <= azdoMaxChars {
+	if utf8.RuneCount(content) <= azdoMaxChars {
 		return content
 	}
 	result := make([]byte, 0, len(azdoWarning)+len(content))

--- a/json2junit/json2junit_test.go
+++ b/json2junit/json2junit_test.go
@@ -103,3 +103,66 @@ func TestConverterErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestWarnLongContent_NoWarning(t *testing.T) {
+	input := []byte("short output\nline two\n")
+	got := warnLongContent(input)
+	if string(got) != string(input) {
+		t.Errorf("expected no change, got %q", got)
+	}
+}
+
+func TestWarnLongContent_Empty(t *testing.T) {
+	got := warnLongContent(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %q", got)
+	}
+	got = warnLongContent([]byte{})
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestWarnLongContent_ExactlyAtLimit(t *testing.T) {
+	input := []byte(strings.Repeat("b\n", azdoMaxChars/2))[:azdoMaxChars]
+	got := warnLongContent(input)
+	if string(got) != string(input) {
+		t.Errorf("expected no change for content at exact limit, got len %d", len(got))
+	}
+}
+
+func TestWarnLongContent_OneBeyondLimit(t *testing.T) {
+	input := []byte(strings.Repeat("c\n", (azdoMaxChars+2)/2))
+	if len(input) <= azdoMaxChars {
+		t.Fatalf("test setup: expected >%d bytes, got %d", azdoMaxChars, len(input))
+	}
+
+	got := warnLongContent(input)
+	if !strings.HasPrefix(string(got), string(azdoWarning)) {
+		t.Error("expected warning at beginning")
+	}
+	afterWarning := string(got)[len(azdoWarning):]
+	if afterWarning != string(input) {
+		t.Errorf("expected original content after warning, got len %d vs %d", len(afterWarning), len(input))
+	}
+}
+
+func TestWarnLongContent_PreservesAllContent(t *testing.T) {
+	var lines []string
+	for i := 0; i < 1500; i++ {
+		lines = append(lines, strings.Repeat("a", 30))
+	}
+	input := []byte(strings.Join(lines, "\n"))
+	if len(input) <= azdoMaxChars {
+		t.Fatalf("test input too short: %d", len(input))
+	}
+
+	got := warnLongContent(input)
+	if !strings.HasPrefix(string(got), string(azdoWarning)) {
+		t.Error("expected warning at beginning")
+	}
+	afterWarning := string(got)[len(azdoWarning):]
+	if afterWarning != string(input) {
+		t.Error("expected all content preserved without any truncation")
+	}
+}


### PR DESCRIPTION
This pull request enhances the `json2junit` tool to improve the handling of large test output content, specifically for Azure DevOps (AzDO) users. It introduces a mechanism to prepend a warning message to test outputs that exceed AzDO's display limit, alerting users that their output may be truncated in the UI, while ensuring the full content is preserved in the raw output. Comprehensive unit tests are also added to verify this behavior.

**AzDO output warning improvements:**

* Added a constant (`azdoMaxChars`) to define the maximum number of characters AzDO displays before truncating test output, and a warning message (`azdoWarning`) to alert users when this limit is exceeded. Introduced the `warnLongContent` function to prepend this warning to long outputs without truncating the content. (`json2junit/json2junit.go`)
* Updated the processing logic for test suite and test case outputs to use `warnLongContent`, ensuring the warning is added when necessary for both system out and failure/skipped messages. (`json2junit/json2junit.go`) [[1]](diffhunk://#diff-a4075adc4a8a10a3be1eed359843c0565051a96ae37d2ffecc727f065cbe08f3L273-R293) [[2]](diffhunk://#diff-a4075adc4a8a10a3be1eed359843c0565051a96ae37d2ffecc727f065cbe08f3L295-R322)

**Testing and validation:**

* Added unit tests for `warnLongContent` to verify correct behavior for short, empty, boundary-length, and over-limit content, as well as to ensure that all original output is preserved and the warning is correctly prepended. (`json2junit/json2junit_test.go`)