### PR TITLE
Allow PR classifier to update pull request labels

### DIFF
--- a/.github/workflows/classify-pull-request.yml
+++ b/.github/workflows/classify-pull-request.yml
@@ -13,7 +13,7 @@
 #   permissions:
 #     contents: read
 #     issues: write
-#     pull-requests: read
+#     pull-requests: write
 #
 #   jobs:
 #     classify:
@@ -21,7 +21,7 @@
 #       permissions:
 #         contents: read
 #         issues: write
-#         pull-requests: read
+#         pull-requests: write
 #       with:
 #         pr-number: ${{ github.event.pull_request.number || inputs.pr-number || 0 }}
 #         area-prefixes: |
@@ -51,7 +51,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   classify:


### PR DESCRIPTION
## Summary

- grant the reusable deterministic classifier `pull-requests: write`
- update the caller example to document the required permission

GitHub authorizes labeling a pull request through the `pull-requests` permission even though the REST route is `/issues/{number}/labels`. With only `issues: write` and `pull-requests: read`, production run https://github.com/microsoft/agent-framework-go/actions/runs/31719034436 failed with `403 Resource not accessible by integration`.

## Validation

- actionlint passes for `.github/workflows/classify-pull-request.yml`
- Agent Framework workflow-dispatch run https://github.com/microsoft/agent-framework-go/actions/runs/31733681923 successfully completed deterministic classification of PR #835 and applied `size:medium` and `area:agent`