### PR TITLE
Benchmark workflow improvements

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -85,7 +85,13 @@ jobs:
     steps:
       - name: Initialize status
         shell: bash
-        run: echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
+        # Seed the result files up front so the report step can always rely on
+        # their presence. benchcheck overwrites them when it runs; if the job
+        # dies earlier, empty files plus benchmark_error=true still upload.
+        run: |
+          echo '{"regression":false,"test_failures":false,"benchmark_error":true}' > status.json
+          : > failures.txt
+          : > regressions.txt
 
       - name: Container setup
         if: matrix.container-setup != ''

--- a/cmd/benchcheck/check.go
+++ b/cmd/benchcheck/check.go
@@ -32,11 +32,13 @@ type config struct {
 }
 
 type regression struct {
-	Name      string
-	Unit      string
-	PctChange float64
-	PValue    float64
-	BaseVal   float64
+	Name       string
+	Unit       string
+	PctChange  float64
+	PValue     float64
+	BaseVal    float64
+	BaseSpread string // base confidence-interval range, e.g. "±3%"
+	HeadSpread string // head confidence-interval range
 }
 
 func cmdCheck(args []string) {
@@ -115,9 +117,9 @@ Flags:
 	var regressionLines []string
 	for _, r := range regressions {
 		if isAllocUnit(r.Unit) {
-			regressionLines = append(regressionLines, fmt.Sprintf("alloc regression: %s [%s] +%.2f%% (p=%.3f)", r.Name, r.Unit, r.PctChange, r.PValue))
+			regressionLines = append(regressionLines, fmt.Sprintf("alloc regression: %s [%s] +%.2f%% (p=%.3f, base ±%s, head ±%s)", r.Name, r.Unit, r.PctChange, r.PValue, r.BaseSpread, r.HeadSpread))
 		} else {
-			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec)", r.Name, r.PctChange, r.PValue, r.BaseVal))
+			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec ±%s, head ±%s)", r.Name, r.PctChange, r.PValue, r.BaseVal, r.BaseSpread, r.HeadSpread))
 		}
 	}
 	writeErr := errors.Join(
@@ -267,41 +269,59 @@ func checkRegressions(base, head map[benchKey][]float64, cfg config) []regressio
 		baseSummary := benchmath.AssumeNothing.Summary(baseSample, 0.95)
 		headSummary := benchmath.AssumeNothing.Summary(headSample, 0.95)
 
-		if headSummary.Center <= baseSummary.Center {
-			continue // improvement or same
+		// Record each sample's confidence-interval range so the report can show
+		// how noisy the benchmark is.
+		baseSpread := baseSummary.PctRangeString()
+		headSpread := headSummary.PctRangeString()
+
+		// Compare the least-performant base (upper CI bound) against the
+		// best-performing head (lower CI bound), flagging a regression only when
+		// the confidence intervals don't overlap. For zero-variance samples this
+		// reduces to comparing Centers.
+		baseWorst := baseSummary.Hi
+		headBest := headSummary.Lo
+
+		if headBest <= baseWorst {
+			continue // improvement, no change, or within variance
 		}
 
-		if baseSummary.Center == 0 {
-			// Base is zero; only flag allocation units (sec/op can't be 0 meaningfully).
+		if baseWorst == 0 {
+			// Base upper bound is zero; only flag allocation units (sec/op can't be 0 meaningfully).
 			if isAllocUnit(key.Unit) {
 				regressions = append(regressions, regression{
-					Name:      key.Name,
-					Unit:      key.Unit,
-					PctChange: 100, // 0 → non-zero
-					PValue:    cmp.P,
+					Name:       key.Name,
+					Unit:       key.Unit,
+					PctChange:  100, // 0 → non-zero
+					PValue:     cmp.P,
+					BaseSpread: baseSpread,
+					HeadSpread: headSpread,
 				})
 			}
 			continue
 		}
 
-		pctChange := (headSummary.Center - baseSummary.Center) / baseSummary.Center * 100
+		pctChange := (headBest - baseWorst) / baseWorst * 100
 
 		switch {
 		case isAllocUnit(key.Unit):
 			regressions = append(regressions, regression{
-				Name:      key.Name,
-				Unit:      key.Unit,
-				PctChange: pctChange,
-				PValue:    cmp.P,
+				Name:       key.Name,
+				Unit:       key.Unit,
+				PctChange:  pctChange,
+				PValue:     cmp.P,
+				BaseSpread: baseSpread,
+				HeadSpread: headSpread,
 			})
 		case key.Unit == "sec/op":
 			if baseSummary.Center >= cfg.MinTime && pctChange >= cfg.TimeThreshold {
 				regressions = append(regressions, regression{
-					Name:      key.Name,
-					Unit:      key.Unit,
-					PctChange: pctChange,
-					PValue:    cmp.P,
-					BaseVal:   baseSummary.Center,
+					Name:       key.Name,
+					Unit:       key.Unit,
+					PctChange:  pctChange,
+					PValue:     cmp.P,
+					BaseVal:    baseSummary.Center,
+					BaseSpread: baseSpread,
+					HeadSpread: headSpread,
 				})
 			}
 		}

--- a/cmd/benchcheck/check.go
+++ b/cmd/benchcheck/check.go
@@ -37,8 +37,8 @@ type regression struct {
 	PctChange  float64
 	PValue     float64
 	BaseVal    float64
-	BaseSpread string // base confidence-interval range, e.g. "±3%"
-	HeadSpread string // head confidence-interval range
+	BaseSpread string // base confidence-interval range, e.g. "3%"
+	HeadSpread string // head confidence-interval range, e.g. "3%"
 }
 
 func cmdCheck(args []string) {
@@ -117,9 +117,9 @@ Flags:
 	var regressionLines []string
 	for _, r := range regressions {
 		if isAllocUnit(r.Unit) {
-			regressionLines = append(regressionLines, fmt.Sprintf("alloc regression: %s [%s] +%.2f%% (p=%.3f, base ±%s, head ±%s)", r.Name, r.Unit, r.PctChange, r.PValue, r.BaseSpread, r.HeadSpread))
+			regressionLines = append(regressionLines, fmt.Sprintf("alloc regression: %s [%s] +%.2f%% (p=%.3f, base %s, head %s)", r.Name, r.Unit, r.PctChange, r.PValue, r.BaseSpread, r.HeadSpread))
 		} else {
-			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec ±%s, head ±%s)", r.Name, r.PctChange, r.PValue, r.BaseVal, r.BaseSpread, r.HeadSpread))
+			regressionLines = append(regressionLines, fmt.Sprintf("time regression: %s +%.2f%% (p=%.3f, base=%.2g sec %s, head %s)", r.Name, r.PctChange, r.PValue, r.BaseVal, r.BaseSpread, r.HeadSpread))
 		}
 	}
 	writeErr := errors.Join(

--- a/cmd/benchcheck/main_test.go
+++ b/cmd/benchcheck/main_test.go
@@ -156,6 +156,58 @@ func TestCustomThresholds(t *testing.T) {
 	}
 }
 
+func TestVarianceRobust_OverlapNotFlagged(t *testing.T) {
+	// Base and head medians differ (~+10%), but the samples overlap heavily, so
+	// the confidence intervals overlap and no confident regression exists.
+	base := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {3e-6, 4e-6, 5e-6, 6e-6, 7e-6, 3.5e-6, 4.5e-6, 5.5e-6, 6.5e-6, 5e-6},
+	}
+	head := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {3.3e-6, 4.4e-6, 5.5e-6, 6.6e-6, 7.7e-6, 3.85e-6, 4.95e-6, 6.05e-6, 7.15e-6, 5.5e-6},
+	}
+	if r := checkRegressions(base, head, defaultCfg()); len(r) != 0 {
+		t.Errorf("expected no regression for overlapping samples, got %+v", r)
+	}
+}
+
+func TestVarianceRobust_SeparatedFlagged(t *testing.T) {
+	// Tight, clearly separated distributions: even the best-performing head is
+	// worse than the least-performant base, so the regression is still flagged.
+	base := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {5e-6, 5.01e-6, 4.99e-6, 5.005e-6, 4.995e-6, 5e-6, 5.01e-6, 4.99e-6, 5e-6, 5e-6},
+	}
+	head := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {9e-6, 9.01e-6, 8.99e-6, 9.005e-6, 8.995e-6, 9e-6, 9.01e-6, 8.99e-6, 9e-6, 9e-6},
+	}
+	found := false
+	for _, reg := range checkRegressions(base, head, defaultCfg()) {
+		if reg.Unit == "sec/op" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected sec/op regression for clearly separated samples, got none")
+	}
+}
+
+func TestRegressionCarriesSpread(t *testing.T) {
+	// A flagged regression records each sample's confidence-interval spread so
+	// the report can surface how noisy the benchmark is.
+	base := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {5e-6, 5.01e-6, 4.99e-6, 5.005e-6, 4.995e-6, 5e-6, 5.01e-6, 4.99e-6, 5e-6, 5e-6},
+	}
+	head := map[benchKey][]float64{
+		{Name: "Foo-8", Unit: "sec/op"}: {9e-6, 9.3e-6, 8.7e-6, 9.1e-6, 8.9e-6, 9e-6, 9.2e-6, 8.8e-6, 9e-6, 9e-6},
+	}
+	regs := checkRegressions(base, head, defaultCfg())
+	if len(regs) != 1 {
+		t.Fatalf("expected 1 regression, got %d: %+v", len(regs), regs)
+	}
+	if regs[0].BaseSpread == "" || regs[0].HeadSpread == "" {
+		t.Errorf("expected non-empty spreads, got base=%q head=%q", regs[0].BaseSpread, regs[0].HeadSpread)
+	}
+}
+
 func TestParseBenchmarks(t *testing.T) {
 	input := "BenchmarkSHA256-8\t1000\t1234 ns/op\t56 B/op\t3 allocs/op\n" +
 		"BenchmarkSHA256-8\t1000\t1245 ns/op\t56 B/op\t3 allocs/op\n" +

--- a/cmd/benchcheck/report.go
+++ b/cmd/benchcheck/report.go
@@ -35,7 +35,7 @@ func cmdReport(args []string) {
 	}
 
 	resultsDir := fs.Arg(0)
-	jobURLs := loadJobURLs(*jobURLsFile)
+	jobURLs, readErr := loadJobURLs(*jobURLsFile)
 
 	var buf strings.Builder
 
@@ -82,8 +82,9 @@ func cmdReport(args []string) {
 			jobURL = *runURL
 		}
 		status := readJobStatus(filepath.Join(dir, "status.json"))
-		failures := readFileContent(filepath.Join(dir, "failures.txt"))
-		regressions := readFileContent(filepath.Join(dir, "regressions.txt"))
+		failures, failErr := readFileContent(filepath.Join(dir, "failures.txt"))
+		regressions, regErr := readFileContent(filepath.Join(dir, "regressions.txt"))
+		readErr = errors.Join(readErr, failErr, regErr)
 
 		if status.Failed() {
 			buf.WriteString("<details>\n")
@@ -122,6 +123,13 @@ func cmdReport(args []string) {
 	}
 
 	fmt.Print(output)
+
+	// A missing result file is expected (a job may not produce one); a genuine
+	// read error is not, and must fail the report rather than be swallowed.
+	if readErr != nil {
+		fmt.Fprintf(os.Stderr, "benchcheck report: %v\n", readErr)
+		os.Exit(1)
+	}
 }
 
 func readJobStatus(path string) Status {
@@ -141,17 +149,17 @@ func readJobStatus(path string) Status {
 	return s
 }
 
-func loadJobURLs(path string) map[string]string {
+func loadJobURLs(path string) (map[string]string, error) {
 	urls := make(map[string]string)
 	if path == "" {
-		return urls
+		return urls, nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "reading %s: %v\n", path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return urls, nil
 		}
-		return urls
+		return urls, fmt.Errorf("reading %s: %w", path, err)
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 		parts := strings.SplitN(line, "\t", 2)
@@ -159,16 +167,16 @@ func loadJobURLs(path string) map[string]string {
 			urls[parts[0]] = parts[1]
 		}
 	}
-	return urls
+	return urls, nil
 }
 
-func readFileContent(path string) string {
+func readFileContent(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "reading %s: %v\n", path, err)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
 		}
-		return ""
+		return "", fmt.Errorf("reading %s: %w", path, err)
 	}
-	return strings.TrimSpace(string(data))
+	return strings.TrimSpace(string(data)), nil
 }

--- a/cmd/benchcheck/report.go
+++ b/cmd/benchcheck/report.go
@@ -35,7 +35,7 @@ func cmdReport(args []string) {
 	}
 
 	resultsDir := fs.Arg(0)
-	jobURLs, readErr := loadJobURLs(*jobURLsFile)
+	jobURLs, readErr := readJobURLsFileIfExists(*jobURLsFile)
 
 	var buf strings.Builder
 
@@ -82,8 +82,8 @@ func cmdReport(args []string) {
 			jobURL = *runURL
 		}
 		status := readJobStatus(filepath.Join(dir, "status.json"))
-		failures, failErr := readFileContent(filepath.Join(dir, "failures.txt"))
-		regressions, regErr := readFileContent(filepath.Join(dir, "regressions.txt"))
+		failures, failErr := readTrimmedContentIfExists(filepath.Join(dir, "failures.txt"))
+		regressions, regErr := readTrimmedContentIfExists(filepath.Join(dir, "regressions.txt"))
 		readErr = errors.Join(readErr, failErr, regErr)
 
 		if status.Failed() {
@@ -149,19 +149,19 @@ func readJobStatus(path string) Status {
 	return s
 }
 
-func loadJobURLs(path string) (map[string]string, error) {
+func readJobURLsFileIfExists(path string) (map[string]string, error) {
 	urls := make(map[string]string)
 	if path == "" {
 		return urls, nil
 	}
-	data, err := os.ReadFile(path)
+	content, err := readTrimmedContentIfExists(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return urls, nil
-		}
-		return urls, fmt.Errorf("reading %s: %w", path, err)
+		return urls, err
 	}
-	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+	if content == "" {
+		return urls, nil
+	}
+	for _, line := range strings.Split(content, "\n") {
 		parts := strings.SplitN(line, "\t", 2)
 		if len(parts) == 2 {
 			urls[parts[0]] = parts[1]
@@ -170,7 +170,10 @@ func loadJobURLs(path string) (map[string]string, error) {
 	return urls, nil
 }
 
-func readFileContent(path string) (string, error) {
+// readTrimmedContentIfExists reads path and returns its whitespace-trimmed
+// contents. A missing file is not an error: it returns an empty string and a
+// nil error. Any other read error is returned to the caller.
+func readTrimmedContentIfExists(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/cmd/benchcheck/report.go
+++ b/cmd/benchcheck/report.go
@@ -82,8 +82,8 @@ func cmdReport(args []string) {
 			jobURL = *runURL
 		}
 		status := readJobStatus(filepath.Join(dir, "status.json"))
-		failures, failErr := readTrimmedContentIfExists(filepath.Join(dir, "failures.txt"))
-		regressions, regErr := readTrimmedContentIfExists(filepath.Join(dir, "regressions.txt"))
+		failures, failErr := readTrimmedFile(filepath.Join(dir, "failures.txt"))
+		regressions, regErr := readTrimmedFile(filepath.Join(dir, "regressions.txt"))
 		readErr = errors.Join(readErr, failErr, regErr)
 
 		if status.Failed() {
@@ -124,8 +124,10 @@ func cmdReport(args []string) {
 
 	fmt.Print(output)
 
-	// A missing result file is expected (a job may not produce one); a genuine
-	// read error is not, and must fail the report rather than be swallowed.
+	// The benchmark job always writes failures.txt and regressions.txt (empty
+	// when there is nothing to report), so any read error—including a missing
+	// file—means the artifact is incomplete and must fail the report rather than
+	// be swallowed.
 	if readErr != nil {
 		fmt.Fprintf(os.Stderr, "benchcheck report: %v\n", readErr)
 		os.Exit(1)
@@ -172,13 +174,27 @@ func readJobURLsFileIfExists(path string) (map[string]string, error) {
 
 // readTrimmedContentIfExists reads path and returns its whitespace-trimmed
 // contents. A missing file is not an error: it returns an empty string and a
-// nil error. Any other read error is returned to the caller.
+// nil error. This suits optional inputs (such as the job-URLs file) whose
+// absence simply means "not provided". Any other read error is returned to the
+// caller.
 func readTrimmedContentIfExists(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", nil
 		}
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// readTrimmedFile reads path and returns its whitespace-trimmed contents. Unlike
+// readTrimmedContentIfExists, a missing file is an error: the benchmark job
+// always writes its result files (empty when there is nothing to report), so an
+// absent file means the artifact is incomplete.
+func readTrimmedFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
 		return "", fmt.Errorf("reading %s: %w", path, err)
 	}
 	return strings.TrimSpace(string(data)), nil

--- a/cmd/benchcheck/report_test.go
+++ b/cmd/benchcheck/report_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 )
 
-func TestReadFileContent(t *testing.T) {
+func TestReadTrimmedContentIfExists(t *testing.T) {
 	dir := t.TempDir()
 
 	// A missing file is expected and not an error.
-	if got, err := readFileContent(filepath.Join(dir, "absent.txt")); err != nil || got != "" {
+	if got, err := readTrimmedContentIfExists(filepath.Join(dir, "absent.txt")); err != nil || got != "" {
 		t.Errorf("absent file: got (%q, %v), want (\"\", nil)", got, err)
 	}
 
@@ -22,24 +22,24 @@ func TestReadFileContent(t *testing.T) {
 	if err := os.WriteFile(p, []byte("  hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := readFileContent(p); err != nil || got != "hello" {
+	if got, err := readTrimmedContentIfExists(p); err != nil || got != "hello" {
 		t.Errorf("existing file: got (%q, %v), want (\"hello\", nil)", got, err)
 	}
 
 	// A genuine read error (here, reading a directory) must be reported.
-	if _, err := readFileContent(dir); err == nil {
+	if _, err := readTrimmedContentIfExists(dir); err == nil {
 		t.Error("expected an error reading a directory, got nil")
 	}
 }
 
-func TestLoadJobURLs(t *testing.T) {
+func TestReadJobURLsFileIfExists(t *testing.T) {
 	dir := t.TempDir()
 
 	// Empty path and missing file both yield an empty map without error.
-	if m, err := loadJobURLs(""); err != nil || len(m) != 0 {
+	if m, err := readJobURLsFileIfExists(""); err != nil || len(m) != 0 {
 		t.Errorf("empty path: got (%v, %v)", m, err)
 	}
-	if m, err := loadJobURLs(filepath.Join(dir, "absent.tsv")); err != nil || len(m) != 0 {
+	if m, err := readJobURLsFileIfExists(filepath.Join(dir, "absent.tsv")); err != nil || len(m) != 0 {
 		t.Errorf("absent file: got (%v, %v)", m, err)
 	}
 
@@ -48,7 +48,7 @@ func TestLoadJobURLs(t *testing.T) {
 	if err := os.WriteFile(p, []byte("label-a\thttps://x/1\nlabel-b\thttps://x/2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	m, err := loadJobURLs(p)
+	m, err := readJobURLsFileIfExists(p)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestLoadJobURLs(t *testing.T) {
 	}
 
 	// A genuine read error (directory) must be reported.
-	if _, err := loadJobURLs(dir); err == nil {
+	if _, err := readJobURLsFileIfExists(dir); err == nil {
 		t.Error("expected an error reading a directory, got nil")
 	}
 }

--- a/cmd/benchcheck/report_test.go
+++ b/cmd/benchcheck/report_test.go
@@ -32,6 +32,33 @@ func TestReadTrimmedContentIfExists(t *testing.T) {
 	}
 }
 
+func TestReadTrimmedFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// A missing file is an error: result files are always expected to exist.
+	if _, err := readTrimmedFile(filepath.Join(dir, "absent.txt")); err == nil {
+		t.Error("expected an error for a missing file, got nil")
+	}
+
+	// An empty file yields an empty string without error.
+	empty := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readTrimmedFile(empty); err != nil || got != "" {
+		t.Errorf("empty file: got (%q, %v), want (\"\", nil)", got, err)
+	}
+
+	// An existing file is read and trimmed.
+	p := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(p, []byte("  hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readTrimmedFile(p); err != nil || got != "hello" {
+		t.Errorf("existing file: got (%q, %v), want (\"hello\", nil)", got, err)
+	}
+}
+
 func TestReadJobURLsFileIfExists(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/benchcheck/report_test.go
+++ b/cmd/benchcheck/report_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadFileContent(t *testing.T) {
+	dir := t.TempDir()
+
+	// A missing file is expected and not an error.
+	if got, err := readFileContent(filepath.Join(dir, "absent.txt")); err != nil || got != "" {
+		t.Errorf("absent file: got (%q, %v), want (\"\", nil)", got, err)
+	}
+
+	// An existing file is read and trimmed.
+	p := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(p, []byte("  hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readFileContent(p); err != nil || got != "hello" {
+		t.Errorf("existing file: got (%q, %v), want (\"hello\", nil)", got, err)
+	}
+
+	// A genuine read error (here, reading a directory) must be reported.
+	if _, err := readFileContent(dir); err == nil {
+		t.Error("expected an error reading a directory, got nil")
+	}
+}
+
+func TestLoadJobURLs(t *testing.T) {
+	dir := t.TempDir()
+
+	// Empty path and missing file both yield an empty map without error.
+	if m, err := loadJobURLs(""); err != nil || len(m) != 0 {
+		t.Errorf("empty path: got (%v, %v)", m, err)
+	}
+	if m, err := loadJobURLs(filepath.Join(dir, "absent.tsv")); err != nil || len(m) != 0 {
+		t.Errorf("absent file: got (%v, %v)", m, err)
+	}
+
+	// A well-formed TSV is parsed.
+	p := filepath.Join(dir, "urls.tsv")
+	if err := os.WriteFile(p, []byte("label-a\thttps://x/1\nlabel-b\thttps://x/2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := loadJobURLs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m["label-a"] != "https://x/1" || m["label-b"] != "https://x/2" {
+		t.Errorf("unexpected map: %v", m)
+	}
+
+	// A genuine read error (directory) must be reported.
+	if _, err := loadJobURLs(dir); err == nil {
+		t.Error("expected an error reading a directory, got nil")
+	}
+}


### PR DESCRIPTION
Compare the least-performant base against the best-performing head using the confidence-interval bounds instead of the medians, so a regression is only flagged when the intervals do not overlap. Surface each sample's confidence-interval spread in the report so reviewers can see how noisy a benchmark is.

Also fail 'benchcheck report' on genuine result-file read errors instead of silently returning empty content.

- https://github.com/microsoft/go-lab/issues/342