### PR TITLE
Add patch release workflow

### DIFF
--- a/.github/workflows/create-go-infra-patch-release.yml
+++ b/.github/workflows/create-go-infra-patch-release.yml
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Create go-infra patch release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run: calculate the next v0.0.x release without creating it."
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: create-go-infra-patch-release
+  cancel-in-progress: false
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: "Create next go-infra patch release (dry: ${{ inputs.dry-run }})"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          go run ./cmd/releasego create-go-infra-patch
+          -repo="${{ github.repository }}"
+          -github-pat="$GH_TOKEN"
+          -dry-run="${{ inputs.dry-run }}"

--- a/cmd/releasego/create-go-infra-patch.go
+++ b/cmd/releasego/create-go-infra-patch.go
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+
+	"github.com/google/go-github/v65/github"
+	"github.com/microsoft/go-infra/githubutil"
+	"github.com/microsoft/go-infra/subcmd"
+)
+
+func init() {
+	subcommands = append(subcommands, subcmd.Option{
+		Name:    "create-go-infra-patch",
+		Summary: "Create the next v0.0.x release for go-infra.",
+		Description: `
+
+Using the GitHub API, find the latest published release, calculate the next v0.0.x patch tag, and
+create a release with generated release notes. If someone creates the same release first, GitHub's
+create-release operation fails and this command exits with an error.
+`,
+		Handle: handleCreateGoInfraPatch,
+	})
+}
+
+var goInfraPatchTagPattern = regexp.MustCompile(`^v0\.0\.(\d+)$`)
+
+func handleCreateGoInfraPatch(p subcmd.ParseFunc) error {
+	repo := githubutil.BindRepoFlag()
+	gitHubAuthFlags := githubutil.BindGitHubAuthFlags("")
+	dryRun := flag.Bool("dry-run", false, "Print the next release tag without creating it.")
+
+	if err := p(); err != nil {
+		return err
+	}
+
+	owner, name, err := githubutil.ParseRepoFlag(repo)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client, err := gitHubAuthFlags.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	repository, err := githubutil.FetchRepository(ctx, client, owner, name)
+	if err != nil {
+		return err
+	}
+	defaultBranch := repository.GetDefaultBranch()
+	if defaultBranch == "" {
+		return errors.New("repository default branch is empty")
+	}
+
+	var latestRelease *github.RepositoryRelease
+	if err := githubutil.Retry(func() error {
+		var err error
+		log.Printf("Fetching latest release from %v/%v...\n", owner, name)
+		latestRelease, _, err = client.Repositories.GetLatestRelease(ctx, owner, name)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	latestTag := latestRelease.GetTagName()
+	nextTag, err := nextGoInfraPatchTag(latestTag)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Latest release: %v\n", latestTag)
+	log.Printf("Next release: %v\n", nextTag)
+	if *dryRun {
+		log.Println("Dry run: not creating release.")
+		return nil
+	}
+
+	log.Printf("Creating release %v from %v with generated release notes...\n", nextTag, defaultBranch)
+	generateReleaseNotes := true
+	release := &github.RepositoryRelease{
+		TagName:              github.String(nextTag),
+		Name:                 github.String(nextTag),
+		TargetCommitish:      github.String(defaultBranch),
+		GenerateReleaseNotes: &generateReleaseNotes,
+	}
+	if err := githubutil.Retry(func() error {
+		created, _, err := client.Repositories.CreateRelease(ctx, owner, name, release)
+		if err != nil {
+			return err
+		}
+		log.Printf("Created release: %v\n", created.GetHTMLURL())
+		return nil
+	}); err != nil {
+		return fmt.Errorf("create release %v: %w", nextTag, err)
+	}
+
+	return nil
+}
+
+func nextGoInfraPatchTag(latestTag string) (string, error) {
+	match := goInfraPatchTagPattern.FindStringSubmatch(latestTag)
+	if match == nil {
+		return "", fmt.Errorf("latest release tag %q is not a v0.0.x tag", latestTag)
+	}
+	patch, err := strconv.Atoi(match[1])
+	if err != nil {
+		return "", fmt.Errorf("parse patch number from %q: %w", latestTag, err)
+	}
+	return fmt.Sprintf("v0.0.%d", patch+1), nil
+}

--- a/cmd/releasego/create-go-infra-patch_test.go
+++ b/cmd/releasego/create-go-infra-patch_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import "testing"
+
+func Test_nextGoInfraPatchTag(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		latest  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "first patch",
+			latest: "v0.0.0",
+			want:   "v0.0.1",
+		},
+		{
+			name:   "multi digit patch",
+			latest: "v0.0.12",
+			want:   "v0.0.13",
+		},
+		{
+			name:    "v1 blocked",
+			latest:  "v1.0.0",
+			wantErr: true,
+		},
+		{
+			name:    "minor blocked",
+			latest:  "v0.1.0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid patch",
+			latest:  "v0.0.x",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := nextGoInfraPatchTag(tc.latest)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/361

This is a workflow that can be manually started to create a simple release with tag with the correct next patch version.

I tested this a little on my fork. It wasn't able to generate the bullet-pointed list of commits, only the tag diff link, but this seemed like it might have been a limitation of being a fork. (The tags already existing on the parent repo, or something like that.) It doesn't seem worth investigating for now: if that part of this workflow doesn't work in microsoft/go-infra as well, we can fix it up later. Note: a brief attempt to call https://docs.github.com/en/rest/releases/releases?apiVersion=2026-03-10#generate-release-notes-content-for-a-release manually rather than depend on `GenerateReleaseNotes: true` didn't change anything.