### PR TITLE
git-go-patch: make submodule seed data sharable

### DIFF
--- a/cmd/git-go-patch/README.md
+++ b/cmd/git-go-patch/README.md
@@ -227,7 +227,7 @@ export GIT_GO_PATCH_SUBMODULE_REFERENCES="
 > [!TIP]
 > This makes it much faster and less storage-intensive to use many short-lived worktrees with repositories like the Microsoft build of Go's!
 >
-> See [the `--reference` documentation in the Git manual](https://git-scm.com/docs/git-submodule.html?utm_source=openai#Documentation/git-submodule.txt---referencerepository) for more information about how this works.
+> See [the `--reference` documentation in the Git manual](https://git-scm.com/docs/git-submodule.html#Documentation/git-submodule.txt---referencerepository) for more information about how this works.
 
 When a configured URL matches the submodule URL, `git-go-patch` passes the corresponding path to `git submodule update` using `--reference`.
 

--- a/cmd/git-go-patch/README.md
+++ b/cmd/git-go-patch/README.md
@@ -207,6 +207,30 @@ git go-patch apply
 # Proj and proj's submodule are now ready to examine.
 ```
 
+To speed up cloning a submodule, set `GIT_GO_PATCH_SUBMODULE_REFERENCES` to comma-separated pairs of submodule repository URLs and local reference repository paths.
+Whitespace around each value is ignored.
+For example, set this in your sh shell's environment to make future `git go-patch apply` setup faster:
+
+```sh
+export GIT_GO_PATCH_SUBMODULE_REFERENCES="
+  https://github.com/golang/go, $HOME/git/golang-go,
+  https://github.com/docker-library/golang, $HOME/git/docker-library-golang
+"
+```
+
+> [!WARNING]
+> Make sure any local directories mentioned in `GIT_GO_PATCH_SUBMODULE_REFERENCES` stick around.
+>
+> If you delete or move a reference directory, any submodules based on the reference will be missing Git objects, causing failures with common Git commands.
+> Fresh `git go-patch apply` runs with a misconfigured `GIT_GO_PATCH_SUBMODULE_REFERENCES` may attempt to fall back to the remote, but may still fail due to the missing target.
+
+> [!TIP]
+> This makes it much faster and less storage-intensive to use many short-lived worktrees with repositories like the Microsoft build of Go's!
+>
+> See [the `--reference` documentation in the Git manual](https://git-scm.com/docs/git-submodule.html?utm_source=openai#Documentation/git-submodule.txt---referencerepository) for more information about how this works.
+
+When a configured URL matches the submodule URL, `git-go-patch` passes the corresponding path to `git submodule update` using `--reference`.
+
 However, in build scripts, you may want to use traditional Git commands to avoid the dependency on the `git-go-patch` tool in production environments.
 We suggest:
 

--- a/cmd/git-go-patch/apply.go
+++ b/cmd/git-go-patch/apply.go
@@ -14,7 +14,6 @@ import (
 	"github.com/microsoft/go-infra/gitcmd"
 	"github.com/microsoft/go-infra/patch"
 	"github.com/microsoft/go-infra/subcmd"
-	"github.com/microsoft/go-infra/submodule"
 )
 
 // errSubmoduleDirty indicates that reapplying patches would discard unexpected changes in the
@@ -90,7 +89,7 @@ func applyPatches(config *patch.FoundConfig, force, noRefresh bool, branch strin
 	}
 
 	if !noRefresh {
-		if err := submodule.Reset(rootDir, goDir, force); err != nil {
+		if err := resetSubmodule(rootDir, goDir, force); err != nil {
 			return err
 		}
 	}

--- a/cmd/git-go-patch/review.go
+++ b/cmd/git-go-patch/review.go
@@ -20,7 +20,6 @@ import (
 	"github.com/microsoft/go-infra/githubutil"
 	"github.com/microsoft/go-infra/patch"
 	"github.com/microsoft/go-infra/subcmd"
-	"github.com/microsoft/go-infra/submodule"
 )
 
 func init() {
@@ -258,7 +257,7 @@ func handleReviewGH(p subcmd.ParseFunc) error {
 // resetSubmoduleTo resets the submodule (or fails if dirty) then checks out the
 // target commit.
 func resetSubmoduleTo(rootDir, goDir, commit string, force bool) error {
-	if err := submodule.Reset(rootDir, goDir, force); err != nil {
+	if err := resetSubmodule(rootDir, goDir, force); err != nil {
 		return fmt.Errorf("failed to reset submodule: %v", err)
 	}
 	if err := gitcmd.Run(goDir, "checkout", commit); err != nil {

--- a/cmd/git-go-patch/submodule-reference.go
+++ b/cmd/git-go-patch/submodule-reference.go
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/microsoft/go-infra/gitcmd"
+	"github.com/microsoft/go-infra/submodule"
+)
+
+const submoduleReferencesEnv = "GIT_GO_PATCH_SUBMODULE_REFERENCES"
+
+func resetSubmodule(rootDir, submoduleDir string, force bool) error {
+	reference, err := configuredSubmoduleReference(rootDir, submoduleDir)
+	if err != nil {
+		return err
+	}
+	return submodule.ResetWithReference(rootDir, submoduleDir, force, reference)
+}
+
+func configuredSubmoduleReference(rootDir, submoduleDir string) (string, error) {
+	references, err := parseSubmoduleReferences(os.Getenv(submoduleReferencesEnv))
+	if err != nil || len(references) == 0 {
+		return "", err
+	}
+
+	url, err := submoduleURL(rootDir, submoduleDir)
+	if err != nil {
+		return "", err
+	}
+	return references[url], nil
+}
+
+func parseSubmoduleReferences(value string) (map[string]string, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+
+	fields := strings.Split(value, ",")
+	if len(fields)%2 != 0 {
+		return nil, fmt.Errorf("%s must contain comma-separated repository URL and local path pairs", submoduleReferencesEnv)
+	}
+
+	references := make(map[string]string, len(fields)/2)
+	for i := 0; i < len(fields); i += 2 {
+		url := strings.TrimSpace(fields[i])
+		path := strings.TrimSpace(fields[i+1])
+		if url == "" || path == "" {
+			return nil, fmt.Errorf("%s contains an empty repository URL or local path", submoduleReferencesEnv)
+		}
+		references[url] = path
+	}
+	return references, nil
+}
+
+func submoduleURL(rootDir, submoduleDir string) (string, error) {
+	relativePath, err := filepath.Rel(rootDir, submoduleDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to find submodule path: %w", err)
+	}
+
+	pathEntries, err := gitcmd.CombinedOutput(
+		rootDir,
+		"config",
+		"--null",
+		"--file",
+		".gitmodules",
+		"--get-regexp",
+		`^submodule\..*\.path$`,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to read submodule paths from .gitmodules: %w", err)
+	}
+
+	// First, examine each submodule path entry to find a match for the submodule we're managing.
+	for _, entry := range strings.Split(pathEntries, "\x00") {
+		key, path, ok := strings.Cut(entry, "\n")
+		if !ok || filepath.Clean(filepath.FromSlash(path)) != filepath.Clean(relativePath) {
+			continue
+		}
+
+		// We found a match, now determine the URL of this match.
+		urlKey := strings.TrimSuffix(key, ".path") + ".url"
+		url, err := gitcmd.CombinedOutput(rootDir, "config", "--null", "--file", ".gitmodules", "--get", urlKey)
+		if err != nil {
+			return "", fmt.Errorf("failed to read URL for submodule %q: %w", relativePath, err)
+		}
+		return strings.TrimSuffix(url, "\x00"), nil
+	}
+
+	return "", fmt.Errorf("failed to find submodule %q in .gitmodules", relativePath)
+}

--- a/cmd/git-go-patch/submodule-reference.go
+++ b/cmd/git-go-patch/submodule-reference.go
@@ -20,6 +20,15 @@ func resetSubmodule(rootDir, submoduleDir string, force bool) error {
 	if err != nil {
 		return err
 	}
+	if reference != "" {
+		fi, err := os.Stat(reference)
+		if err != nil {
+			return fmt.Errorf("%s reference path %q does not exist: %w", submoduleReferencesEnv, reference, err)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("%s reference path %q is not a directory", submoduleReferencesEnv, reference)
+		}
+	}
 	return submodule.ResetWithReference(rootDir, submoduleDir, force, reference)
 }
 

--- a/cmd/git-go-patch/submodule-reference_test.go
+++ b/cmd/git-go-patch/submodule-reference_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSubmoduleReferences(t *testing.T) {
+	references, err := parseSubmoduleReferences(
+		" https://github.com/golang/go , /src/go,https://github.com/docker-library/golang,/src/golang ",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := references["https://github.com/golang/go"], "/src/go"; got != want {
+		t.Errorf("golang/go reference: got %q, want %q", got, want)
+	}
+	if got, want := references["https://github.com/docker-library/golang"], "/src/golang"; got != want {
+		t.Errorf("docker-library/golang reference: got %q, want %q", got, want)
+	}
+}
+
+func TestParseSubmoduleReferencesInvalid(t *testing.T) {
+	for _, value := range []string{
+		"https://github.com/golang/go",
+		"https://github.com/golang/go,",
+		",/src/go",
+	} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseSubmoduleReferences(value); err == nil {
+				t.Error("parseSubmoduleReferences unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestConfiguredSubmoduleReference(t *testing.T) {
+	rootDir := t.TempDir()
+	gitmodules := `[submodule "name-different-from-path"]
+	path = nested/go
+	url = https://github.com/golang/go
+`
+	if err := os.WriteFile(filepath.Join(rootDir, ".gitmodules"), []byte(gitmodules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(
+		submoduleReferencesEnv,
+		"https://github.com/other/repo,/src/other, https://github.com/golang/go, /src/go",
+	)
+
+	got, err := configuredSubmoduleReference(rootDir, filepath.Join(rootDir, "nested", "go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "/src/go"; got != want {
+		t.Errorf("configuredSubmoduleReference: got %q, want %q", got, want)
+	}
+}
+
+func TestConfiguredSubmoduleReferenceNoMatch(t *testing.T) {
+	rootDir := t.TempDir()
+	gitmodules := `[submodule "go"]
+	path = go
+	url = https://github.com/golang/go
+`
+	if err := os.WriteFile(filepath.Join(rootDir, ".gitmodules"), []byte(gitmodules), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(submoduleReferencesEnv, "https://github.com/other/repo,/src/other")
+
+	got, err := configuredSubmoduleReference(rootDir, filepath.Join(rootDir, "go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("configuredSubmoduleReference: got %q, want no reference", got)
+	}
+}

--- a/submodule/submodule.go
+++ b/submodule/submodule.go
@@ -35,12 +35,14 @@ func Init(rootDir, origin, fetchBearerToken string, shallow bool) error {
 // Reset updates the submodule (with '--init'). If "force", throw away changes in the submodule,
 // abort all in-progress Git operations like rebases, and clean all untracked files.
 func Reset(rootDir, submoduleDir string, force bool) error {
+	return ResetWithReference(rootDir, submoduleDir, force, "")
+}
+
+// ResetWithReference is like Reset, but uses reference as a local reference repository when cloning
+// an uninitialized submodule.
+func ResetWithReference(rootDir, submoduleDir string, force bool, reference string) error {
 	// Update the submodule commit, and initialize if it hasn't been done already.
-	submoduleUpdateCmd := dirCmd(rootDir, "git", "submodule", "update", "--init")
-	if force {
-		// If any conflicting changes are in the stage in the submodule, throw them away.
-		submoduleUpdateCmd.Args = append(submoduleUpdateCmd.Args, "-f")
-	}
+	submoduleUpdateCmd := resetUpdateCmd(rootDir, reference, force)
 	if err := executil.Run(submoduleUpdateCmd); err != nil {
 		return err
 	}
@@ -82,6 +84,18 @@ func Reset(rootDir, submoduleDir string, force bool) error {
 	// '.gitignore': these files shouldn't interfere with the build process and could be used for
 	// incremental builds.
 	return executil.Run(dirCmd(submoduleDir, "git", "clean", "-df"))
+}
+
+func resetUpdateCmd(rootDir, reference string, force bool) *exec.Cmd {
+	cmd := dirCmd(rootDir, "git", "submodule", "update", "--init")
+	if reference != "" {
+		cmd.Args = append(cmd.Args, "--reference", reference)
+	}
+	if force {
+		// If any conflicting changes are in the stage in the submodule, throw them away.
+		cmd.Args = append(cmd.Args, "-f")
+	}
+	return cmd
 }
 
 func getToplevel(dir string) (string, error) {

--- a/submodule/submodule_test.go
+++ b/submodule/submodule_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package submodule
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResetUpdateCmdReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+		force     bool
+		want      []string
+	}{
+		{
+			name: "default",
+			want: []string{"git", "submodule", "update", "--init"},
+		},
+		{
+			name:      "reference",
+			reference: "/reference/repo",
+			want:      []string{"git", "submodule", "update", "--init", "--reference", "/reference/repo"},
+		},
+		{
+			name:  "force",
+			force: true,
+			want:  []string{"git", "submodule", "update", "--init", "-f"},
+		},
+		{
+			name:      "reference and force",
+			reference: "/reference/repo",
+			force:     true,
+			want:      []string{"git", "submodule", "update", "--init", "--reference", "/reference/repo", "-f"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := resetUpdateCmd("/repo", test.reference, test.force)
+			if !reflect.DeepEqual(cmd.Args, test.want) {
+				t.Errorf("resetUpdateCmd args: got %q, want %q", cmd.Args, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Worktrees for `microsoft/go` aren't ideal: to initialize the submodule, you need to clone the whole `golang/go` repo for each worktree, which vastly outweighs the `microsoft/go` Git data. Add a feature to let you use a target repo as a reference, reducing the amount of data Git needs to download.

It needs some per-user setup. In theory, we could have `git-go-patch` set up a clone by default in `.local/go-infra/git-go-patch` or something, but I think starting with this makes sense.

(Copilot plus some cleanup.)