### PR TITLE
telemetry: send module hash as property instead of counter key

### DIFF
--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -50,7 +50,8 @@
 			"Name": "cmd/go",
 			"Counters": [
 				{
-					"Name": "go/invocations"
+					"Name": "go/invocations",
+					"Properties": ["msgo/module/hash"]
 				},
 				{
 					"Name": "go/goexperiment:{ms_tls_config_schannel,systemcrypto,nosystemcrypto,opensslcrypto,cngcrypto,darwincrypto,ms_nocgo_opensslcrypto}"
@@ -69,11 +70,6 @@
 				},
 				{
 					"Name": "msgo/systemcrypto:{enabled,disabled}"
-				}
-			],
-			"Properties": [
-				{
-					"Name": "msgo/modulehash"
 				}
 			]
 		}

--- a/telemetry/config/config.json
+++ b/telemetry/config/config.json
@@ -69,9 +69,11 @@
 				},
 				{
 					"Name": "msgo/systemcrypto:{enabled,disabled}"
-				},
+				}
+			],
+			"Properties": [
 				{
-					"Name": "msgo/module:*"
+					"Name": "msgo/modulehash"
 				}
 			]
 		}

--- a/telemetry/counter/counter.go
+++ b/telemetry/counter/counter.go
@@ -30,6 +30,14 @@ func New(name string) *Counter {
 	return telemetry.Client.NewEvent(name, nil)
 }
 
+// NewWithProperties returns a counter with the given name and custom properties.
+// Properties are sent as custom dimensions in Application Insights, allowing
+// high-cardinality values (such as hashes) to be sent as values rather than
+// as part of the counter name.
+func NewWithProperties(name string, properties map[string]string) *Counter {
+	return telemetry.Client.NewEvent(name, properties)
+}
+
 // CountFlags creates a counter for every flag that is set
 // and increments the counter. The name of the counter is
 // the concatenation of prefix and the flag name.

--- a/telemetry/export_test.go
+++ b/telemetry/export_test.go
@@ -5,3 +5,6 @@ package telemetry
 
 // UploadFilterForTest is exported for testing only.
 var UploadFilterForTest = uploadFilter
+
+// PropertyFilterForTest is exported for testing only.
+var PropertyFilterForTest = propertyFilter

--- a/telemetry/internal/appinsights/client.go
+++ b/telemetry/internal/appinsights/client.go
@@ -53,6 +53,11 @@ type Client struct {
 	// If nil, all telemetry items are sent.
 	UploadFilter func(name string) bool
 
+	// Function to filter property keys for a given event name.
+	// Returns a new map containing only the allowed keys.
+	// If nil, all properties are sent.
+	PropertyFilter func(name string, properties map[string]string) map[string]string
+
 	channel *inMemoryChannel
 	context *telemetryContext
 
@@ -153,6 +158,9 @@ func (c *Client) Stop() {
 func (c *Client) track(data contracts.EventData, n int64) {
 	if n == 0 || (c.UploadFilter != nil && !c.UploadFilter(data.Name)) {
 		return
+	}
+	if c.PropertyFilter != nil && data.Properties != nil {
+		data.Properties = c.PropertyFilter(data.Name, data.Properties)
 	}
 	if !c.init() {
 		// Stop or Close consumed initOnce before init could run.

--- a/telemetry/internal/config/config.go
+++ b/telemetry/internal/config/config.go
@@ -18,24 +18,18 @@ type UploadConfig struct {
 
 // A ProgramConfig contains the configuration for a single program.
 type ProgramConfig struct {
-	// the counter names may have to be
-	// repeated for each program. (e.g., if the counters are in a package
-	// that is used in more than one program.)
-	Name       string
-	Counters   []CounterConfig  `json:",omitempty"`
-	Properties []PropertyConfig `json:",omitempty"`
+	// The counter and property names may have to be repeated for each
+	// program (e.g., if they are defined in a package used by more than
+	// one program).
+	Name     string
+	Counters []CounterConfig `json:",omitempty"`
 }
 
 // A CounterConfig contains the configuration for a single counter.
+// Counters may optionally declare associated property event names.
 type CounterConfig struct {
-	Name string // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
-}
-
-// A PropertyConfig contains the configuration for an event that carries
-// high-cardinality data as custom dimensions (properties) rather than as
-// part of the counter name.
-type PropertyConfig struct {
-	Name string // The event name (e.g. "msgo/modulehash")
+	Name       string   // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
+	Properties []string `json:",omitempty"` // Associated property event names
 }
 
 func ReadConfig(file string) (*UploadConfig, error) {

--- a/telemetry/internal/config/config.go
+++ b/telemetry/internal/config/config.go
@@ -21,13 +21,21 @@ type ProgramConfig struct {
 	// the counter names may have to be
 	// repeated for each program. (e.g., if the counters are in a package
 	// that is used in more than one program.)
-	Name     string
-	Counters []CounterConfig `json:",omitempty"`
+	Name       string
+	Counters   []CounterConfig  `json:",omitempty"`
+	Properties []PropertyConfig `json:",omitempty"`
 }
 
 // A CounterConfig contains the configuration for a single counter.
 type CounterConfig struct {
 	Name string // The "collapsed" counter: <chart>:{<bucket1>,<bucket2>,...}
+}
+
+// A PropertyConfig contains the configuration for an event that carries
+// high-cardinality data as custom dimensions (properties) rather than as
+// part of the counter name.
+type PropertyConfig struct {
+	Name string // The event name (e.g. "msgo/modulehash")
 }
 
 func ReadConfig(file string) (*UploadConfig, error) {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -54,8 +54,9 @@ type Config struct {
 	Logger *slog.Logger
 }
 
-var countersToUpload map[string]struct{}
+var eventsToUpload map[string]struct{}
 var wildcardPrefixes []string
+var allowedProperties map[string]map[string]struct{}
 
 // Start initializes telemetry using the specified configuration.
 func Start(cfg Config) {
@@ -91,7 +92,8 @@ func Start(cfg Config) {
 	if progIdx == -1 {
 		return // Program not configured for telemetry
 	}
-	countersToUpload = make(map[string]struct{})
+	eventsToUpload = make(map[string]struct{})
+	allowedProperties = make(map[string]map[string]struct{})
 	wildcardPrefixes = nil
 	for _, c := range uploadConfig.Programs[progIdx].Counters {
 		if c.Name == "" {
@@ -103,13 +105,15 @@ func Start(cfg Config) {
 					wildcardPrefixes = append(wildcardPrefixes, prefix)
 				}
 			} else {
-				countersToUpload[e] = struct{}{}
+				eventsToUpload[e] = struct{}{}
+				if len(c.Properties) > 0 {
+					keys := make(map[string]struct{}, len(c.Properties))
+					for _, p := range c.Properties {
+						keys[p] = struct{}{}
+					}
+					allowedProperties[e] = keys
+				}
 			}
-		}
-	}
-	for _, p := range uploadConfig.Programs[progIdx].Properties {
-		if p.Name != "" {
-			countersToUpload[p.Name] = struct{}{}
 		}
 	}
 
@@ -122,8 +126,9 @@ func Start(cfg Config) {
 			"ai.application.ver": ver,
 			"ai.cloud.role":      prog,
 		},
-		UploadFilter: uploadFilter,
-		Logger:       cfg.Logger,
+		UploadFilter:   uploadFilter,
+		PropertyFilter: propertyFilter,
+		Logger:         cfg.Logger,
 	})
 }
 
@@ -137,7 +142,7 @@ func Close(ctx context.Context) {
 }
 
 func uploadFilter(name string) bool {
-	if _, ok := countersToUpload[name]; ok {
+	if _, ok := eventsToUpload[name]; ok {
 		return true
 	}
 	for _, prefix := range wildcardPrefixes {
@@ -146,4 +151,18 @@ func uploadFilter(name string) bool {
 		}
 	}
 	return false
+}
+
+func propertyFilter(name string, properties map[string]string) map[string]string {
+	keys, ok := allowedProperties[name]
+	if !ok {
+		return nil
+	}
+	filtered := make(map[string]string, len(keys))
+	for k, v := range properties {
+		if _, ok := keys[k]; ok {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -107,6 +107,11 @@ func Start(cfg Config) {
 			}
 		}
 	}
+	for _, p := range uploadConfig.Programs[progIdx].Properties {
+		if p.Name != "" {
+			countersToUpload[p.Name] = struct{}{}
+		}
+	}
 
 	telemetry.Init(&appinsights.Client{
 		InstrumentationKey: cfg.InstrumentationKey,

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -101,6 +101,107 @@ func TestUploadFilter(t *testing.T) {
 	telemetry.Close(t.Context())
 }
 
+func TestUploadFilterProperties(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	// Declare allowed property keys on the first counter.
+	uploadConfig.Programs[0].Counters[0].Properties = []string{
+		"msgo/module/hash",
+	}
+	startTelemetry(t, uploadConfig, 0)
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// The counter itself should still be allowed.
+		{"test_counter", true},
+		{"go:1", true},
+
+		// Property keys don't become event names.
+		{"msgo/module/hash", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := telemetry.UploadFilterForTest(tt.name)
+			if got != tt.want {
+				t.Errorf("UploadFilter(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+
+	telemetry.Close(t.Context())
+}
+
+func TestPropertyFilter(t *testing.T) {
+	uploadConfig := baseUploadConfig(t)
+	// "test_counter" allows property key "msgo/module/hash"
+	uploadConfig.Programs[0].Counters[0].Properties = []string{
+		"msgo/module/hash",
+	}
+	startTelemetry(t, uploadConfig, 0)
+
+	tests := []struct {
+		name       string
+		eventName  string
+		properties map[string]string
+		want       map[string]string
+	}{
+		{
+			name:       "declared property key kept",
+			eventName:  "test_counter",
+			properties: map[string]string{"msgo/module/hash": "abc123"},
+			want:       map[string]string{"msgo/module/hash": "abc123"},
+		},
+		{
+			name:       "undeclared property key stripped",
+			eventName:  "test_counter",
+			properties: map[string]string{"msgo/module/hash": "abc123", "secret": "oops"},
+			want:       map[string]string{"msgo/module/hash": "abc123"},
+		},
+		{
+			name:       "all keys undeclared returns empty",
+			eventName:  "test_counter",
+			properties: map[string]string{"secret": "oops"},
+			want:       map[string]string{},
+		},
+		{
+			name:       "counter without properties returns nil",
+			eventName:  "go:1",
+			properties: map[string]string{"a": "1"},
+			want:       nil,
+		},
+		{
+			name:       "unknown event returns nil",
+			eventName:  "unknown/event",
+			properties: map[string]string{"a": "1"},
+			want:       nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := telemetry.PropertyFilterForTest(tt.eventName, tt.properties)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("PropertyFilter(%q, ...) = %v, want nil", tt.eventName, got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("PropertyFilter(%q, ...) returned %d keys, want %d\ngot:  %v\nwant: %v",
+					tt.eventName, len(got), len(tt.want), got, tt.want)
+				return
+			}
+			for k, wantV := range tt.want {
+				if gotV, ok := got[k]; !ok || gotV != wantV {
+					t.Errorf("PropertyFilter(%q, ...)[%q] = %q, want %q", tt.eventName, k, gotV, wantV)
+				}
+			}
+		})
+	}
+
+	telemetry.Close(t.Context())
+}
+
 func TestTelemetryWrongGOOS(t *testing.T) {
 	uploadConfig := baseUploadConfig(t)
 	uploadConfig.GOOS = []string{"not-a-real-os"} // intentionally wrong


### PR DESCRIPTION
## Summary

Send the module hash as an Application Insights custom dimension (property value) rather than encoding it in the counter name (key). This avoids needing individual GDPR approval for every unique module hash.

## Changes

- Add `Properties` field to `CounterConfig` to declare allowed property keys (custom dimension names) per counter
- Add `PropertyFilter` to the appinsights client, which strips undeclared property keys before sending
- Add `counter.NewWithProperties` for creating events with custom dimensions
- Declare `msgo/modulehash` as an allowed property on the `go/invocations` counter in config.json

## Config

Property keys are declared on the counter they belong to:
```json
{
    "Name": "go/invocations",
    "Properties": ["msgo/modulehash"]
}
```

## Usage

Instead of:
```go
counter.Inc("msgo/modulehash:" + hash)
```

Use:
```go
counter.NewWithProperties("go/invocations", map[string]string{"msgo/modulehash": hash}).Inc()
```

The hash appears as a custom dimension in Application Insights, queryable via `customDimensions["msgo/modulehash"]` in KQL.