### PR TITLE
telemetry/config: "go/platform/target/port" counter

### DIFF
--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -59,12 +59,6 @@
 					"Name": "go/subcommand:{build,install,run}"
 				},
 				{
-					"Name": "go/platform/target/goos:{aix,android,darwin,dragonfly,freebsd,hurd,illumos,ios,js,linux,nacl,netbsd,openbsd,plan9,solaris,wasip1,windows,zos}"
-				},
-				{
-					"Name": "go/platform/target/goarch:{386,amd64,amd64p32,arm,arm64,arm64be,armbe,loong64,mips,mips64,mips64le,mips64p32,mips64p32le,mipsle,ppc,ppc64,ppc64le,riscv,riscv64,s390,s390x,sparc,sparc64,wasm}"
-				},
-				{
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -71,10 +71,13 @@
 					"Name": "msgo/ci:{appveyor,aws_codebuild,azdo,circleci,github,gitlab,google_cloud_build,jenkins,teamcity,travis}"
 				},
 				{
-					"Name": "mssgo/systemcrypto:{enabled,disabled}"
+					"Name": "msgo/systemcrypto:{enabled,disabled}"
 				},
 				{
 					"Name": "msgo/module:*"
+				},
+				{
+					"Name": "go/platform/target/port:{aix-ppc64,android-386,android-amd64,android-arm,android-arm64,darwin-amd64,darwin-arm64,dragonfly-amd64,freebsd-386,freebsd-amd64,freebsd-arm,freebsd-arm64,freebsd-riscv64,illumos-amd64,ios-amd64,ios-arm64,js-wasm,linux-386,linux-amd64,linux-arm,linux-arm64,linux-loong64,linux-mips,linux-mips64,linux-mips64le,linux-mipsle,linux-ppc64,linux-ppc64le,linux-riscv64,linux-s390x,linux-sparc64,netbsd-386,netbsd-amd64,netbsd-arm,netbsd-arm64,openbsd-386,openbsd-amd64,openbsd-arm,openbsd-arm64,openbsd-ppc64,openbsd-riscv64,plan9-386,plan9-amd64,plan9-arm,solaris-amd64,wasip1-wasm,windows-386,windows-amd64,windows-arm64}"
 				}
 			]
 		}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -59,6 +59,9 @@
 					"Name": "go/subcommand:{build,install,run}"
 				},
 				{
+					"Name": "go/platform/target/port:{aix-ppc64,android-386,android-amd64,android-arm,android-arm64,darwin-amd64,darwin-arm64,dragonfly-amd64,freebsd-386,freebsd-amd64,freebsd-arm,freebsd-arm64,freebsd-riscv64,illumos-amd64,ios-amd64,ios-arm64,js-wasm,linux-386,linux-amd64,linux-arm,linux-arm64,linux-loong64,linux-mips,linux-mips64,linux-mips64le,linux-mipsle,linux-ppc64,linux-ppc64le,linux-riscv64,linux-s390x,linux-sparc64,netbsd-386,netbsd-amd64,netbsd-arm,netbsd-arm64,openbsd-386,openbsd-amd64,openbsd-arm,openbsd-arm64,openbsd-ppc64,openbsd-riscv64,plan9-386,plan9-amd64,plan9-arm,solaris-amd64,wasip1-wasm,windows-386,windows-amd64,windows-arm64}"
+				},
+				{
 					"Name": "go/cgo:{enabled,disabled}"
 				},
 				{
@@ -69,9 +72,6 @@
 				},
 				{
 					"Name": "msgo/module:*"
-				},
-				{
-					"Name": "go/platform/target/port:{aix-ppc64,android-386,android-amd64,android-arm,android-arm64,darwin-amd64,darwin-arm64,dragonfly-amd64,freebsd-386,freebsd-amd64,freebsd-arm,freebsd-arm64,freebsd-riscv64,illumos-amd64,ios-amd64,ios-arm64,js-wasm,linux-386,linux-amd64,linux-arm,linux-arm64,linux-loong64,linux-mips,linux-mips64,linux-mips64le,linux-mipsle,linux-ppc64,linux-ppc64le,linux-riscv64,linux-s390x,linux-sparc64,netbsd-386,netbsd-amd64,netbsd-arm,netbsd-arm64,openbsd-386,openbsd-amd64,openbsd-arm,openbsd-arm64,openbsd-ppc64,openbsd-riscv64,plan9-386,plan9-amd64,plan9-arm,solaris-amd64,wasip1-wasm,windows-386,windows-amd64,windows-arm64}"
 				}
 			]
 		}


### PR DESCRIPTION
Upstream will remove the `go/platform/target/goos` and the `go/platform/target/goarch` counters in favor of the new `go/platform/target/port` counter, see https://go-review.googlesource.com/c/go/+/775981. The latter combines the two removed counter for the sake of consistency. This is good for us too, as our dashboard show some entries that missed either the port or the os.

The accepted values for the new counter are taken from https://go-review.googlesource.com/c/telemetry/+/776000.

While here, fix a typo in the `msgo/systemcrypto` counter.