### PR TITLE
Add msgo/systemcrypto counter

### DIFF
--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -68,7 +68,7 @@
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{
-					"Name": "msgo/modulehash:*"
+					"Name": "msgo/systemcrypto:{enabled,disabled}"
 				}
 			]
 		}


### PR DESCRIPTION
The `systemcrypto` goexperiment will be removed in Go 1.27, so we won't be able to use it as a proxy for counting systemcrypto usage.

Add a new counter, `msgo/systemcrypto`, to explicitly keep track of systemcrypto usage. 

While here, remove `msgo/modulehash`, as it is not currently used.