### PR TITLE
releaseagent: remove inferred ongoing release tracking

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -49,9 +49,6 @@ ProcessDefinition{
 
     `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for custom lifecycles. Do not combine these handlers with `DurableAction`.
 
-With read-only Azure access enabled, **Track ongoing releases** discovers waiting and running pipeline `1023` builds and refreshes their status every 15 seconds.
-These live Azure entries are merged with the durable local session and link directly to their Azure run; tracking never queues or changes a run.
-
 ## Go-images release modes
 
 See the canonical [Golang toolset images release instructions](https://github.com/microsoft/go-lab/tree/main/docs/release#golang-toolset-images).

--- a/cmd/releaseagent/internal/releaseui/disabled_services.go
+++ b/cmd/releaseagent/internal/releaseui/disabled_services.go
@@ -31,25 +31,25 @@ func (disabledGoImagesService) PollPipeline(context.Context, string) error {
 
 var _ goimagesworkflow.Service = disabledGoImagesService{}
 
-type importedRunMonitor struct {
+type restoredRunMonitor struct {
 	buildID int
 	monitor func(context.Context, int) error
 }
 
-func (importedRunMonitor) PollMirror(context.Context, string, string) error {
-	return errors.New("an imported-run monitor cannot verify a source mirror")
+func (restoredRunMonitor) PollMirror(context.Context, string, string) error {
+	return errors.New("a restored-run monitor cannot verify a source mirror")
 }
 
-func (importedRunMonitor) QueuePipeline(context.Context, int, map[string]string) (string, error) {
-	return "", errors.New("an imported-run monitor cannot queue a pipeline")
+func (restoredRunMonitor) QueuePipeline(context.Context, int, map[string]string) (string, error) {
+	return "", errors.New("a restored-run monitor cannot queue a pipeline")
 }
 
-func (monitor importedRunMonitor) PollPipeline(ctx context.Context, buildID string) error {
+func (monitor restoredRunMonitor) PollPipeline(ctx context.Context, buildID string) error {
 	id, err := strconv.Atoi(buildID)
 	if err != nil || id != monitor.buildID {
-		return fmt.Errorf("monitor build ID %q does not match imported build %d", buildID, monitor.buildID)
+		return fmt.Errorf("monitor build ID %q does not match restored build %d", buildID, monitor.buildID)
 	}
 	return monitor.monitor(ctx, id)
 }
 
-var _ goimagesworkflow.Service = importedRunMonitor{}
+var _ goimagesworkflow.Service = restoredRunMonitor{}

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -97,15 +97,6 @@ type GoImagesRollbackSource struct {
 	Versions      []string `json:"versions"`
 }
 
-// GoImagesOngoingRun is a read-only view of one currently waiting or running pipeline 1023 build.
-type GoImagesOngoingRun struct {
-	BuildID int
-	Mode    goimagesworkflow.Mode
-	Status  string
-	URL     string
-	Queued  time.Time
-}
-
 // GoImagesReadOnlyIntegration is the explicitly enabled Azure read boundary. It resolves current
 // main and validates rollback builds but cannot queue, cancel, approve, or otherwise mutate a run.
 type GoImagesReadOnlyIntegration struct {
@@ -113,7 +104,6 @@ type GoImagesReadOnlyIntegration struct {
 	Preflight            func(context.Context) (string, error)
 	ResolveCurrentSource func(context.Context) (GoImagesSource, error)
 	ValidateRollback     func(context.Context, int) (GoImagesRollbackSource, error)
-	ListOngoing          func(context.Context) ([]GoImagesOngoingRun, error)
 }
 
 // GoImagesExecutionIntegration is the only real execution boundary. Its implementation must
@@ -213,7 +203,7 @@ func New(ctx context.Context, options ...Option) (*Server, error) {
 			return nil, fmt.Errorf("go-images definition %d is not allowlisted", server.readOnly.DefinitionID)
 		}
 		if server.readOnly.Preflight == nil || server.readOnly.ResolveCurrentSource == nil ||
-			server.readOnly.ValidateRollback == nil || server.readOnly.ListOngoing == nil {
+			server.readOnly.ValidateRollback == nil {
 
 			return nil, errors.New("go-images read-only integration is incomplete")
 		}
@@ -325,7 +315,6 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("GET /assets/", http.StripPrefix("/assets/", http.FileServer(http.FS(assets))))
 	mux.HandleFunc("GET /api/dashboard", s.handleDashboard)
 	mux.HandleFunc("GET /api/processes/{id}", s.handleProcess)
-	mux.HandleFunc("GET /api/releases/ongoing", s.handleOngoingReleases)
 	return s.withSecurityHeaders(s.authenticate(mux))
 }
 
@@ -592,44 +581,6 @@ func (s *Server) handleDashboard(response http.ResponseWriter, _ *http.Request) 
 	}
 	s.mu.Unlock()
 	writeJSON(response, http.StatusOK, result)
-}
-
-func (s *Server) handleOngoingReleases(response http.ResponseWriter, request *http.Request) {
-	s.mu.Lock()
-	if s.readOnly == nil {
-		s.mu.Unlock()
-		writeError(response, http.StatusForbidden, "live release tracking is not enabled")
-		return
-	}
-	preflight := s.readOnly.Preflight
-	listOngoing := s.readOnly.ListOngoing
-	s.mu.Unlock()
-	if _, err := preflight(request.Context()); err != nil {
-		writeError(response, http.StatusPreconditionFailed, fmt.Sprintf("Azure preflight failed: %v", err))
-		return
-	}
-	runs, err := listOngoing(request.Context())
-	if err != nil {
-		writeError(response, http.StatusBadGateway, fmt.Sprintf("list ongoing go-images releases: %v", err))
-		return
-	}
-	releases := make([]releaseSummary, 0, len(runs))
-	for _, run := range runs {
-		if run.BuildID <= 0 || run.Status == "" {
-			writeError(response, http.StatusBadGateway, "ongoing release discovery returned invalid run metadata")
-			return
-		}
-		mode := run.Mode
-		if mode == "" {
-			mode = goimagesworkflow.ModeNormal
-		}
-		releases = append(releases, releaseSummary{
-			ID: "azdo-" + strconv.Itoa(run.BuildID), ProcessID: goImagesProcessID, Name: "Go images",
-			Mode: string(mode), Status: run.Status, RunID: strconv.Itoa(run.BuildID), RunLabel: "Azure build",
-			UpdatedAt: run.Queued, Href: run.URL,
-		})
-	}
-	writeJSON(response, http.StatusOK, map[string]any{"releases": releases})
 }
 
 func (s *Server) releaseSummaryLocked() releaseSummary {
@@ -1055,7 +1006,7 @@ func (s *Server) resumeRestoredMonitoring() error {
 	if err != nil {
 		return fmt.Errorf("restore go-images monitoring service: %w", err)
 	}
-	monitor := importedRunMonitor{
+	monitor := restoredRunMonitor{
 		buildID: buildID,
 		monitor: func(ctx context.Context, id int) error {
 			return service.PollPipeline(ctx, strconv.Itoa(id))

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -90,7 +90,6 @@ func testReadOnly(source *GoImagesSource, rollbackCalls *int) GoImagesReadOnlyIn
 				SourceVersion: testSourceCommit, Versions: []string{"1.25.12-1", "1.26.5-2"},
 			}, nil
 		},
-		ListOngoing: func(context.Context) ([]GoImagesOngoingRun, error) { return nil, nil },
 	}
 }
 
@@ -267,37 +266,6 @@ func assertPreparedProcess(t *testing.T, ui *testUI, processID string, wantStatu
 	}
 	if plan["process"] != processID {
 		t.Fatalf("process %s plan = %#v", processID, plan)
-	}
-}
-
-func TestTrackOngoingReleases(t *testing.T) {
-	store, err := goimagessession.NewFileStore(filepath.Join(t.TempDir(), "release-session.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
-	readOnly := testReadOnly(&source, nil)
-	queued := time.Date(2026, 8, 6, 12, 30, 0, 0, time.UTC)
-	readOnly.ListOngoing = func(context.Context) ([]GoImagesOngoingRun, error) {
-		return []GoImagesOngoingRun{{
-			BuildID: 3035000, Mode: goimagesworkflow.ModeTest,
-			Status: "running", URL: "https://example/build/3035000", Queued: queued,
-		}}, nil
-	}
-	ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(readOnly))
-	response, err := ui.client.Get(ui.http.URL + "/api/releases/ongoing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var result struct {
-		Releases []releaseSummary `json:"releases"`
-	}
-	decodeResponse(t, response, &result)
-	if response.StatusCode != http.StatusOK || len(result.Releases) != 1 ||
-		result.Releases[0].RunID != "3035000" || result.Releases[0].Mode != string(goimagesworkflow.ModeTest) ||
-		result.Releases[0].Href != "https://example/build/3035000" {
-
-		t.Fatalf("ongoing releases = %#v", result.Releases)
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -4,36 +4,14 @@ const ongoingReleases = document.querySelector("#ongoing-releases");
 const recentSection = document.querySelector("#recent-section");
 const recentReleases = document.querySelector("#recent-releases");
 const processGrid = document.querySelector("#process-grid");
-const trackButton = document.querySelector("#track-releases");
 const preflightList = document.querySelector("#preflight-list");
 const availableCount = document.querySelector("#available-count");
 const toast = document.querySelector("#toast");
-const trackingPreflightPath = "/api/processes/go-images/preflight";
 let toastTimer = null;
 let dashboardState = null;
-let preflight = null;
-let trackingTimer = null;
 
 loadDashboard();
 loadPreflight();
-
-trackButton.addEventListener("click", async () => {
-  setBusy(trackButton, true, "Refreshing…");
-  try {
-    await refreshTrackedReleases();
-    if (!trackingTimer) {
-      trackingTimer = setInterval(() => {
-        refreshTrackedReleases().catch((error) => showError(error.message));
-      }, 15000);
-    }
-    trackButton.textContent = "Refresh tracked releases";
-  } catch (error) {
-    showError(error.message);
-  } finally {
-    trackButton.disabled = false;
-    if (!trackingTimer) trackButton.textContent = "Track ongoing releases";
-  }
-});
 
 async function loadDashboard() {
   dashboardState = await requestJSON("/api/dashboard");
@@ -46,7 +24,7 @@ async function loadDashboard() {
 
 async function loadPreflight() {
   try {
-    preflight = await requestJSON(trackingPreflightPath);
+    const preflight = await requestJSON("/api/processes/go-images/preflight");
     preflightList.replaceChildren(...preflight.checks.map((check) => {
       const item = document.createElement("li");
       item.dataset.status = check.status;
@@ -54,29 +32,9 @@ async function loadPreflight() {
       item.textContent = check.name;
       return item;
     }));
-    trackButton.title = preflight.azureReadOnlyEnabled
-      ? "Discover pipeline 1023 releases that are queued or in progress and refresh them every 15 seconds"
-      : "Live Azure tracking requires read-only access";
   } catch (error) {
     showError(`Unable to check local readiness: ${error.message}`);
   }
-}
-
-async function refreshTrackedReleases() {
-  await loadDashboard();
-  if (!preflight) preflight = await requestJSON(trackingPreflightPath);
-  if (!preflight.azureReadOnlyEnabled) {
-    throw new Error("Live release tracking is unavailable.");
-  }
-  const live = await requestJSON("/api/releases/ongoing");
-  const merged = new Map();
-  for (const release of live.releases) merged.set(releaseKey(release), release);
-  for (const release of dashboardState.ongoing) merged.set(releaseKey(release), release);
-  renderReleases(ongoingReleases, Array.from(merged.values()), "No ongoing pipeline 1023 releases were found.");
-}
-
-function releaseKey(release) {
-  return `${release.processId}:${release.runId || release.id}`;
 }
 
 function renderReleases(container, releases, emptyText) {
@@ -168,11 +126,6 @@ async function requestJSON(path, options = {}) {
   const data = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(data.error || `${response.status} ${response.statusText}`);
   return data;
-}
-
-function setBusy(button, busy, label) {
-  button.disabled = busy;
-  button.textContent = label;
 }
 
 function showError(message) {

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -48,9 +48,6 @@
           <h2 id="ongoing-title">Ongoing releases</h2>
           <p>Reopen the release currently owned by this durable local session.</p>
         </div>
-        <button id="track-releases" class="button button-secondary" type="button">
-          Track ongoing releases
-        </button>
       </div>
       <div id="ongoing-releases" class="release-list" aria-live="polite">
         <article class="release-empty loading-card">Checking the local session…</article>

--- a/cmd/releaseagent/serve.go
+++ b/cmd/releaseagent/serve.go
@@ -182,27 +182,6 @@ func handleServe(parse subcmd.ParseFunc) error {
 				SourceVersion: candidate.SourceVersion, Versions: versions,
 			}, nil
 		},
-		ListOngoing: func(ctx context.Context) ([]releaseui.GoImagesOngoingRun, error) {
-			builds, err := azureClient.ListRecent(ctx, 1023)
-			if err != nil {
-				return nil, err
-			}
-			result := make([]releaseui.GoImagesOngoingRun, 0)
-			for _, build := range builds {
-				state, err := build.State()
-				if err != nil {
-					return nil, fmt.Errorf("interpret pipeline 1023 build %d: %w", build.ID, err)
-				}
-				if state != azdopipeline.RunStateWaiting && state != azdopipeline.RunStateRunning {
-					continue
-				}
-				result = append(result, releaseui.GoImagesOngoingRun{
-					BuildID: build.ID, Mode: goImagesModeFromBuild(build), Status: string(state),
-					URL: build.WebURL, Queued: build.QueueTime,
-				})
-			}
-			return result, nil
-		},
 	}))
 	queueClient, err := goimagesexecution.NewHTTPQueueClient(
 		"https://dev.azure.com/dnceng",
@@ -318,26 +297,4 @@ func processRunStorePath(sessionPath string) (string, error) {
 		return "", fmt.Errorf("inspect legacy go-infra action journal: %w", err)
 	}
 	return sessionPath + ".process-run.json", nil
-}
-
-func goImagesModeFromBuild(build *azdopipeline.Build) goimagesworkflow.Mode {
-	if build == nil {
-		return goimagesworkflow.ModeNormal
-	}
-	switch mode := goimagesworkflow.Mode(build.Parameters["ReleaseUIGoImagesMode"]); mode {
-	case goimagesworkflow.ModeNormal,
-		goimagesworkflow.ModeRollback,
-		goimagesworkflow.ModeTest:
-
-		return mode
-	}
-	prefix, _ := build.TemplateParameters["publishRepoPrefix"].(string)
-	if prefix == "dev/" {
-		return goimagesworkflow.ModeTest
-	}
-	sourceBuild, _ := build.TemplateParameters["sourceBuildPipelineRunId"].(string)
-	if sourceBuild != "" && sourceBuild != "$(Build.BuildId)" {
-		return goimagesworkflow.ModeRollback
-	}
-	return goimagesworkflow.ModeNormal
 }

--- a/cmd/releaseagent/serve_test.go
+++ b/cmd/releaseagent/serve_test.go
@@ -8,9 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
-	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesworkflow"
 )
 
 func TestProcessRunStorePathRejectsLegacyJournal(t *testing.T) {
@@ -28,34 +25,5 @@ func TestProcessRunStorePathRejectsLegacyJournal(t *testing.T) {
 	}
 	if _, err := processRunStorePath(sessionPath); err == nil || !strings.Contains(err.Error(), "legacy go-infra action journal") {
 		t.Fatalf("error = %v", err)
-	}
-}
-
-func TestGoImagesModeFromBuild(t *testing.T) {
-	tests := []struct {
-		name  string
-		build *azdopipeline.Build
-		want  goimagesworkflow.Mode
-	}{
-		{name: "correlated test", build: &azdopipeline.Build{
-			Parameters: map[string]string{"ReleaseUIGoImagesMode": "test"},
-		}, want: goimagesworkflow.ModeTest},
-		{name: "dev prefix", build: &azdopipeline.Build{
-			TemplateParameters: map[string]any{"publishRepoPrefix": "dev/"},
-		}, want: goimagesworkflow.ModeTest},
-		{name: "old artifacts", build: &azdopipeline.Build{
-			TemplateParameters: map[string]any{"sourceBuildPipelineRunId": "3019035"},
-		}, want: goimagesworkflow.ModeRollback},
-		{name: "current build", build: &azdopipeline.Build{
-			TemplateParameters: map[string]any{"sourceBuildPipelineRunId": "$(Build.BuildId)"},
-		}, want: goimagesworkflow.ModeNormal},
-		{name: "defaults omitted", build: &azdopipeline.Build{}, want: goimagesworkflow.ModeNormal},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := goImagesModeFromBuild(test.build); got != test.want {
-				t.Fatalf("mode = %q, want %q", got, test.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
## Summary

Remove the dashboard feature that discovers arbitrary ongoing Azure pipeline runs and heuristically reconstructs their release mode.

This follows up on the review feedback in #557 that reconstructing a release flow without its original configuration is unreliable and adds unnecessary complexity.

## Changes

- Remove pipeline `1023` enumeration for waiting and running builds.
- Remove heuristic mode reconstruction from Azure pipeline parameters.
- Remove the `/api/releases/ongoing` endpoint.
- Remove the dashboard tracking button and 15-second polling.
- Remove related documentation and tests.
- Rename `importedRunMonitor` to `restoredRunMonitor` to clarify its remaining purpose.

Durable local-session reopening and restart monitoring for runs created by the release UI are preserved. Those paths use the original persisted release configuration rather than inferring it from Azure metadata.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- `git diff --check`

No workflows, releases, labels, or Azure pipelines were triggered.

## Dependency

Base: `dev/mclayton/release-ui-runtime-simplification`