### PR TITLE
Add pipeline self-description and adjust readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ distribution.
 Visit the [docs](docs) directory for more information about the infrastructure
 implemented in this repository.
 
+For build and release pipeline entry points, see the [pipeline docs](eng/pipelines/README.md).
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/eng/pipelines/README.md
+++ b/eng/pipelines/README.md
@@ -8,3 +8,5 @@ This directory contains Azure DevOps (AzDO) YAML pipelines for CI and utilities.
 Each pipeline yml file contains links to its pipeline or pipelines.
 
 See [the release process design docs](/docs/release-process/design.md) for more information about the sequence of the `release-*` pipelines.
+
+For information about the style of these pipelines, see [the AzDO pipeline yml style guide](/docs/pipeline-yml-style.md).

--- a/eng/pipelines/fuzz-pipeline.yml
+++ b/eng/pipelines/fuzz-pipeline.yml
@@ -3,7 +3,7 @@
 
 # Run fuzz tests internally on a schedule.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1182
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1182
 
 trigger: none
 pr: none

--- a/eng/pipelines/pr-pipeline.yml
+++ b/eng/pipelines/pr-pipeline.yml
@@ -3,7 +3,7 @@
 
 # This pipeline validates PRs. It builds the repo and runs inner loop tests.
 
-# https://dev.azure.com/dnceng-public/public/_build?definitionId=197
+# public: https://dev.azure.com/dnceng-public/public/_build?definitionId=197
 
 trigger: none
 pr:

--- a/eng/pipelines/release-build-pipeline.yml
+++ b/eng/pipelines/release-build-pipeline.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1142
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1142
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:

--- a/eng/pipelines/release-go-images-pipeline.yml
+++ b/eng/pipelines/release-go-images-pipeline.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1151
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1151
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:

--- a/eng/pipelines/release-go-start-pipeline.yml
+++ b/eng/pipelines/release-go-start-pipeline.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1153
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1153
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:

--- a/eng/pipelines/release-innerloop-pipeline.yml
+++ b/eng/pipelines/release-innerloop-pipeline.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1348
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1348
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:

--- a/eng/pipelines/rolling-internal-validation-pipeline-unofficial.yml
+++ b/eng/pipelines/rolling-internal-validation-pipeline-unofficial.yml
@@ -2,8 +2,7 @@
 # Origin file: rolling-internal-validation.gen.yml
 
 # Copyright (c) Microsoft Corporation.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
+# Licensed under the MIT License.
 
 # This pipeline runs rolling validation.
 # For go-infra: CodeQL on active branch.
@@ -13,6 +12,15 @@
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1496
 
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL, for go-infra
+      and internal go-mirror branches.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535
+        \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline-unofficial.yml  \U0001F535
+      \U0001F535"
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications
       in dev branches.'

--- a/eng/pipelines/rolling-internal-validation-pipeline.yml
+++ b/eng/pipelines/rolling-internal-validation-pipeline.yml
@@ -2,8 +2,7 @@
 # Origin file: rolling-internal-validation.gen.yml
 
 # Copyright (c) Microsoft Corporation.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
+# Licensed under the MIT License.
 
 # This pipeline runs rolling validation.
 # For go-infra: CodeQL on active branch.
@@ -13,6 +12,13 @@
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1496
 
 parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline runs rolling validation, like CodeQL, for go-infra
+      and internal go-mirror branches.
+    type: string
+    values:
+      - "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  rolling-internal-validation-pipeline.yml  \U0001F535 \U0001F535"
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications
       in dev branches.'

--- a/eng/pipelines/rolling-internal-validation.gen.yml
+++ b/eng/pipelines/rolling-internal-validation.gen.yml
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
-# Use of this source code is governed by a BSD-style
-# license that can be found in the LICENSE file.
+# Licensed under the MIT License.
 
 # This pipeline runs rolling validation.
 # For go-infra: CodeQL on active branch.
@@ -20,6 +19,8 @@ pipelineymlgen:
 ---
 
 parameters:
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline runs rolling validation, like CodeQL, for go-infra and internal go-mirror branches.
   - name: enableCodeQL
     displayName: '[Debug input] Enable CodeQL, ignoring cadence. Use to try modifications in dev branches.'
     type: boolean

--- a/eng/pipelines/update-azure-linux-pipeline.yml
+++ b/eng/pipelines/update-azure-linux-pipeline.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# https://dev.azure.com/dnceng/internal/_build?definitionId=1405
+# internal: https://dev.azure.com/dnceng/internal/_build?definitionId=1405
 
 # For info about runtime parameters, see https://github.com/microsoft/go-infra/blob/main/docs/pipeline-yml-style.md#runtime-parameters
 parameters:

--- a/eng/pipelines/upstream-sync-pipeline-unofficial.yml
+++ b/eng/pipelines/upstream-sync-pipeline-unofficial.yml
@@ -7,7 +7,14 @@
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1061
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1495
 
-parameters: []
+parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline syncs upstream Go changes into the microsoft/go
+      repository by creating update PRs.
+    type: string
+    values:
+      - "\U0001F535  upstream-sync-pipeline-unofficial.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  upstream-sync-pipeline-unofficial.yml  \U0001F535 \U0001F535"
 trigger: none
 pr: none
 schedules: []

--- a/eng/pipelines/upstream-sync-pipeline.yml
+++ b/eng/pipelines/upstream-sync-pipeline.yml
@@ -7,7 +7,14 @@
 # official: https://dev.azure.com/dnceng/internal/_build?definitionId=1061
 # unofficial: https://dev.azure.com/dnceng/internal/_build?definitionId=1495
 
-parameters: []
+parameters:
+  - name: _info
+    displayName: ℹ️ This pipeline syncs upstream Go changes into the microsoft/go
+      repository by creating update PRs.
+    type: string
+    values:
+      - "\U0001F535  upstream-sync-pipeline.yml  \U0001F535 \U0001F535"
+    default: "\U0001F535  upstream-sync-pipeline.yml  \U0001F535 \U0001F535"
 trigger: none
 pr: none
 schedules:

--- a/eng/pipelines/upstream-sync.gen.yml
+++ b/eng/pipelines/upstream-sync.gen.yml
@@ -14,7 +14,9 @@ pipelineymlgen:
         official: true
 ---
 
-parameters: []
+parameters:
+  - ${ inlinetemplate "util/info.gen.yml" }:
+      desc: This pipeline syncs upstream Go changes into the microsoft/go repository by creating update PRs.
 
 trigger: none
 pr: none

--- a/eng/pipelines/util/info.gen.yml
+++ b/eng/pipelines/util/info.gen.yml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This pipelineymlgen template creates a placeholder parameter object that shows
+# important information to the user who hit the "Run" button so they can make a
+# more informed decision about whether they should use this pipeline.
+#
+# data inputs:
+# - desc - The description text to include.
+# - output - An output file of the template. Generally a pipeline .gen.yml file
+#   will automatically populate this data.
+#
+# The value is chosen to make it seem less out of place:
+#
+# The emoji fits in with the radio selection that shows up in the Run dialog to
+# obscure the oddity of a single-option choice. The yml filename is included
+# because it's technically potentially useful and fits in, even though it's
+# likely not important.
+
+name: _info
+displayName: ${ cat "ℹ️" .desc }
+type: string
+values:
+  - ${ cat "🔵 " .output " 🔵 🔵" }
+default: ${ cat "🔵 " .output " 🔵 🔵" }


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/434
  * Only add `_info` to pipelines already using templates. It doesn't seem worth adding a handful of extra gen.yml templates for this small thing. go-infra pipelines tend to be easier to pick out from the crowd already.
* Include small README adjustments: extra link for nav, point at style guide.
* While here, fix a few license headers that likely originally came from copying from a different repo.