### PR TITLE
Add upstream commit details to submodule sync PR body

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -503,6 +503,9 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 				return nil
 			}
 
+			// Get the current submodule commit before updating, so we can build a compare link.
+			oldSubmoduleCommit, _ := getTrimmedCmdOutput("rev-parse", "HEAD:"+entry.SubmoduleTarget)
+
 			// This update uses a submodule, so find the target version of upstream and update the
 			// submodule to point at it. UpstreamLocalSyncTarget might be a commit hash, and if so,
 			// this rev-parse is simply checking that the commit actually exists.
@@ -591,6 +594,28 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 
 			prTitle = fmt.Sprintf("Update submodule to latest %#q in %#q", b.UpstreamName, b.Name)
 			commitMessage = fmt.Sprintf("Update submodule to latest %v (%v): %v", b.UpstreamName, newCommit[:8], snippet)
+
+			// Add a compare link and commit list so reviewers can see what changed upstream.
+			if oldSubmoduleCommit != "" && oldSubmoduleCommit != newCommit {
+				compareRepoURL := entry.UpstreamMirror
+				if compareRepoURL == "" {
+					compareRepoURL = entry.Upstream
+				}
+				if parsed, err := gitpr.ParseRemoteURL(compareRepoURL); err == nil {
+					// Get the list of commits in the range for an inline summary.
+					commitList, logErr := getTrimmedCmdOutput(
+						"log", "--oneline", "--no-decorate",
+						oldSubmoduleCommit+".."+newCommit,
+					)
+					var commitLog string
+					if logErr == nil {
+						commitLog = commitList
+					}
+					prBody += formatUpstreamCommitDetails(
+						parsed.GetOwnerSlashRepo(), oldSubmoduleCommit, newCommit, commitLog,
+					)
+				}
+			}
 		}
 
 		// Check if there are any files in the stage. If not, we don't need to process this branch
@@ -894,4 +919,37 @@ func createCommitMessageSnippet(message string) string {
 		message = message[:maxUpstreamCommitMessageInSnippet-len(snippetCutoffIndicator)+1] + snippetCutoffIndicator
 	}
 	return message
+}
+
+// formatUpstreamCommitDetails builds a collapsible Markdown section listing the upstream commits
+// included in a submodule update, with clickable links to the GitHub commit pages and a compare
+// link showing the full diff. commitLog is the output of "git log --oneline" for the commit range;
+// it may be empty if the log could not be retrieved.
+func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog string) string {
+	compareLink := fmt.Sprintf(
+		"https://github.com/%s/compare/%s...%s",
+		ownerSlashRepo, oldCommit, newCommit,
+	)
+
+	var b strings.Builder
+	b.WriteString("\n\n<details><summary>Upstream commits included in this update</summary>\n\n")
+
+	if commitLog != "" {
+		for _, line := range strings.Split(commitLog, "\n") {
+			if parts := strings.SplitN(line, " ", 2); len(parts) == 2 {
+				fmt.Fprintf(&b, "- [`%s`](https://github.com/%s/commit/%s) %s\n",
+					parts[0], ownerSlashRepo, parts[0], parts[1],
+				)
+			} else {
+				b.WriteString("- " + line + "\n")
+			}
+		}
+	} else {
+		b.WriteString("Could not retrieve commit list.\n")
+	}
+
+	fmt.Fprintf(&b, "\n[View full diff on GitHub](%s)", compareLink)
+	b.WriteString("\n\n</details>")
+
+	return b.String()
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -596,24 +596,23 @@ func MakeBranchPRs(f *Flags, dir string, entry *ConfigEntry) ([]SyncResult, erro
 			commitMessage = fmt.Sprintf("Update submodule to latest %v (%v): %v", b.UpstreamName, newCommit[:8], snippet)
 
 			// Add a compare link and commit list so reviewers can see what changed upstream.
+			// Only emit GitHub links when the resolved URL is actually on github.com.
 			if oldSubmoduleCommit != "" && oldSubmoduleCommit != newCommit {
 				compareRepoURL := entry.UpstreamMirror
 				if compareRepoURL == "" {
 					compareRepoURL = entry.Upstream
 				}
-				if parsed, err := gitpr.ParseRemoteURL(compareRepoURL); err == nil {
-					// Get the list of commits in the range for an inline summary.
-					commitList, logErr := getTrimmedCmdOutput(
-						"log", "--oneline", "--no-decorate",
-						oldSubmoduleCommit+".."+newCommit,
-					)
-					var commitLog string
-					if logErr == nil {
-						commitLog = commitList
+				if strings.Contains(compareRepoURL, "github.com") {
+					if parsed, err := gitpr.ParseRemoteURL(compareRepoURL); err == nil {
+						// Get the list of commits in the range for an inline summary.
+						commitList, logErr := getTrimmedCmdOutput(
+							"log", "--oneline", "--no-decorate",
+							oldSubmoduleCommit+".."+newCommit,
+						)
+						prBody += formatUpstreamCommitDetails(
+							parsed.GetOwnerSlashRepo(), oldSubmoduleCommit, newCommit, commitList, logErr != nil,
+						)
 					}
-					prBody += formatUpstreamCommitDetails(
-						parsed.GetOwnerSlashRepo(), oldSubmoduleCommit, newCommit, commitLog,
-					)
 				}
 			}
 		}
@@ -923,9 +922,10 @@ func createCommitMessageSnippet(message string) string {
 
 // formatUpstreamCommitDetails builds a collapsible Markdown section listing the upstream commits
 // included in a submodule update, with clickable links to the GitHub commit pages and a compare
-// link showing the full diff. commitLog is the output of "git log --oneline" for the commit range;
-// it may be empty if the log could not be retrieved.
-func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog string) string {
+// link showing the full diff. commitLog is the output of "git log --oneline" for the commit range.
+// logFailed indicates whether the git log command itself failed (as opposed to returning an empty
+// result for a valid but empty range).
+func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog string, logFailed bool) string {
 	compareLink := fmt.Sprintf(
 		"https://github.com/%s/compare/%s...%s",
 		ownerSlashRepo, oldCommit, newCommit,
@@ -934,7 +934,9 @@ func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog
 	var b strings.Builder
 	b.WriteString("\n\n<details><summary>Upstream commits included in this update</summary>\n\n")
 
-	if commitLog != "" {
+	if logFailed {
+		b.WriteString("Could not retrieve commit list.\n")
+	} else if commitLog != "" {
 		for _, line := range strings.Split(commitLog, "\n") {
 			if parts := strings.SplitN(line, " ", 2); len(parts) == 2 {
 				fmt.Fprintf(&b, "- [`%s`](https://github.com/%s/commit/%s) %s\n",
@@ -945,7 +947,7 @@ func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog
 			}
 		}
 	} else {
-		b.WriteString("Could not retrieve commit list.\n")
+		b.WriteString("No commits in range.\n")
 	}
 
 	fmt.Fprintf(&b, "\n[View full diff on GitHub](%s)", compareLink)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -309,6 +309,7 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 		oldCommit      string
 		newCommit      string
 		commitLog      string
+		logFailed      bool
 		wantContains   []string
 		wantNotContain []string
 	}{
@@ -338,17 +339,35 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 			},
 		},
 		{
-			name:           "empty commit log",
+			name:           "log failed",
 			ownerSlashRepo: "golang/go",
 			oldCommit:      "aaa0000",
 			newCommit:      "bbb1111",
 			commitLog:      "",
+			logFailed:      true,
 			wantContains: []string{
 				"Could not retrieve commit list.",
 				"https://github.com/golang/go/compare/aaa0000...bbb1111",
 			},
 			wantNotContain: []string{
 				"- [`",
+				"No commits in range.",
+			},
+		},
+		{
+			name:           "empty range",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "",
+			logFailed:      false,
+			wantContains: []string{
+				"No commits in range.",
+				"https://github.com/golang/go/compare/aaa0000...bbb1111",
+			},
+			wantNotContain: []string{
+				"- [`",
+				"Could not retrieve commit list.",
 			},
 		},
 		{
@@ -364,7 +383,7 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatUpstreamCommitDetails(tt.ownerSlashRepo, tt.oldCommit, tt.newCommit, tt.commitLog)
+			got := formatUpstreamCommitDetails(tt.ownerSlashRepo, tt.oldCommit, tt.newCommit, tt.commitLog, tt.logFailed)
 			for _, want := range tt.wantContains {
 				if !strings.Contains(got, want) {
 					t.Errorf("formatUpstreamCommitDetails() missing expected content %q\ngot:\n%s", want, got)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -301,3 +301,80 @@ func runGit(dir string, args ...string) error {
 	cmd.Dir = dir
 	return run(cmd)
 }
+
+func Test_formatUpstreamCommitDetails(t *testing.T) {
+	tests := []struct {
+		name           string
+		ownerSlashRepo string
+		oldCommit      string
+		newCommit      string
+		commitLog      string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "multiple commits",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "abc1234",
+			newCommit:      "def5678",
+			commitLog:      "def5678 runtime: reduce allocations\nabc1235 cmd/go: fix module loading",
+			wantContains: []string{
+				"<details><summary>Upstream commits included in this update</summary>",
+				"- [`def5678`](https://github.com/golang/go/commit/def5678) runtime: reduce allocations",
+				"- [`abc1235`](https://github.com/golang/go/commit/abc1235) cmd/go: fix module loading",
+				"[View full diff on GitHub](https://github.com/golang/go/compare/abc1234...def5678)",
+				"</details>",
+			},
+		},
+		{
+			name:           "single commit",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "bbb1111 net/http: fix redirect handling",
+			wantContains: []string{
+				"- [`bbb1111`](https://github.com/golang/go/commit/bbb1111) net/http: fix redirect handling",
+				"https://github.com/golang/go/compare/aaa0000...bbb1111",
+			},
+		},
+		{
+			name:           "empty commit log",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "",
+			wantContains: []string{
+				"Could not retrieve commit list.",
+				"https://github.com/golang/go/compare/aaa0000...bbb1111",
+			},
+			wantNotContain: []string{
+				"- [`",
+			},
+		},
+		{
+			name:           "commit line without space",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "bbb1111",
+			wantContains: []string{
+				"- bbb1111",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatUpstreamCommitDetails(tt.ownerSlashRepo, tt.oldCommit, tt.newCommit, tt.commitLog)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatUpstreamCommitDetails() missing expected content %q\ngot:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(got, notWant) {
+					t.Errorf("formatUpstreamCommitDetails() contains unexpected content %q\ngot:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR improves the PR body for submodule sync PRs by adding a collapsible details section that lists each upstream commit with clickable GitHub links, plus a compare link showing the full diff.

## Changes

- Before updating the submodule index, capture the old submodule commit hash
- After computing the new commit, build a `<details>` section listing each commit as a clickable link (e.g. `golang/go`)
- Prefer `UpstreamMirror` (GitHub) for link URLs, falling back to `Upstream`
- Include a "View full diff on GitHub" compare link at the bottom
- Extract `formatUpstreamCommitDetails` as a standalone function for testability
- Add unit tests covering multiple commits, single commit, empty log, and malformed lines