### PR TITLE
releaseagent: trim registry and storage plumbing

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -8,15 +8,9 @@ Subcommands:
 * `releaseagent serve` starts the local release UI.
 * `releaseagent write-mermaid-diagram` writes a Mermaid diagram of the broader release process.
 
-The landing page is a release dashboard. It lists work tracked by the current durable session and a
-validated registry of release processes. Go images provides local planning, execution, and
-monitoring. Go infrastructure provides reviewed, confirmed actions for the two GitHub-owned patch
-release paths documented by the team. The complete Microsoft Build of Go release process remains a
-future addition rather than being mixed into either focused workflow.
+The landing page is a release dashboard. It lists work tracked by the current durable session and a validated registry of release processes. Go images provides local planning, execution, and monitoring. Go infrastructure provides reviewed, confirmed actions for the two GitHub-owned patch release paths documented by the team. The complete Microsoft Build of Go release process remains a future addition rather than being mixed into either focused workflow.
 
-Each registry entry owns its dashboard metadata, documented release methods, inputs, dependency
-graph, and optional server callbacks. The server derives `/{ID}` and every process API route from
-that entry. A single `process.html` template and its generic JavaScript render every process.
+Each registry entry owns its dashboard metadata, documented release methods, inputs, and optional server callbacks. The server derives `/{ID}` and every process API route from that entry. A single `process.html` template and its generic JavaScript render every process. Runtime dependency graphs come only from `coordinator` steps after a plan is prepared.
 
 ## Adding a release process
 
@@ -35,8 +29,7 @@ Add one `ProcessDefinition` to `defaultProcessRegistry` in
 | `Methods` | Documented external release paths. Use these when GitHub or another authenticated UI owns execution. |
 | `Workflow` | Optional in-UI inputs, dependency steps, and execution behavior. |
 
-For an external process, fill `Methods` and stop. For a reviewed, durable external action, describe
-the form and graph with `ProcessInput` and `ProcessStep`, then set `DurableAction`:
+For an external process, fill `Methods` and stop. For a reviewed, durable external action, describe the form with `ProcessInput`, then set `DurableAction`:
 
 ```go
 ProcessDefinition{
@@ -45,30 +38,16 @@ ProcessDefinition{
     Workflow: &ProcessWorkflow{
         Heading: "Configure release", SubmitLabel: "Prepare release",
         Inputs: []ProcessInput{{ID: "version", Type: "text", Label: "Version", Required: true}},
-        Steps: []ProcessStep{
-          {Name: "Verify release"},
-          {Name: "Publish release", DependsOn: []string{"Verify release"}},
-        },
         DurableAction: true,
     },
 }
 ```
 
-      Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store
-      holds the server's single current durable external action, regardless of which executor owns it. The
-      executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`.
-      The server generates the HTTP lifecycle, confirmation digest, duplicate-start protection, atomic
-      checkpoints, restart behavior, coordinator step, state API, and event stream. Executors keep fixed
-      targets, credentials, input validation, and external calls behind their Go boundary.
+    Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store holds the server's single current durable external action. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart behavior, state APIs, and event streaming.
 
-      Before preparation, the shared lifecycle validates request keys, required and conditional fields,
-      choice values, numeric syntax, defaults, and string values against the registry input definitions.
-      Executors then apply process-specific semantic and fixed-target validation.
+    Before preparation, the shared lifecycle validates request keys, required and conditional fields, choice values, numeric syntax, defaults, and string values. Executors then apply process-specific semantic and fixed-target validation.
 
-      `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for workflows with a
-      custom lifecycle. `GetPlan` and `Prepare` are a pair. Do not combine these handlers with
-      `DurableAction`; go-images retains them because its multi-step Azure session predates the generic
-      single-action executor.
+    `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for custom lifecycles. Do not combine these handlers with `DurableAction`.
 
 With read-only Azure access enabled, **Track ongoing releases** discovers waiting and running pipeline `1023` builds and refreshes their status every 15 seconds.
 These live Azure entries are merged with the durable local session and link directly to their Azure run; tracking never queues or changes a run.
@@ -107,18 +86,11 @@ The go-infra page follows the canonical
 [microsoft/go-infra release instructions](https://github.com/microsoft/go-lab/tree/main/docs/release#microsoftgo-infra)
 and exposes both supported paths:
 
-* **Release on merge** accepts one pull request number. The server verifies that the PR is open,
-  targets `main`, and is not from a fork, then prepares a request to add `release-on-merge`. Starting
-  the action rechecks the exact PR head SHA before adding the fixed label. The UI never merges the
-  PR; the existing workflow creates the release only after the labeled PR is merged.
+* **Release on merge** accepts one pull request number. The server verifies that the PR is open, targets `main`, and is not from a fork, then prepares a request to add the `release-on-merge` label. Starting the action rechecks the exact PR head SHA. The UI never merges the PR; the existing workflow creates the release only after the labeled PR is merged.
 * **Manual patch release** dispatches only `create-go-infra-patch-release.yml` on `main`. Dry-run
-  mode fixes `dry-run` to `true` and only calculates the next version. Publish mode fixes it to
+  mode sets `dry-run` to `true` and only calculates the next version. Publish mode sets it to
   `false` and can create the next patch release. After GitHub accepts the dispatch, the server
-  discovers the new run for the authenticated user, journals its ID and URL, and polls it while it
-  is queued or running. Each UI dispatch includes a random internal correlation token reflected as
-  the exact Actions run title, so concurrent same-user dispatches cannot be mistaken for this run.
-  The UI completes the step only after the run reports a terminal conclusion. If a monitoring
-  interval reaches its timeout, polling automatically continues from the checkpointed run ID.
+  discovers the new run, journals its ID and URL, and polls it to a terminal conclusion. GitHub's workflow dispatch endpoint does not return a run ID, so the UI supplies a random token as the run title and matches that exact title. If a monitoring interval times out, polling continues from the checkpointed run ID. The dashboard reports the final result.
 
 Both paths require an authenticated `gh` CLI, a reviewed plan, and a separate confirmation click.
 The server hardcodes `microsoft/go-infra`, `main`,
@@ -186,16 +158,7 @@ Dashboard responses include both go-images sessions and durable process runs as 
 ongoing and recent release lists, so a future multi-session store can expand tracking without
 changing the browser API.
 
-Durable external actions use an adjacent, schema-versioned atomic process-run journal derived from
-`-session-file`. The shared executor persists the reviewed digest and checkpoints `started` before
-calling the target service. Once an external run is discovered, its process-specific resume state,
-ID, URL, and terminal summary are also journaled; startup validates the stored policy and resumes
-monitoring an incomplete known run. If the process exits before a run can be correlated, the next
-startup marks the action `uncertain` and refuses a replacement plan. Inspect the target service,
-stop the server, and remove the adjacent `.process-run.json` file only after deciding whether
-another action is safe. The UI never starts a replacement action automatically. Startup also fails
-closed when the former `.go-infra-action.json` journal exists so it cannot silently discard an
-uncertain action during migration.
+Durable external actions use an adjacent, schema-versioned atomic process-run journal derived from `-session-file`. The shared executor checkpoints `started` before calling the target service and resumes monitoring a known external run after restart. If a run cannot be correlated, the next startup marks the action `uncertain` and refuses a replacement. The local file protects one machine; it is not a shared handoff mechanism for an unexpected outage. A future `ProcessRunStore` implementation can use a work item or another shared store without changing process policy.
 
 If a process terminates without cleaning up its lease, verify no release UI process is using the
 session and remove the adjacent `.lock` file manually.
@@ -207,9 +170,7 @@ session and remove the adjacent `.lock` file manually.
 * State-changing requests require a matching Origin header.
 * Azure CLI tokens are acquired on demand, cached only in memory, and never sent to the browser,
   logged, or persisted.
-* Go-infra uses the locally authenticated `gh` CLI only when explicitly enabled. JSON mutation
-  bodies are sent through stdin, and the GitHub host, repository, ref, label, and workflow are
-  hardcoded server-side.
+* Go-infra uses the locally authenticated `gh` CLI. JSON mutation bodies are sent through stdin, and the GitHub host, repository, ref, label, and workflow are hardcoded server-side.
 * The generic Azure pipeline client is read-only.
 * The dedicated queue client can only POST definition `1023` on `refs/heads/microsoft/main` with a server-derived normal, rollback, or test parameter set.
 * The durable session stores non-secret input, state, structural and execution digests, and no credentials.

--- a/cmd/releaseagent/internal/atomicfile/json.go
+++ b/cmd/releaseagent/internal/atomicfile/json.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package atomicfile provides strict, private local JSON persistence.
+package atomicfile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ReadJSON decodes exactly one JSON value and rejects unknown fields.
+func ReadJSON(path string, maxSize int64, target any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() > maxSize {
+		return fmt.Errorf("file is %d bytes, maximum is %d", info.Size(), maxSize)
+	}
+	decoder := json.NewDecoder(io.LimitReader(file, maxSize))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("file must contain exactly one JSON value")
+	}
+	return nil
+}
+
+// WriteJSON atomically replaces path with one indented JSON value and private permissions.
+func WriteJSON(path, temporaryPattern string, maxSize int64, value any) error {
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(directory, temporaryPattern)
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	keepTemporary := false
+	defer func() {
+		if !keepTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	encoder := json.NewEncoder(temporary)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	info, err := temporary.Stat()
+	if err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if info.Size() > maxSize {
+		_ = temporary.Close()
+		return fmt.Errorf("encoded file is %d bytes, maximum is %d", info.Size(), maxSize)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	keepTemporary = true
+	if err := os.Chmod(path, 0o600); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/cmd/releaseagent/internal/goimagessession/store.go
+++ b/cmd/releaseagent/internal/goimagessession/store.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"time"
+
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/atomicfile"
 )
 
 const maxDocumentSize = 4 << 20
@@ -63,30 +63,11 @@ func (s *FileStore) Load(ctx context.Context) (*Document, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	file, err := os.Open(s.path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("open session file: %w", err)
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat session file: %w", err)
-	}
-	if info.Size() > maxDocumentSize {
-		return nil, fmt.Errorf("session file is %d bytes, maximum is %d", info.Size(), maxDocumentSize)
-	}
-
-	decoder := json.NewDecoder(io.LimitReader(file, maxDocumentSize))
-	decoder.DisallowUnknownFields()
 	var document Document
-	if err := decoder.Decode(&document); err != nil {
-		return nil, fmt.Errorf("decode session file: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, errors.New("session file must contain exactly one JSON value")
+	if err := atomicfile.ReadJSON(s.path, maxDocumentSize, &document); errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrNotFound
+	} else if err != nil {
+		return nil, fmt.Errorf("read session file: %w", err)
 	}
 	if err := document.Validate(); err != nil {
 		return nil, fmt.Errorf("validate session file: %w", err)
@@ -105,57 +86,8 @@ func (s *FileStore) Save(ctx context.Context, document *Document) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
-		return fmt.Errorf("create session directory: %w", err)
-	}
-
-	temporary, err := os.CreateTemp(filepath.Dir(s.path), ".release-session-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temporary session file: %w", err)
-	}
-	temporaryPath := temporary.Name()
-	keepTemporary := false
-	defer func() {
-		if !keepTemporary {
-			_ = os.Remove(temporaryPath)
-		}
-	}()
-
-	if err := temporary.Chmod(0o600); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("restrict temporary session permissions: %w", err)
-	}
-	encoder := json.NewEncoder(temporary)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(document); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("encode session file: %w", err)
-	}
-	info, err := temporary.Stat()
-	if err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("stat temporary session file: %w", err)
-	}
-	if info.Size() > maxDocumentSize {
-		_ = temporary.Close()
-		return fmt.Errorf("encoded session is %d bytes, maximum is %d", info.Size(), maxDocumentSize)
-	}
-	if err := temporary.Sync(); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("sync temporary session file: %w", err)
-	}
-	if err := temporary.Close(); err != nil {
-		return fmt.Errorf("close temporary session file: %w", err)
-	}
-	if err := os.Rename(temporaryPath, s.path); err != nil {
-		return fmt.Errorf("replace session file: %w", err)
-	}
-	keepTemporary = true
-	if err := os.Chmod(s.path, 0o600); err != nil {
-		return fmt.Errorf("restrict session file permissions: %w", err)
-	}
-	if err := syncDirectory(filepath.Dir(s.path)); err != nil {
-		return err
+	if err := atomicfile.WriteJSON(s.path, ".release-session-*.tmp", maxDocumentSize, document); err != nil {
+		return fmt.Errorf("write session file: %w", err)
 	}
 	return nil
 }
@@ -211,21 +143,4 @@ func (l *Lease) Release() error {
 		l.err = errors.Join(closeErr, removeErr)
 	})
 	return l.err
-}
-
-func syncDirectory(path string) error {
-	if runtime.GOOS == "windows" {
-		// Windows does not support syncing directory handles. The file itself was synced before
-		// replacement, which is the strongest portable guarantee available here.
-		return nil
-	}
-	directory, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open session directory for sync: %w", err)
-	}
-	defer directory.Close()
-	if err := directory.Sync(); err != nil {
-		return fmt.Errorf("sync session directory: %w", err)
-	}
-	return nil
 }

--- a/cmd/releaseagent/internal/releaseui/process_execution_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution_test.go
@@ -57,7 +57,6 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 		Workflow: &ProcessWorkflow{
 			Heading: "Run example", SubmitLabel: "Review", DurableAction: true,
 			Inputs: []ProcessInput{{ID: "mode", Type: "text", Label: "Mode", Required: true}},
-			Steps:  []ProcessStep{{Name: "Run example"}},
 		},
 	})
 	if err != nil {

--- a/cmd/releaseagent/internal/releaseui/process_registry.go
+++ b/cmd/releaseagent/internal/releaseui/process_registry.go
@@ -50,7 +50,6 @@ type ProcessWorkflow struct {
 	Description   string         `json:"description,omitempty"`
 	SubmitLabel   string         `json:"submitLabel,omitempty"`
 	Inputs        []ProcessInput `json:"inputs,omitempty"`
-	Steps         []ProcessStep  `json:"steps,omitempty"`
 	DurableAction bool           `json:"-"`
 	Preflight     ProcessHandler `json:"-"`
 	GetPlan       ProcessHandler `json:"-"`
@@ -89,12 +88,6 @@ type ProcessInputOption struct {
 type ProcessCondition struct {
 	InputID string `json:"inputId"`
 	Equals  string `json:"equals"`
-}
-
-// ProcessStep describes the initial dependency graph shown before a process-specific plan is prepared.
-type ProcessStep struct {
-	Name      string   `json:"name"`
-	DependsOn []string `json:"dependsOn,omitempty"`
 }
 
 type processRegistry struct {
@@ -184,12 +177,6 @@ func defaultProcessRegistry() (*processRegistry, error) {
 						VisibleWhen: &ProcessCondition{InputID: "mode", Equals: "rollback"},
 					},
 				},
-				Steps: []ProcessStep{
-					{Name: "Verify go-images commit is mirrored internally"},
-					{Name: "🚀 Queue go-images release", DependsOn: []string{"Verify go-images commit is mirrored internally"}},
-					{Name: "⌚ Wait for go-images release", DependsOn: []string{"🚀 Queue go-images release"}},
-					{Name: "✅ Go-images release complete", DependsOn: []string{"⌚ Wait for go-images release"}},
-				},
 				Preflight: (*Server).handlePreflight,
 				GetPlan:   (*Server).handleGetPlan,
 				Prepare:   (*Server).handlePlan,
@@ -237,7 +224,6 @@ func defaultProcessRegistry() (*processRegistry, error) {
 						},
 					},
 				},
-				Steps:         []ProcessStep{{Name: "Apply selected GitHub action"}},
 				DurableAction: true,
 			},
 		},
@@ -322,58 +308,6 @@ func validateProcessWorkflow(processID string, workflow *ProcessWorkflow) error 
 		}
 		if !matched {
 			return fmt.Errorf("release process %q input %q has an invalid condition value", processID, input.ID)
-		}
-	}
-	steps := make(map[string]ProcessStep, len(workflow.Steps))
-	for _, step := range workflow.Steps {
-		if strings.TrimSpace(step.Name) == "" {
-			return fmt.Errorf("release process %q has a step with an empty name", processID)
-		}
-		if _, exists := steps[step.Name]; exists {
-			return fmt.Errorf("release process %q repeats step %q", processID, step.Name)
-		}
-		steps[step.Name] = step
-	}
-	for _, step := range workflow.Steps {
-		for _, dependency := range step.DependsOn {
-			if dependency == step.Name {
-				return fmt.Errorf("release process %q step %q depends on itself", processID, step.Name)
-			}
-			if _, exists := steps[dependency]; !exists {
-				return fmt.Errorf("release process %q step %q has unknown dependency %q", processID, step.Name, dependency)
-			}
-		}
-	}
-	return validateProcessStepDependencies(processID, steps)
-}
-
-func validateProcessStepDependencies(processID string, steps map[string]ProcessStep) error {
-	const (
-		unvisited = iota
-		visiting
-		visited
-	)
-	states := make(map[string]int, len(steps))
-	var visit func(string) error
-	visit = func(id string) error {
-		switch states[id] {
-		case visiting:
-			return fmt.Errorf("release process %q has a workflow dependency cycle at step %q", processID, id)
-		case visited:
-			return nil
-		}
-		states[id] = visiting
-		for _, dependency := range steps[id].DependsOn {
-			if err := visit(dependency); err != nil {
-				return err
-			}
-		}
-		states[id] = visited
-		return nil
-	}
-	for id := range steps {
-		if err := visit(id); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/cmd/releaseagent/internal/releaseui/process_run_store.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store.go
@@ -9,14 +9,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/atomicfile"
 )
 
 const (
@@ -104,29 +103,11 @@ func (s *ProcessRunFileStore) Load(ctx context.Context) (*ProcessRun, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	file, err := os.Open(s.path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil, ErrProcessRunNotFound
-	}
-	if err != nil {
-		return nil, fmt.Errorf("open process run: %w", err)
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat process run: %w", err)
-	}
-	if info.Size() > maxProcessRunSize {
-		return nil, fmt.Errorf("process run file is %d bytes, maximum is %d", info.Size(), maxProcessRunSize)
-	}
-	decoder := json.NewDecoder(io.LimitReader(file, maxProcessRunSize))
-	decoder.DisallowUnknownFields()
 	var document processRunDocument
-	if err := decoder.Decode(&document); err != nil {
-		return nil, fmt.Errorf("decode process run: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, errors.New("process run file must contain exactly one JSON value")
+	if err := atomicfile.ReadJSON(s.path, maxProcessRunSize, &document); errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrProcessRunNotFound
+	} else if err != nil {
+		return nil, fmt.Errorf("read process run: %w", err)
 	}
 	if document.SchemaVersion != processRunSchemaVersion {
 		return nil, fmt.Errorf("unsupported process run schema %d", document.SchemaVersion)
@@ -156,54 +137,10 @@ func (s *ProcessRunFileStore) Save(ctx context.Context, run *ProcessRun) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
-		return fmt.Errorf("create process run directory: %w", err)
+	if err := atomicfile.WriteJSON(s.path, ".process-run-*.tmp", maxProcessRunSize, document); err != nil {
+		return fmt.Errorf("write process run: %w", err)
 	}
-	temporary, err := os.CreateTemp(filepath.Dir(s.path), ".process-run-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temporary process run: %w", err)
-	}
-	temporaryPath := temporary.Name()
-	keepTemporary := false
-	defer func() {
-		if !keepTemporary {
-			_ = os.Remove(temporaryPath)
-		}
-	}()
-	if err := temporary.Chmod(0o600); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("restrict temporary process run: %w", err)
-	}
-	encoder := json.NewEncoder(temporary)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(document); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("encode process run: %w", err)
-	}
-	info, err := temporary.Stat()
-	if err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("stat temporary process run: %w", err)
-	}
-	if info.Size() > maxProcessRunSize {
-		_ = temporary.Close()
-		return fmt.Errorf("encoded process run is %d bytes, maximum is %d", info.Size(), maxProcessRunSize)
-	}
-	if err := temporary.Sync(); err != nil {
-		_ = temporary.Close()
-		return fmt.Errorf("sync temporary process run: %w", err)
-	}
-	if err := temporary.Close(); err != nil {
-		return fmt.Errorf("close temporary process run: %w", err)
-	}
-	if err := os.Rename(temporaryPath, s.path); err != nil {
-		return fmt.Errorf("replace process run: %w", err)
-	}
-	keepTemporary = true
-	if err := os.Chmod(s.path, 0o600); err != nil {
-		return fmt.Errorf("restrict process run: %w", err)
-	}
-	return syncProcessRunDirectory(filepath.Dir(s.path))
+	return nil
 }
 
 func newProcessRun(processID string, prepared ProcessPreparedRun) (*ProcessRun, error) {
@@ -338,19 +275,4 @@ func cloneProcessRun(run *ProcessRun) *ProcessRun {
 		clone.External = &external
 	}
 	return &clone
-}
-
-func syncProcessRunDirectory(path string) error {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
-	directory, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open process run directory for sync: %w", err)
-	}
-	defer directory.Close()
-	if err := directory.Sync(); err != nil {
-		return fmt.Errorf("sync process run directory: %w", err)
-	}
-	return nil
 }

--- a/cmd/releaseagent/internal/releaseui/processes_test.go
+++ b/cmd/releaseagent/internal/releaseui/processes_test.go
@@ -69,7 +69,7 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 	}
 }
 
-func TestProcessRegistryValidatesWorkflowDependencies(t *testing.T) {
+func TestProcessRegistryValidatesWorkflowInputs(t *testing.T) {
 	prepare := func(*Server, http.ResponseWriter, *http.Request) {}
 	definition := ProcessDefinition{
 		ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available", Available: true,
@@ -79,24 +79,11 @@ func TestProcessRegistryValidatesWorkflowDependencies(t *testing.T) {
 				ID: "mode", Type: "choice", Label: "Mode", Default: "normal",
 				Options: []ProcessInputOption{{Value: "normal", Name: "Normal", Description: "Run normally"}},
 			}},
-			Steps: []ProcessStep{{Name: "Prepare"}, {Name: "Run", DependsOn: []string{"Prepare"}}},
 		},
 	}
 	if _, err := newProcessRegistry(definition); err != nil {
 		t.Fatal(err)
 	}
-	definition.Workflow.Steps[1].DependsOn = []string{"Missing"}
-	if _, err := newProcessRegistry(definition); err == nil {
-		t.Fatal("unknown workflow dependency was accepted")
-	}
-	definition.Workflow.Steps = []ProcessStep{
-		{Name: "Prepare", DependsOn: []string{"Run"}},
-		{Name: "Run", DependsOn: []string{"Prepare"}},
-	}
-	if _, err := newProcessRegistry(definition); err == nil {
-		t.Fatal("workflow dependency cycle was accepted")
-	}
-	definition.Workflow.Steps = nil
 	definition.Workflow.Inputs = []ProcessInput{{ID: "count", Type: "number", Label: "Count", Default: "many"}}
 	if _, err := newProcessRegistry(definition); err == nil {
 		t.Fatal("invalid numeric default was accepted")
@@ -115,7 +102,6 @@ func TestProcessRegistryValidatesDurableAction(t *testing.T) {
 		Workflow: &ProcessWorkflow{
 			Heading: "Configure", SubmitLabel: "Review", DurableAction: true,
 			Inputs: []ProcessInput{{ID: "mode", Type: "text", Label: "Mode", Required: true}},
-			Steps:  []ProcessStep{{Name: "Run"}},
 		},
 	}
 	if _, err := newProcessRegistry(definition); err != nil {

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -536,7 +536,6 @@ type workflowDetail struct {
 	Description  string         `json:"description,omitempty"`
 	SubmitLabel  string         `json:"submitLabel,omitempty"`
 	Inputs       []ProcessInput `json:"inputs,omitempty"`
-	Steps        []ProcessStep  `json:"steps,omitempty"`
 	HasPreflight bool           `json:"hasPreflight"`
 	CanPrepare   bool           `json:"canPrepare"`
 	CanSimulate  bool           `json:"canSimulate"`
@@ -559,7 +558,6 @@ func (s *Server) handleProcess(response http.ResponseWriter, request *http.Reque
 			Heading: definition.Workflow.Heading, Description: definition.Workflow.Description,
 			SubmitLabel:  definition.Workflow.SubmitLabel,
 			Inputs:       append([]ProcessInput(nil), definition.Workflow.Inputs...),
-			Steps:        append([]ProcessStep(nil), definition.Workflow.Steps...),
 			HasPreflight: definition.Workflow.Preflight != nil || definition.Workflow.DurableAction,
 			CanPrepare:   definition.Workflow.Prepare != nil || definition.Workflow.DurableAction,
 			CanSimulate:  definition.Workflow.Simulate != nil,

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -147,7 +147,7 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	var goImages processDetail
 	decodeResponse(t, response, &goImages)
 	if response.StatusCode != http.StatusOK || goImages.Workflow == nil || !goImages.Workflow.CanPrepare ||
-		!goImages.Workflow.CanStart || len(goImages.Workflow.Inputs) != 2 || len(goImages.Workflow.Steps) != 4 {
+		!goImages.Workflow.CanStart || len(goImages.Workflow.Inputs) != 2 {
 
 		t.Fatalf("go-images process = %#v", goImages)
 	}
@@ -159,7 +159,7 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	decodeResponse(t, response, &process)
 	if response.StatusCode != http.StatusOK || process.ID != "go-infra" || len(process.Methods) != 0 ||
 		process.Workflow == nil || !process.Workflow.HasPreflight || !process.Workflow.CanPrepare ||
-		!process.Workflow.CanStart || len(process.Workflow.Inputs) != 3 || len(process.Workflow.Steps) != 1 {
+		!process.Workflow.CanStart || len(process.Workflow.Inputs) != 3 {
 
 		t.Fatalf("process = %#v", process)
 	}


### PR DESCRIPTION
## Summary

Remove nonessential registry and persistence plumbing after establishing clear release-domain boundaries.

## Changes

- Remove display-only workflow step metadata from the process registry.
- Remove the registry’s duplicate graph traversal and cycle validation.
- Keep runtime DAG ownership exclusively in `coordinator`.
- Deduplicate strict atomic JSON persistence into `internal/atomicfile`.
- Simplify the release UI documentation and address the wording and formatting feedback from PR #553.
- Document that local files provide restart safety but are not a shared handoff mechanism.

This branch removes 285 net lines while preserving confirmation, fixed targets, checkpoints, restart safety, and terminal monitoring.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- `git diff --check`

No workflows, releases, labels, or Azure pipelines were triggered.

## Stack

Base: `dev/mclayton/release-ui-fullrelease-boundary`