### PR TITLE
Detect each CI system independently; counter for any CI

### DIFF
--- a/telemetry/ci.go
+++ b/telemetry/ci.go
@@ -6,74 +6,81 @@ package telemetry
 import "strings"
 
 // DetectCI inspects the given environment variables to determine which CI
-// system is in use. The env parameter should be in the same format as
-// os.Environ() (i.e. each entry is "KEY=VALUE"). It returns a short
-// identifier matching the go/ci counter values, or "" if no CI system is
+// systems are in use. The env parameter should be in the same format as
+// os.Environ() (i.e. each entry is "KEY=VALUE"). It returns "ci" plus short
+// identifiers matching the go/ci counter values, or nil if no CI system is
 // detected.
-func DetectCI(env []string) string {
+func DetectCI(env []string) []string {
 	m := envMap(env)
+	var detected []string
+	addDetected := func(ci string) {
+		if len(detected) == 0 {
+			detected = append(detected, "ci")
+		}
+		detected = append(detected, ci)
+	}
 
 	// Azure Pipelines
 	// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
 	if isTrue(m["TF_BUILD"]) {
-		return "azdo"
+		addDetected("azdo")
 	}
 
 	// GitHub Actions
 	// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 	if isTrue(m["GITHUB_ACTIONS"]) {
-		return "github"
+		addDetected("github")
 	}
 
 	// GitLab CI
 	// https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
 	if m["GITLAB_CI"] != "" {
-		return "gitlab"
+		addDetected("gitlab")
 	}
 
 	// AppVeyor
 	// https://www.appveyor.com/docs/environment-variables/
 	if isTrue(m["APPVEYOR"]) {
-		return "appveyor"
+		addDetected("appveyor")
 	}
 
 	// Travis CI
 	// https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 	if isTrue(m["TRAVIS"]) {
-		return "travis"
+		addDetected("travis")
 	}
 
 	// CircleCI
 	// https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 	if isTrue(m["CIRCLECI"]) {
-		return "circleci"
+		addDetected("circleci")
 	}
 
 	// AWS CodeBuild
 	// https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
 	if m["CODEBUILD_BUILD_ID"] != "" && m["AWS_REGION"] != "" {
-		return "aws_codebuild"
+		addDetected("aws_codebuild")
 	}
 
 	// Jenkins
 	// https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
 	if m["BUILD_ID"] != "" && m["BUILD_URL"] != "" {
-		return "jenkins"
+		addDetected("jenkins")
 	}
 
 	// Google Cloud Build
 	// https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 	if m["BUILD_ID"] != "" && m["PROJECT_ID"] != "" {
-		return "google_cloud_build"
+		addDetected("google_cloud_build")
 	}
 
 	// TeamCity
 	// https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
 	if m["TEAMCITY_VERSION"] != "" {
-		return "teamcity"
+		addDetected("teamcity")
 	}
 
-	return ""
+	return detected
 }
 
 // envMap converts an os.Environ()-style slice into a map for fast lookup.

--- a/telemetry/ci_test.go
+++ b/telemetry/ci_test.go
@@ -3,36 +3,40 @@
 
 package telemetry
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestDetectCI(t *testing.T) {
 	tests := []struct {
 		name string
 		env  []string
-		want string
+		want []string
 	}{
-		{"no CI", nil, ""},
-		{"Azure Pipelines", []string{"TF_BUILD=True"}, "azdo"},
-		{"GitHub Actions", []string{"GITHUB_ACTIONS=true"}, "github"},
-		{"GitLab CI", []string{"GITLAB_CI=true"}, "gitlab"},
-		{"AppVeyor", []string{"APPVEYOR=True"}, "appveyor"},
-		{"Travis CI", []string{"TRAVIS=true"}, "travis"},
-		{"CircleCI", []string{"CIRCLECI=true"}, "circleci"},
-		{"AWS CodeBuild", []string{"CODEBUILD_BUILD_ID=build:123", "AWS_REGION=us-east-1"}, "aws_codebuild"},
-		{"Jenkins", []string{"BUILD_ID=42", "BUILD_URL=http://jenkins/job/42"}, "jenkins"},
-		{"Google Cloud Build", []string{"BUILD_ID=abc", "PROJECT_ID=my-project"}, "google_cloud_build"},
-		{"TeamCity", []string{"TEAMCITY_VERSION=2023.05"}, "teamcity"},
-		{"TF_BUILD false not detected", []string{"TF_BUILD=false"}, ""},
-		{"GITHUB_ACTIONS empty not detected", []string{"GITHUB_ACTIONS="}, ""},
-		{"AWS CodeBuild missing region", []string{"CODEBUILD_BUILD_ID=build:123"}, ""},
-		{"Jenkins missing BUILD_URL", []string{"BUILD_ID=42"}, ""},
-		{"azdo wins over generic CI", []string{"TF_BUILD=True", "CI=true"}, "azdo"},
+		{"no CI", nil, nil},
+		{"Azure Pipelines", []string{"TF_BUILD=True"}, []string{"ci", "azdo"}},
+		{"GitHub Actions", []string{"GITHUB_ACTIONS=true"}, []string{"ci", "github"}},
+		{"GitLab CI", []string{"GITLAB_CI=true"}, []string{"ci", "gitlab"}},
+		{"AppVeyor", []string{"APPVEYOR=True"}, []string{"ci", "appveyor"}},
+		{"Travis CI", []string{"TRAVIS=true"}, []string{"ci", "travis"}},
+		{"CircleCI", []string{"CIRCLECI=true"}, []string{"ci", "circleci"}},
+		{"AWS CodeBuild", []string{"CODEBUILD_BUILD_ID=build:123", "AWS_REGION=us-east-1"}, []string{"ci", "aws_codebuild"}},
+		{"Jenkins", []string{"BUILD_ID=42", "BUILD_URL=http://jenkins/job/42"}, []string{"ci", "jenkins"}},
+		{"Google Cloud Build", []string{"BUILD_ID=abc", "PROJECT_ID=my-project"}, []string{"ci", "google_cloud_build"}},
+		{"TeamCity", []string{"TEAMCITY_VERSION=2023.05"}, []string{"ci", "teamcity"}},
+		{"TF_BUILD false not detected", []string{"TF_BUILD=false"}, nil},
+		{"GITHUB_ACTIONS empty not detected", []string{"GITHUB_ACTIONS="}, nil},
+		{"AWS CodeBuild missing region", []string{"CODEBUILD_BUILD_ID=build:123"}, nil},
+		{"Jenkins missing BUILD_URL", []string{"BUILD_ID=42"}, nil},
+		{"generic CI ignored while azdo detected", []string{"TF_BUILD=True", "CI=true"}, []string{"ci", "azdo"}},
+		{"multiple CI systems detected", []string{"TF_BUILD=True", "GITHUB_ACTIONS=true", "TEAMCITY_VERSION=2023.05"}, []string{"ci", "azdo", "github", "teamcity"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DetectCI(tt.env); got != tt.want {
-				t.Errorf("DetectCI() = %q, want %q", got, tt.want)
+			if got := DetectCI(tt.env); (got == nil) != (tt.want == nil) || !slices.Equal(got, tt.want) {
+				t.Errorf("DetectCI() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -68,7 +68,7 @@
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{
-					"Name": "msgo/ci:{appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
+					"Name": "msgo/ci:{ci,appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
 				},
 				{
 					"Name": "mssgo/systemcrypto:{enabled,disabled}"


### PR DESCRIPTION
* From https://github.com/microsoft/go-infra/pull/485#pullrequestreview-4311925349: detect each system independently without short-circuiting.
* Add `msgo/ci:ci` counter and add `ci` to the slice of detected CI when any CI is found.
  * This is more similar to the counter implemented by https://github.com/dotnet/sdk/blob/main/src/Cli/Microsoft.DotNet.Cli.Definitions/Telemetry/CIEnvironmentDetectorForTelemetry.cs
  * In theory, microsoft/go could handle the length check and adding `ci` part, and all this repo would need to do is change `config.json`. But, it seems reasonable enough to handle it here, without any clear reason not to.
  * My hypothesis is that this would potentially make it easier to assemble some telemetry queries on the resulting data, because the individual CI systems wouldn't have to be summed up.
    * Previously, there could be a check for "any msgo/ci counter", but if multiple are reported for a single toolset use, this might be harder.
    * I don't know if this is *actually* helpful--haven't worked with the Microsoft build of Go data--but seems intuitive to have in this situation.