### PR TITLE
releaseagent: remove unused process UI

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -10,7 +10,7 @@ Subcommands:
 
 The landing page is a release dashboard. It lists work tracked by the current durable session and a validated registry of release processes. Go images provides local planning, execution, and monitoring. Go infrastructure provides reviewed, confirmed actions for the two GitHub-owned patch release paths documented by the team. The complete Microsoft Build of Go release process remains a future addition rather than being mixed into either focused workflow.
 
-Each registry entry owns its dashboard metadata, documented release methods, inputs, and optional server callbacks. The server derives `/{ID}` and every process API route from that entry. A single `process.html` template and its generic JavaScript render every process. Runtime dependency graphs come only from `coordinator` steps after a plan is prepared.
+Each registry entry owns its dashboard metadata, inputs, and optional server callbacks. The server derives `/{ID}` and every process API route from that entry. A single `process.html` template and its generic JavaScript render every process. Runtime dependency graphs come only from `coordinator` steps after a plan is prepared.
 
 ## Adding a release process
 
@@ -26,10 +26,9 @@ Add one `ProcessDefinition` to `defaultProcessRegistry` in
 | `Status` | User-facing badge text, such as `Available`, `Planned`, or `Future`. This is display-only; `Available` controls whether the process can be opened. |
 | `Available` | Whether the dashboard card links to the process page. |
 | `DocumentationURL` | Canonical HTTPS release instructions linked from the process page. |
-| `Methods` | Documented external release paths. Use these when GitHub or another authenticated UI owns execution. |
 | `Workflow` | Optional in-UI inputs, dependency steps, and execution behavior. |
 
-For an external process, fill `Methods` and stop. For a reviewed, durable external action, describe the form with `ProcessInput`, then set `DurableAction`:
+For a reviewed, durable external action, describe the form with `ProcessInput`, then set `DurableAction`:
 
 ```go
 ProcessDefinition{

--- a/cmd/releaseagent/internal/releaseui/process_registry.go
+++ b/cmd/releaseagent/internal/releaseui/process_registry.go
@@ -28,19 +28,7 @@ type ProcessDefinition struct {
 	Status           string
 	DocumentationURL string
 	Available        bool
-	Methods          []ProcessMethod
 	Workflow         *ProcessWorkflow
-}
-
-// ProcessMethod is one documented way to complete a release process.
-type ProcessMethod struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Badge       string   `json:"badge,omitempty"`
-	Description string   `json:"description"`
-	Steps       []string `json:"steps"`
-	ActionLabel string   `json:"actionLabel"`
-	ActionHref  string   `json:"actionHref"`
 }
 
 // ProcessWorkflow describes an in-UI workflow. DurableAction uses the shared confirmed execution
@@ -125,24 +113,6 @@ func newProcessRegistry(definitions ...ProcessDefinition) (*processRegistry, err
 		}
 		if definition.DocumentationURL != "" && !strings.HasPrefix(definition.DocumentationURL, "https://") {
 			return nil, fmt.Errorf("release process %q has an invalid documentation URL", definition.ID)
-		}
-		methodIDs := make(map[string]struct{}, len(definition.Methods))
-		for _, method := range definition.Methods {
-			if !processIDPattern.MatchString(method.ID) || strings.TrimSpace(method.Name) == "" ||
-				strings.TrimSpace(method.Description) == "" || len(method.Steps) == 0 ||
-				strings.TrimSpace(method.ActionLabel) == "" || !strings.HasPrefix(method.ActionHref, "https://") {
-
-				return nil, fmt.Errorf("release process %q has an invalid method %q", definition.ID, method.ID)
-			}
-			if _, exists := methodIDs[method.ID]; exists {
-				return nil, fmt.Errorf("release process %q repeats method %q", definition.ID, method.ID)
-			}
-			methodIDs[method.ID] = struct{}{}
-			for _, step := range method.Steps {
-				if strings.TrimSpace(step) == "" {
-					return nil, fmt.Errorf("release process %q method %q has an empty step", definition.ID, method.ID)
-				}
-			}
 		}
 		if err := validateProcessWorkflow(definition.ID, definition.Workflow); err != nil {
 			return nil, err

--- a/cmd/releaseagent/internal/releaseui/processes_test.go
+++ b/cmd/releaseagent/internal/releaseui/processes_test.go
@@ -14,10 +14,6 @@ func TestProcessRegistry(t *testing.T) {
 			ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available",
 			Available:        true,
 			DocumentationURL: "https://example.com/docs",
-			Methods: []ProcessMethod{{
-				ID: "manual", Name: "Manual", Description: "Run it manually", Steps: []string{"Open it"},
-				ActionLabel: "Open", ActionHref: "https://example.com/run",
-			}},
 		},
 		ProcessDefinition{
 			ID: "two", Name: "Two", Mark: "T", Description: "Second process", Status: "Future",
@@ -32,7 +28,7 @@ func TestProcessRegistry(t *testing.T) {
 	if _, ok := registry.page("/two"); ok {
 		t.Fatal("unavailable process has a page")
 	}
-	if process, ok := registry.process("one"); !ok || len(process.Methods) != 1 {
+	if process, ok := registry.process("one"); !ok || process.Name != "One" {
 		t.Fatalf("process = %#v, ok = %v", process, ok)
 	}
 	summaries := registry.summaries()
@@ -54,11 +50,6 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 		{name: "duplicate ID", definitions: []ProcessDefinition{valid, valid}},
 		{name: "invalid ID", definitions: []ProcessDefinition{{
 			ID: "One", Name: "One", Mark: "O", Description: "First", Status: "Future",
-		}}},
-		{name: "invalid method", definitions: []ProcessDefinition{{
-			ID: "one", Name: "One", Mark: "O", Description: "First", Status: "Available",
-			Available: true,
-			Methods:   []ProcessMethod{{ID: "manual", Name: "Manual"}},
 		}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -516,7 +516,6 @@ type processDetail struct {
 	Mark             string          `json:"mark"`
 	Description      string          `json:"description"`
 	DocumentationURL string          `json:"documentationUrl"`
-	Methods          []ProcessMethod `json:"methods"`
 	Workflow         *workflowDetail `json:"workflow,omitempty"`
 }
 
@@ -540,7 +539,6 @@ func (s *Server) handleProcess(response http.ResponseWriter, request *http.Reque
 	detail := processDetail{
 		ID: definition.ID, Name: definition.Name, Mark: definition.Mark,
 		Description: definition.Description, DocumentationURL: definition.DocumentationURL,
-		Methods: append([]ProcessMethod(nil), definition.Methods...),
 	}
 	if definition.Workflow != nil {
 		detail.Workflow = &workflowDetail{

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -156,8 +156,8 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	}
 	var process processDetail
 	decodeResponse(t, response, &process)
-	if response.StatusCode != http.StatusOK || process.ID != "go-infra" || len(process.Methods) != 0 ||
-		process.Workflow == nil || !process.Workflow.HasPreflight || !process.Workflow.CanPrepare ||
+	if response.StatusCode != http.StatusOK || process.ID != "go-infra" || process.Workflow == nil ||
+		!process.Workflow.HasPreflight || !process.Workflow.CanPrepare ||
 		!process.Workflow.CanStart || len(process.Workflow.Inputs) != 3 {
 
 		t.Fatalf("process = %#v", process)

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -4,37 +4,17 @@ const ongoingReleases = document.querySelector("#ongoing-releases");
 const recentSection = document.querySelector("#recent-section");
 const recentReleases = document.querySelector("#recent-releases");
 const processGrid = document.querySelector("#process-grid");
-const preflightList = document.querySelector("#preflight-list");
 const availableCount = document.querySelector("#available-count");
-const toast = document.querySelector("#toast");
-let toastTimer = null;
-let dashboardState = null;
 
 loadDashboard();
-loadPreflight();
 
 async function loadDashboard() {
-  dashboardState = await requestJSON("/api/dashboard");
+  const dashboardState = await requestJSON("/api/dashboard");
   availableCount.textContent = String(dashboardState.processes.filter((process) => process.available).length);
   renderReleases(ongoingReleases, dashboardState.ongoing, "No release is currently being tracked in this local session.");
   processGrid.replaceChildren(...dashboardState.processes.map(createProcessCard));
   recentSection.hidden = dashboardState.recent.length === 0;
   renderReleases(recentReleases, dashboardState.recent, "");
-}
-
-async function loadPreflight() {
-  try {
-    const preflight = await requestJSON("/api/processes/go-images/preflight");
-    preflightList.replaceChildren(...preflight.checks.map((check) => {
-      const item = document.createElement("li");
-      item.dataset.status = check.status;
-      item.title = check.details;
-      item.textContent = check.name;
-      return item;
-    }));
-  } catch (error) {
-    showError(`Unable to check local readiness: ${error.message}`);
-  }
 }
 
 function renderReleases(container, releases, emptyText) {
@@ -121,16 +101,9 @@ function statusText(status) {
   return status === "running" ? "in progress" : status;
 }
 
-async function requestJSON(path, options = {}) {
-  const response = await fetch(path, options);
+async function requestJSON(path) {
+  const response = await fetch(path);
   const data = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(data.error || `${response.status} ${response.statusText}`);
   return data;
-}
-
-function showError(message) {
-  toast.textContent = message;
-  toast.hidden = false;
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => { toast.hidden = true; }, 8000);
 }

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -75,15 +75,6 @@
       <div id="recent-releases" class="release-list"></div>
     </section>
 
-    <section class="readiness-strip" aria-labelledby="readiness-title">
-      <div>
-        <p class="eyebrow">Local readiness</p>
-        <h2 id="readiness-title">Execution boundaries</h2>
-      </div>
-      <ul id="preflight-list" class="preflight-list" aria-live="polite"></ul>
-    </section>
   </main>
-
-  <div id="toast" class="toast" role="alert" aria-live="assertive" hidden></div>
 </body>
 </html>

--- a/cmd/releaseagent/internal/releaseui/web/process.html
+++ b/cmd/releaseagent/internal/releaseui/web/process.html
@@ -41,16 +41,6 @@
       </div>
     </section>
 
-    <section id="methods-section" aria-labelledby="methods-title" hidden>
-      <div class="section-heading">
-        <div>
-          <p class="eyebrow">Available paths</p>
-          <h2 id="methods-title">Choose how to release</h2>
-        </div>
-      </div>
-      <div id="process-methods" class="process-method-grid" aria-live="polite"></div>
-    </section>
-
     <section id="workflow-section" class="release-layout" hidden>
       <aside class="panel release-options-panel">
         <div class="panel-heading">

--- a/cmd/releaseagent/internal/releaseui/web/process.js
+++ b/cmd/releaseagent/internal/releaseui/web/process.js
@@ -5,8 +5,6 @@
   const processName = document.querySelector("#process-name");
   const processDescription = document.querySelector("#process-description");
   const processDocumentation = document.querySelector("#process-documentation");
-  const methodsSection = document.querySelector("#methods-section");
-  const processMethods = document.querySelector("#process-methods");
   const toast = document.querySelector("#toast");
 
   globalThis.releaseProcessReady = loadProcess();
@@ -21,47 +19,11 @@
       processDescription.textContent = process.description;
       processDocumentation.href = process.documentationUrl || "";
       processDocumentation.hidden = !process.documentationUrl;
-      const methods = process.methods || [];
-      processMethods.replaceChildren(...methods.map(createMethod));
-      methodsSection.hidden = methods.length === 0;
       return process;
     } catch (error) {
       showError(error.message);
       throw error;
     }
-  }
-
-  function createMethod(method) {
-    const card = document.createElement("article");
-    card.className = "process-method";
-
-    const heading = document.createElement("div");
-    heading.className = "process-method-heading";
-    const title = document.createElement("h3");
-    title.textContent = method.name;
-    heading.append(title);
-    if (method.badge) {
-      const badge = document.createElement("span");
-      badge.textContent = method.badge;
-      heading.append(badge);
-    }
-
-    const description = document.createElement("p");
-    description.textContent = method.description;
-    const steps = document.createElement("ol");
-    steps.replaceChildren(...method.steps.map((text) => {
-      const item = document.createElement("li");
-      item.textContent = text;
-      return item;
-    }));
-    const action = document.createElement("a");
-    action.className = "button button-primary process-method-action";
-    action.href = method.actionHref;
-    action.target = "_blank";
-    action.rel = "noreferrer";
-    action.textContent = `${method.actionLabel} ↗`;
-    card.append(heading, description, steps, action);
-    return card;
   }
 
   async function requestJSON(path) {

--- a/cmd/releaseagent/internal/releaseui/web/styles.css
+++ b/cmd/releaseagent/internal/releaseui/web/styles.css
@@ -262,7 +262,7 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .dashboard-section { margin-bottom: 26px; padding: 26px; border: 1px solid var(--border); border-radius: 22px; background: linear-gradient(155deg, rgb(17 34 56 / 92%), rgb(9 23 39 / 96%)); box-shadow: var(--shadow); }
 .section-heading { display: flex; align-items: center; justify-content: space-between; gap: 24px; margin-bottom: 20px; }
 .section-heading .eyebrow { margin-bottom: 7px; }
-.section-heading h2, .readiness-strip h2 { margin: 0; font-size: 23px; letter-spacing: 0; }
+.section-heading h2 { margin: 0; font-size: 23px; letter-spacing: 0; }
 .section-heading p:not(.eyebrow) { margin: 7px 0 0; color: var(--muted); font-size: 14px; line-height: 1.5; }
 .release-list { display: grid; gap: 10px; }
 .release-empty { padding: 23px; border: 1px dashed var(--border); border-radius: 14px; color: var(--muted); background: rgb(5 16 29 / 32%); font-size: 14px; text-align: center; }
@@ -287,22 +287,6 @@ a.process-card:hover { transform: translateY(-3px); border-color: rgb(57 213 255
 .process-card p { min-height: 52px; margin: 9px 0 24px; color: var(--muted); font-size: 14px; line-height: 1.55; }
 .process-action { color: var(--cyan); font-size: 13px; font-weight: 800; }
 .process-card[data-available="false"] .process-action { color: var(--muted); }
-.readiness-strip { display: flex; align-items: center; justify-content: space-between; gap: 30px; margin-top: 30px; padding: 22px 26px; border-top: 1px solid var(--border); }
-.readiness-strip .eyebrow { margin-bottom: 6px; }
-.readiness-strip .preflight-list { justify-content: flex-end; margin: 0; }
-
-/* Guided release process */
-#methods-section { margin-bottom: 28px; }
-.process-method-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
-.process-method { display: flex; min-height: 360px; flex-direction: column; padding: 24px; border: 1px solid var(--border); border-radius: 17px; background: linear-gradient(155deg, rgb(17 34 56 / 94%), rgb(9 23 39 / 96%)); box-shadow: var(--shadow); }
-.process-method-heading { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
-.process-method-heading h3 { margin: 0; font-size: 21px; }
-.process-method-heading span { padding: 6px 9px; border-radius: 99px; background: rgb(57 213 255 / 12%); color: var(--cyan); font-size: 11px; font-weight: 900; text-transform: uppercase; }
-.process-method > p { margin: 14px 0 0; color: var(--muted); font-size: 14px; line-height: 1.55; }
-.process-method ol { display: grid; gap: 12px; margin: 22px 0 26px; padding-left: 22px; color: #c8dbea; font-size: 14px; line-height: 1.55; }
-.process-method li::marker { color: var(--cyan); font-weight: 900; }
-.process-method-action { margin-top: auto; text-decoration: none; }
-
 /* Executable release process */
 .release-main { width: min(1480px, 100%); }
 .release-hero { display: grid; grid-template-columns: auto minmax(0, 1fr) minmax(300px, 380px); align-items: center; gap: 24px; padding: 44px 0 34px; }
@@ -375,7 +359,6 @@ label.mode-card { position: relative; display: grid; grid-template-columns: auto
   .release-layout { grid-template-columns: minmax(0, 1fr); }
   .release-options-panel { position: static; }
   .process-grid { grid-template-columns: 1fr; }
-	.process-method-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 620px) {
@@ -387,7 +370,7 @@ label.mode-card { position: relative; display: grid; grid-template-columns: auto
   .plan-heading .button { width: 100%; margin-top: 8px; }
   .panel { padding: 19px; border-radius: 17px; }
   .dashboard-section, .release-options-panel, .release-plan-panel { padding: 19px; border-radius: 17px; }
-  .section-heading, .readiness-strip { align-items: flex-start; flex-direction: column; }
+  .section-heading { align-items: flex-start; flex-direction: column; }
   .section-heading .button { width: 100%; }
   .release-card { align-items: flex-start; flex-wrap: wrap; }
   .release-card .compact-button { width: 100%; }


### PR DESCRIPTION
## Summary

Remove two unused UI paths from the release agent:

- The `ProcessMethod` model and its rendering code. No registered process uses it.
- The dashboard's hardcoded go-images readiness panel. Readiness remains available on each process page.

This keeps the dashboard process-neutral and removes 143 net lines.

## Changes

- Remove `ProcessMethod` from the registry and process API.
- Remove method validation, tests, HTML, JavaScript, and CSS.
- Remove the dashboard's go-images preflight request and readiness panel.
- Update the release agent documentation.

Go-images and go-infra process pages still show their own preflight checks. Planning, confirmation, execution, persistence, and recovery behavior are unchanged.
