### PR TITLE
Retry upon connection reset when polling AzDO build: known flakiness

### DIFF
--- a/cmd/releasego/wait-build.go
+++ b/cmd/releasego/wait-build.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
+	"syscall"
 	"time"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
@@ -50,14 +52,27 @@ func handleWaitBuild(p subcmd.ParseFunc) error {
 		return err
 	}
 
+	const maxSequentialFlakyErrors = 10
+	sequentialFlakyErrors := 0
+
 	for {
 		b, err := c.GetBuild(ctx, build.GetBuildArgs{
 			BuildId: id,
 			Project: azdoFlags.Proj,
 		})
 		if err != nil {
+			if isKnownAPIFlakiness(err) {
+				sequentialFlakyErrors++
+				if sequentialFlakyErrors > maxSequentialFlakyErrors {
+					return fmt.Errorf("too many sequential flaky errors: %w", err)
+				}
+				log.Printf("Encountered suspected AzDO API flakiness when querying build, next poll in %v: %v", pollDelay, err)
+				time.Sleep(pollDelay)
+				continue
+			}
 			return err
 		}
+		sequentialFlakyErrors = 0
 
 		url, _ := azdo.GetBuildWebURL(b)
 
@@ -79,4 +94,8 @@ func handleWaitBuild(p subcmd.ParseFunc) error {
 	}
 
 	return nil
+}
+
+func isKnownAPIFlakiness(err error) bool {
+	return errors.Is(err, syscall.ECONNRESET)
 }

--- a/cmd/releasego/wait-build_linux_test.go
+++ b/cmd/releasego/wait-build_linux_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/build"
+)
+
+// TestAzDOGetBuildConnectionReset exercises the error returned by the real AzDO
+// client when its HTTP connection is reset. The server sets SO_LINGER to zero
+// before closing the socket, which reliably makes Linux send a TCP RST and
+// makes Go return a *url.Error wrapping a *net.OpError and syscall.ECONNRESET.
+// Other platforms may surface this forced close differently, such as io.EOF, so
+// the _linux_test.go suffix keeps the test from being flaky on those platforms.
+func TestAzDOGetBuildConnectionReset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions && r.URL.Path == "/_apis" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"count":1,"value":[{"area":"build","id":"0cd358e1-9217-4d94-8269-1c1ee6f93dcf","maxVersion":"7.2","minVersion":"2.0","releasedVersion":"7.2","resourceName":"Builds","resourceVersion":2,"routeTemplate":"{project}/_apis/build/builds/{buildId}"}]}`)
+			return
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/internal/_apis/build/builds/2990681" {
+			http.NotFound(w, r)
+			return
+		}
+
+		connection, _, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			t.Errorf("hijacking connection: %v", err)
+			return
+		}
+		tcpConnection, ok := connection.(*net.TCPConn)
+		if !ok {
+			connection.Close()
+			t.Errorf("connection has type %T, want *net.TCPConn", connection)
+			return
+		}
+		if err := tcpConnection.SetLinger(0); err != nil {
+			t.Errorf("setting connection linger: %v", err)
+		}
+		if err := tcpConnection.Close(); err != nil {
+			t.Errorf("closing connection: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	connection := azuredevops.NewAnonymousConnection(server.URL)
+	client := &build.ClientImpl{Client: *azuredevops.NewClient(connection, server.URL)}
+	project := "internal"
+	buildID := 2990681
+	_, err := client.GetBuild(context.Background(), build.GetBuildArgs{
+		BuildId: &buildID,
+		Project: &project,
+	})
+	if err == nil {
+		t.Fatal("GetBuild() returned no error, want connection reset")
+	}
+	var urlError *url.Error
+	if !errors.As(err, &urlError) {
+		t.Fatalf("GetBuild error has type %T, want wrapped *url.Error: %v", err, err)
+	}
+	var operationError *net.OpError
+	if !errors.As(err, &operationError) {
+		t.Fatalf("GetBuild error does not wrap *net.OpError: %v", err)
+	}
+	if !isKnownAPIFlakiness(err) {
+		t.Fatalf("isKnownAPIFlakiness(GetBuild error) = false, error type %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
This pull request improves the reliability of the `wait-build` command by adding detection and handling for transient Azure DevOps (AzDO) API flakiness, specifically connection reset errors. It also introduces a Linux-specific test to ensure this behavior works as expected.

* Fixes https://github.com/microsoft/go-lab/issues/412
  * (Until proven otherwise.)