### PR TITLE
telemetry: re-enable module counter, add CI detection

### DIFF
--- a/telemetry/ci.go
+++ b/telemetry/ci.go
@@ -88,6 +88,10 @@ func envMap(env []string) map[string]string {
 }
 
 // isTrue reports whether the value is a common boolean-true string.
+// Matches the logic in dotnet/sdk EnvironmentVariableParser.ParseBool.
 func isTrue(v string) bool {
-	return v == "true" || v == "True" || v == "TRUE" || v == "1"
+	return v == "1" ||
+		strings.EqualFold(v, "true") ||
+		strings.EqualFold(v, "yes") ||
+		strings.EqualFold(v, "on")
 }

--- a/telemetry/ci.go
+++ b/telemetry/ci.go
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry
+
+import "strings"
+
+// DetectCI inspects the given environment variables to determine which CI
+// system is in use. The env parameter should be in the same format as
+// os.Environ() (i.e. each entry is "KEY=VALUE"). It returns a short
+// identifier matching the go/ci counter values, or "" if no CI system is
+// detected.
+func DetectCI(env []string) string {
+	m := envMap(env)
+
+	// Azure Pipelines
+	// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
+	if isTrue(m["TF_BUILD"]) {
+		return "azdo"
+	}
+
+	// GitHub Actions
+	// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+	if isTrue(m["GITHUB_ACTIONS"]) {
+		return "github"
+	}
+
+	// GitLab CI
+	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
+	if m["GITLAB_CI"] != "" {
+		return "gitlab"
+	}
+
+	// AppVeyor
+	// https://www.appveyor.com/docs/environment-variables/
+	if isTrue(m["APPVEYOR"]) {
+		return "appveyor"
+	}
+
+	// Travis CI
+	// https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+	if isTrue(m["TRAVIS"]) {
+		return "travis"
+	}
+
+	// CircleCI
+	// https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+	if isTrue(m["CIRCLECI"]) {
+		return "circleci"
+	}
+
+	// AWS CodeBuild
+	// https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+	if m["CODEBUILD_BUILD_ID"] != "" && m["AWS_REGION"] != "" {
+		return "aws_codebuild"
+	}
+
+	// Jenkins
+	// https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+	if m["BUILD_ID"] != "" && m["BUILD_URL"] != "" {
+		return "jenkins"
+	}
+
+	// Google Cloud Build
+	// https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+	if m["BUILD_ID"] != "" && m["PROJECT_ID"] != "" {
+		return "google_cloud_build"
+	}
+
+	// TeamCity
+	// https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+	if m["TEAMCITY_VERSION"] != "" {
+		return "teamcity"
+	}
+
+	return ""
+}
+
+// envMap converts an os.Environ()-style slice into a map for fast lookup.
+func envMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+// isTrue reports whether the value is a common boolean-true string.
+func isTrue(v string) bool {
+	return v == "true" || v == "True" || v == "TRUE" || v == "1"
+}

--- a/telemetry/ci_test.go
+++ b/telemetry/ci_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package telemetry
+
+import "testing"
+
+func TestDetectCI(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want string
+	}{
+		{"no CI", nil, ""},
+		{"Azure Pipelines", []string{"TF_BUILD=True"}, "azdo"},
+		{"GitHub Actions", []string{"GITHUB_ACTIONS=true"}, "github"},
+		{"GitLab CI", []string{"GITLAB_CI=true"}, "gitlab"},
+		{"AppVeyor", []string{"APPVEYOR=True"}, "appveyor"},
+		{"Travis CI", []string{"TRAVIS=true"}, "travis"},
+		{"CircleCI", []string{"CIRCLECI=true"}, "circleci"},
+		{"AWS CodeBuild", []string{"CODEBUILD_BUILD_ID=build:123", "AWS_REGION=us-east-1"}, "aws_codebuild"},
+		{"Jenkins", []string{"BUILD_ID=42", "BUILD_URL=http://jenkins/job/42"}, "jenkins"},
+		{"Google Cloud Build", []string{"BUILD_ID=abc", "PROJECT_ID=my-project"}, "google_cloud_build"},
+		{"TeamCity", []string{"TEAMCITY_VERSION=2023.05"}, "teamcity"},
+		{"TF_BUILD false not detected", []string{"TF_BUILD=false"}, ""},
+		{"GITHUB_ACTIONS empty not detected", []string{"GITHUB_ACTIONS="}, ""},
+		{"AWS CodeBuild missing region", []string{"CODEBUILD_BUILD_ID=build:123"}, ""},
+		{"Jenkins missing BUILD_URL", []string{"BUILD_ID=42"}, ""},
+		{"azdo wins over generic CI", []string{"TF_BUILD=True", "CI=true"}, "azdo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectCI(tt.env); got != tt.want {
+				t.Errorf("DetectCI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -69,6 +69,9 @@
 				},
 				{
 					"Name": "msgo/systemcrypto:{enabled,disabled}"
+				},
+				{
+					"Name": "msgo/modulehash:*"
 				}
 			]
 		}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -68,10 +68,13 @@
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{
-					"Name": "msgo/systemcrypto:{enabled,disabled}"
+					"Name": "go/ci:{appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
 				},
 				{
-					"Name": "msgo/modulehash:*"
+					"Name": "mssgo/systemcrypto:{enabled,disabled}"
+				},
+				{
+					"Name": "msgo/module:*"
 				}
 			]
 		}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -68,7 +68,7 @@
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{
-					"Name": "go/ci:{appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
+					"Name": "msgo/ci:{appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
 				},
 				{
 					"Name": "mssgo/systemcrypto:{enabled,disabled}"


### PR DESCRIPTION
Also implements `DetectCI` as a direct life and shift of https://github.com/dotnet/sdk/blob/main/src/Cli/Microsoft.DotNet.Cli.Definitions/Telemetry/CIEnvironmentDetectorForTelemetry.cs