### PR TITLE
Enable whitespace linter with multi-if rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,11 @@ linters:
     - nakedret
     - predeclared
     - unconvert
+    - whitespace
+  settings:
+    whitespace:
+      # Enforce a newline (or comment) after every multi-line if statement.
+      multi-if: true
   exclusions:
     generated: lax
     presets:

--- a/buildreport/buildreport.go
+++ b/buildreport/buildreport.go
@@ -289,7 +289,6 @@ func (s *State) notificationPreamble() string {
 
 	case SymbolSucceeded:
 		switch s.Name {
-
 		case releaseBuildPipelineName:
 			notification := "Completed releasing one version! If every version's release-build and innerloop tests are successful, approve the release-go-images build to continue.\n"
 			if goversion.New(s.Version).Patch == "0" {

--- a/internal/pipelineymlgen/eval.go
+++ b/internal/pipelineymlgen/eval.go
@@ -117,7 +117,6 @@ func (e *EvalState) eval(orig *yaml.Node) (any, error) {
 	}
 
 	switch orig.Kind {
-
 	case yaml.DocumentNode:
 		if len(orig.Content) > 1 {
 			return fail(fmt.Errorf("document node contains multiple content nodes"))
@@ -288,7 +287,6 @@ func (e *EvalState) evalExpressionScalar(node *yaml.Node) (any, error) {
 			}
 
 			switch result := result.(type) {
-
 			// Something like "hello ${ .name }!".
 			case string:
 				return []byte(result)
@@ -352,7 +350,6 @@ func (e *EvalState) resultToYAML(r any) (*yaml.Node, error) {
 	}
 
 	switch r := r.(type) {
-
 	case *yaml.Node:
 		return r, nil
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -733,7 +733,6 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 					"). Skipping PR submission."
 			}
 		}
-
 	}
 
 	if len(changedBranches) == 0 {


### PR DESCRIPTION
Enables the whitespace linter with multi-if: true so that multi-line if expressions are required to be followed by a newline (or comment). Also fixes pre-existing whitespace violations flagged by the default rules.

- https://github.com/microsoft/go-lab/issues/239