### PR TITLE
Handle untrusted data in sync PR description

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -966,7 +966,7 @@ func cutLogHash(logLine string) (hash, message string) {
 		return "", logLine
 	}
 	for _, h := range hash {
-		if !(('0' <= h && h <= '9') || ('a' <= h && h <= 'f')) {
+		if (h < '0' || h > '9') && (h < 'a' || h > 'f') {
 			// If the hash doesn't look like a real commit hash,
 			// treat it as a message.
 			return "", logLine

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -938,13 +938,12 @@ func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog
 		b.WriteString("Could not retrieve commit list.\n")
 	} else if commitLog != "" {
 		for _, line := range strings.Split(commitLog, "\n") {
-			if parts := strings.SplitN(line, " ", 2); len(parts) == 2 {
-				fmt.Fprintf(&b, "- [`%s`](https://github.com/%s/commit/%s) %s\n",
-					parts[0], ownerSlashRepo, parts[0], parts[1],
-				)
-			} else {
-				b.WriteString("- " + line + "\n")
+			fmt.Fprintf(&b, "- ")
+			hash, message := cutLogHash(line)
+			if hash != "" {
+				fmt.Fprintf(&b, "[`%s`](https://github.com/%s/commit/%s) ", hash, ownerSlashRepo, hash)
 			}
+			fmt.Fprintf(&b, "%s\n", formatCommitMessageForPRDescription(message))
 		}
 	} else {
 		b.WriteString("No commits in range.\n")
@@ -954,4 +953,46 @@ func formatUpstreamCommitDetails(ownerSlashRepo, oldCommit, newCommit, commitLog
 	b.WriteString("\n\n</details>")
 
 	return b.String()
+}
+
+// cutLogHash attempts to split a "git log --oneline" line into the commit hash
+// and the commit message. If the line doesn't look like a valid "git log
+// --oneline" line, it returns an empty hash and the full line as the message.
+func cutLogHash(logLine string) (hash, message string) {
+	hash, message, ok := strings.Cut(logLine, " ")
+	if !ok {
+		// If the log line doesn't contain a space, it doesn't look like a valid
+		// "git log --oneline" line.
+		return "", logLine
+	}
+	for _, h := range hash {
+		if !(('0' <= h && h <= '9') || ('a' <= h && h <= 'f')) {
+			// If the hash doesn't look like a real commit hash,
+			// treat it as a message.
+			return "", logLine
+		}
+	}
+	return hash, message
+}
+
+// formatCommitMessageForPRDescription formats a commit message for display in
+// the PR description without making the PR take any actions upon merge, without
+// linking issues, without pinging users, and others, by formatting the message
+// as an inline code span.
+func formatCommitMessageForPRDescription(message string) string {
+	codeSpanDelimiter := "`"
+	// Increase the size of the inline code span delimiter until the message
+	// doesn't contain it, so the wrapping can't be interrupted.
+	// (This is like a code fence, but inline.)
+	// It's rare to hit backticks in a message--not worth doing efficiently.
+	for strings.Contains(message, codeSpanDelimiter) {
+		codeSpanDelimiter += "`"
+	}
+	// Insert a space if the message begins or ends with backticks to avoid
+	// (according to parsers) unbalanced backticks that won't be understood
+	// correctly.
+	if strings.HasPrefix(message, "`") || strings.HasSuffix(message, "`") {
+		return codeSpanDelimiter + " " + message + " " + codeSpanDelimiter
+	}
+	return codeSpanDelimiter + message + codeSpanDelimiter
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/microsoft/go-infra/goldentest"
 )
 
 func Test_createCommitMessageSnippet(t *testing.T) {
@@ -321,8 +323,8 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 			commitLog:      "def5678 runtime: reduce allocations\nabc1235 cmd/go: fix module loading",
 			wantContains: []string{
 				"<details><summary>Upstream commits included in this update</summary>",
-				"- [`def5678`](https://github.com/golang/go/commit/def5678) runtime: reduce allocations",
-				"- [`abc1235`](https://github.com/golang/go/commit/abc1235) cmd/go: fix module loading",
+				"- [`def5678`](https://github.com/golang/go/commit/def5678) `runtime: reduce allocations`",
+				"- [`abc1235`](https://github.com/golang/go/commit/abc1235) `cmd/go: fix module loading`",
 				"[View full diff on GitHub](https://github.com/golang/go/compare/abc1234...def5678)",
 				"</details>",
 			},
@@ -334,7 +336,7 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 			newCommit:      "bbb1111",
 			commitLog:      "bbb1111 net/http: fix redirect handling",
 			wantContains: []string{
-				"- [`bbb1111`](https://github.com/golang/go/commit/bbb1111) net/http: fix redirect handling",
+				"- [`bbb1111`](https://github.com/golang/go/commit/bbb1111) `net/http: fix redirect handling`",
 				"https://github.com/golang/go/compare/aaa0000...bbb1111",
 			},
 		},
@@ -377,8 +379,57 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 			newCommit:      "bbb1111",
 			commitLog:      "bbb1111",
 			wantContains: []string{
-				"- bbb1111",
+				"- `bbb1111`",
 			},
+		},
+		{
+			name:           "fix keyword",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "61c83b6407 sinit.c: recursion in sinit fixes #1617",
+		},
+		{
+			name:           "auto-linked issue references",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog: "4d95fe6653 test: add regress test for #53619\n" +
+				"4d95fe6653 test: add regress test for golang/go#53619\n" +
+				"4d95fe6653 test: add regress test for https://github.com/golang/go/issues/53619",
+		},
+		{
+			name:           "markdown syntax in commit message",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog:      "4d95fe6653 doc: mention `go test` fixes #53619 and <details> for @ghost",
+		},
+		{
+			name:           "handful",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "abdc5da461185ab87c1240384e9a66339219f766",
+			newCommit:      "39b11f4b14ee3ecce33588a48f9190bc49363e75",
+			commitLog: `39b11f4b14 [dev.simd] simd: add ARM64 NEON shift intrinsics
+e4283592e5 fmt: give advice on wrapper functions
+098d688071 [dev.simd] simdgen: add argsMatchRule for broadcast-to-VMOVI folding
+1bcea1df64 cmd/{vet,fix}: use new constants from /x/tools/go/analysis/suite
+ae1c21739d [dev.simd] simd: add ARM64 NEON Broadcast and String helpers
+399bc412ae [dev.simd] simd: add ARM64 NEON support for partial slice operations
+60f0ced65b internal/testenv: make MustHaveSource detect missing source
+e0a8616941 math/rand/v2: add method Rand.N
+8621461b26 cmd: update vendored x/arch
+0db3804845 archive/zip: turn off large zip test on 32-bit archs
+abdc5da461 simd/archsimd/_gen: annotate text/template usage`,
+		},
+		{
+			name:           "backticks",
+			ownerSlashRepo: "golang/go",
+			oldCommit:      "aaa0000",
+			newCommit:      "bbb1111",
+			commitLog: "e5489a34ca crypto/x509: add missing `be` to comment about serial number positivity\n" +
+				"73652af80d cmd/compile: use `else if` for mutually exclusive `if` statements\n" +
+				"54af9a3ba5 runtime: reintroduce ``dead'' space during GC scan",
 		},
 	}
 	for _, tt := range tests {
@@ -394,6 +445,11 @@ func Test_formatUpstreamCommitDetails(t *testing.T) {
 					t.Errorf("formatUpstreamCommitDetails() contains unexpected content %q\ngot:\n%s", notWant, got)
 				}
 			}
+			// Don't include the <details> block and repeated \n for the golden
+			// output so it's easier to preview.
+			gotSimple := strings.ReplaceAll(got, "\n\n<details><summary>Upstream commits included in this update</summary>\n\n", "")
+			gotSimple = strings.ReplaceAll(gotSimple, "\n</details>", "")
+			goldentest.Check(t, "*.PRDescription.md", gotSimple)
 		})
 	}
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -429,7 +429,8 @@ abdc5da461 simd/archsimd/_gen: annotate text/template usage`,
 			newCommit:      "bbb1111",
 			commitLog: "e5489a34ca crypto/x509: add missing `be` to comment about serial number positivity\n" +
 				"73652af80d cmd/compile: use `else if` for mutually exclusive `if` statements\n" +
-				"54af9a3ba5 runtime: reintroduce ``dead'' space during GC scan",
+				"54af9a3ba5 runtime: reintroduce ``dead'' space during GC scan\n" +
+				"58a8fdb6cf cmd/go: inject State parameter into `bug.runBug`",
 		},
 	}
 	for _, tt := range tests {

--- a/sync/testdata/Test_formatUpstreamCommitDetails/auto-linked_issue_references.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/auto-linked_issue_references.PRDescription.md
@@ -1,0 +1,5 @@
+- [`4d95fe6653`](https://github.com/golang/go/commit/4d95fe6653) `test: add regress test for #53619`
+- [`4d95fe6653`](https://github.com/golang/go/commit/4d95fe6653) `test: add regress test for golang/go#53619`
+- [`4d95fe6653`](https://github.com/golang/go/commit/4d95fe6653) `test: add regress test for https://github.com/golang/go/issues/53619`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/backticks.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/backticks.PRDescription.md
@@ -1,0 +1,5 @@
+- [`e5489a34ca`](https://github.com/golang/go/commit/e5489a34ca) ``crypto/x509: add missing `be` to comment about serial number positivity``
+- [`73652af80d`](https://github.com/golang/go/commit/73652af80d) ``cmd/compile: use `else if` for mutually exclusive `if` statements``
+- [`54af9a3ba5`](https://github.com/golang/go/commit/54af9a3ba5) ```runtime: reintroduce ``dead'' space during GC scan```
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/backticks.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/backticks.PRDescription.md
@@ -1,5 +1,6 @@
 - [`e5489a34ca`](https://github.com/golang/go/commit/e5489a34ca) ``crypto/x509: add missing `be` to comment about serial number positivity``
 - [`73652af80d`](https://github.com/golang/go/commit/73652af80d) ``cmd/compile: use `else if` for mutually exclusive `if` statements``
 - [`54af9a3ba5`](https://github.com/golang/go/commit/54af9a3ba5) ```runtime: reintroduce ``dead'' space during GC scan```
+- [`58a8fdb6cf`](https://github.com/golang/go/commit/58a8fdb6cf) `` cmd/go: inject State parameter into `bug.runBug` ``
 
 [View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/commit_line_without_space.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/commit_line_without_space.PRDescription.md
@@ -1,0 +1,3 @@
+- `bbb1111`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/empty_range.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/empty_range.PRDescription.md
@@ -1,0 +1,3 @@
+No commits in range.
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/fix_keyword.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/fix_keyword.PRDescription.md
@@ -1,0 +1,3 @@
+- [`61c83b6407`](https://github.com/golang/go/commit/61c83b6407) `sinit.c: recursion in sinit fixes #1617`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/handful.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/handful.PRDescription.md
@@ -1,0 +1,13 @@
+- [`39b11f4b14`](https://github.com/golang/go/commit/39b11f4b14) `[dev.simd] simd: add ARM64 NEON shift intrinsics`
+- [`e4283592e5`](https://github.com/golang/go/commit/e4283592e5) `fmt: give advice on wrapper functions`
+- [`098d688071`](https://github.com/golang/go/commit/098d688071) `[dev.simd] simdgen: add argsMatchRule for broadcast-to-VMOVI folding`
+- [`1bcea1df64`](https://github.com/golang/go/commit/1bcea1df64) `cmd/{vet,fix}: use new constants from /x/tools/go/analysis/suite`
+- [`ae1c21739d`](https://github.com/golang/go/commit/ae1c21739d) `[dev.simd] simd: add ARM64 NEON Broadcast and String helpers`
+- [`399bc412ae`](https://github.com/golang/go/commit/399bc412ae) `[dev.simd] simd: add ARM64 NEON support for partial slice operations`
+- [`60f0ced65b`](https://github.com/golang/go/commit/60f0ced65b) `internal/testenv: make MustHaveSource detect missing source`
+- [`e0a8616941`](https://github.com/golang/go/commit/e0a8616941) `math/rand/v2: add method Rand.N`
+- [`8621461b26`](https://github.com/golang/go/commit/8621461b26) `cmd: update vendored x/arch`
+- [`0db3804845`](https://github.com/golang/go/commit/0db3804845) `archive/zip: turn off large zip test on 32-bit archs`
+- [`abdc5da461`](https://github.com/golang/go/commit/abdc5da461) `simd/archsimd/_gen: annotate text/template usage`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/abdc5da461185ab87c1240384e9a66339219f766...39b11f4b14ee3ecce33588a48f9190bc49363e75)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/log_failed.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/log_failed.PRDescription.md
@@ -1,0 +1,3 @@
+Could not retrieve commit list.
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/markdown_syntax_in_commit_message.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/markdown_syntax_in_commit_message.PRDescription.md
@@ -1,0 +1,3 @@
+- [`4d95fe6653`](https://github.com/golang/go/commit/4d95fe6653) ``doc: mention `go test` fixes #53619 and <details> for @ghost``
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/multiple_commits.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/multiple_commits.PRDescription.md
@@ -1,0 +1,4 @@
+- [`def5678`](https://github.com/golang/go/commit/def5678) `runtime: reduce allocations`
+- [`abc1235`](https://github.com/golang/go/commit/abc1235) `cmd/go: fix module loading`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/abc1234...def5678)

--- a/sync/testdata/Test_formatUpstreamCommitDetails/single_commit.PRDescription.md
+++ b/sync/testdata/Test_formatUpstreamCommitDetails/single_commit.PRDescription.md
@@ -1,0 +1,3 @@
+- [`bbb1111`](https://github.com/golang/go/commit/bbb1111) `net/http: fix redirect handling`
+
+[View full diff on GitHub](https://github.com/golang/go/compare/aaa0000...bbb1111)


### PR DESCRIPTION
Handle untrusted `git log` output more carefully when generating sync PR descriptions. Code formatting prevents a handful of things:

* Letting commits from upstream repos [close issues in our repos](https://docs.github.com/en/enterprise-cloud@latest/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via `fixes #123`, `fixes microsoft/go#123`, `fixes https://github.com/microsoft/go/issues/123`, etc.
  * This can happen unintentionally with commits like `61c83b6407 sinit.c: recursion in sinit fixes #1617`
* Noisy issue backlink generation by GitHub when our PRs include issue links.
  * These issue links would also sometimes be inaccurate because `#` refers to a different pool of issues.
* Recontextualized formatting that breaks the remaining PR description, e.g. backticks and HTML elements.
* Pinging individuals on GitHub with messages like `57d37b55b8 doc: rename @go_nuts to @golang`

---

* https://github.com/microsoft/go-infra/pull/497