### PR TITLE
releaseagent: narrow registry to active process contracts

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -3,14 +3,15 @@
 This command contains the release coordination prototype and the local release-management UI.
 The server runs on the release runner's machine and opens in their default browser.
 
-Subcommands:
+`releaseagent serve` starts the local release UI.
 
-* `releaseagent serve` starts the local release UI.
-* `releaseagent write-mermaid-diagram` writes a Mermaid diagram of the broader release process.
+The landing page lists work tracked by the current durable session and the two implemented release
+processes. Go images provides local planning, execution, and monitoring. Go infrastructure provides
+reviewed, confirmed actions for the two GitHub-owned patch release paths documented by the team.
 
-The landing page is a release dashboard. It lists work tracked by the current durable session and a validated registry of release processes. Go images provides local planning, execution, and monitoring. Go infrastructure provides reviewed, confirmed actions for the two GitHub-owned patch release paths documented by the team. The complete Microsoft Build of Go release process remains a future addition rather than being mixed into either focused workflow.
-
-Each registry entry owns its dashboard metadata, inputs, and optional server callbacks. The server derives `/{ID}` and every process API route from that entry. A single `process.html` template and its generic JavaScript render every process. Runtime dependency graphs come only from `coordinator` steps after a plan is prepared.
+Each registry entry owns its dashboard metadata, inputs, and workflow callbacks. The server derives
+the process page and API routes from that entry. One HTML page and JavaScript implementation render
+both processes. Browser-editable inputs are limited to fixed choices and positive integer IDs.
 
 ## Adding a release process
 
@@ -23,30 +24,27 @@ Add one `ProcessDefinition` to `defaultProcessRegistry` in
 | `Name` | User-facing process name shown on the dashboard and process page. |
 | `Mark` | Short visual abbreviation shown on the dashboard card, such as `IN`. |
 | `Description` | Brief dashboard explanation of what the process releases. |
-| `Status` | User-facing badge text, such as `Available`, `Planned`, or `Future`. This is display-only; `Available` controls whether the process can be opened. |
-| `Available` | Whether the dashboard card links to the process page. |
 | `DocumentationURL` | Canonical HTTPS release instructions linked from the process page. |
-| `Workflow` | Optional in-UI inputs, dependency steps, and execution behavior. |
+| `Workflow` | Required in-UI inputs and execution behavior. |
 
 For a reviewed, durable external action, describe the form with `ProcessInput`, then set `DurableAction`:
 
 ```go
 ProcessDefinition{
     ID: "example", Name: "Example", Mark: "EX", Description: "Release the example.",
-    Status: "Available", Available: true,
     Workflow: &ProcessWorkflow{
         Heading: "Configure release", SubmitLabel: "Prepare release",
-        Inputs: []ProcessInput{{ID: "version", Type: "text", Label: "Version", Required: true}},
+    Inputs: []ProcessInput{{ID: "run", Type: "number", Label: "Run ID", Required: true}},
         DurableAction: true,
     },
 }
 ```
 
-    Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store holds the server's single current durable external action. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart behavior, state APIs, and event streaming.
+  Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store holds the server's single current durable external action. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart behavior, state APIs, and event streaming.
 
-    Before preparation, the shared lifecycle validates request keys, required and conditional fields, choice values, numeric syntax, defaults, and string values. Executors then apply process-specific semantic and fixed-target validation.
+  Before preparation, the shared lifecycle validates request keys, required and conditional fields, choice values, positive integer syntax, and defaults. Executors then apply process-specific semantic and fixed-target validation.
 
-    `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for custom lifecycles. Do not combine these handlers with `DurableAction`.
+  `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for custom lifecycles. Do not combine these handlers with `DurableAction`.
 
 ## Go-images release modes
 

--- a/cmd/releaseagent/internal/releaseui/process_execution.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution.go
@@ -85,7 +85,7 @@ func WithProcessRunStore(store ProcessRunStore) Option {
 func (s *Server) validateProcessExecutionConfiguration() error {
 	for processID, executor := range s.processExecutors {
 		definition, ok := s.processes.byID[processID]
-		if !ok || definition.Workflow == nil || !definition.Workflow.DurableAction {
+		if !ok || !definition.Workflow.DurableAction {
 			return fmt.Errorf("process executor %q has no durable workflow definition", processID)
 		}
 		if executor.Preflight == nil || executor.Prepare == nil || executor.Execute == nil ||
@@ -172,7 +172,7 @@ func (s *Server) handlePrepareProcessRun(processID string, response http.Respons
 		writeError(response, http.StatusForbidden, "external process execution is not enabled")
 		return
 	}
-	if !defined || definition.Workflow == nil || !definition.Workflow.DurableAction {
+	if !defined || !definition.Workflow.DurableAction {
 		s.mu.Unlock()
 		writeError(response, http.StatusInternalServerError, "durable process definition is unavailable")
 		return

--- a/cmd/releaseagent/internal/releaseui/process_execution_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution_test.go
@@ -53,10 +53,13 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 		Validate: func(run *ProcessRun) error { return nil },
 	}
 	registry, err := newProcessRegistry(ProcessDefinition{
-		ID: "example", Name: "Example", Mark: "EX", Description: "Example process", Status: "Available", Available: true,
+		ID: "example", Name: "Example", Mark: "EX", Description: "Example process",
 		Workflow: &ProcessWorkflow{
 			Heading: "Run example", SubmitLabel: "Review", DurableAction: true,
-			Inputs: []ProcessInput{{ID: "mode", Type: "text", Label: "Mode", Required: true}},
+			Inputs: []ProcessInput{{
+				ID: "mode", Type: "choice", Label: "Mode", Required: true,
+				Options: []ProcessInputOption{{Value: "run", Name: "Run", Description: "Run example"}},
+			}},
 		},
 	})
 	if err != nil {
@@ -70,7 +73,7 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 		runner:           &coordinator.StepRunner{},
 	}
 	prepared := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "http://localhost/api/processes/example/plan", strings.NewReader(`{"mode":"test"}`))
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/api/processes/example/plan", strings.NewReader(`{"mode":"run"}`))
 	request.Header.Set("Origin", "http://localhost")
 	server.handlePrepareProcessRun("example", prepared, request)
 	if prepared.Code != http.StatusOK {

--- a/cmd/releaseagent/internal/releaseui/process_input.go
+++ b/cmd/releaseagent/internal/releaseui/process_input.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strconv"
 	"strings"
 )
@@ -73,11 +72,10 @@ func normalizeProcessInputs(inputs []ProcessInput, data json.RawMessage) (json.R
 				return nil, fmt.Errorf("process input %q has unsupported value %q", input.ID, value)
 			}
 		case "number":
-			number, err := strconv.ParseFloat(value, 64)
-			if err != nil || math.IsInf(number, 0) || math.IsNaN(number) {
-				return nil, fmt.Errorf("process input %q must be a finite number", input.ID)
+			number, err := strconv.ParseUint(value, 10, 64)
+			if err != nil || number == 0 {
+				return nil, fmt.Errorf("process input %q must be a positive integer", input.ID)
 			}
-		case "text":
 		default:
 			return nil, fmt.Errorf("process input %q has unsupported type %q", input.ID, input.Type)
 		}

--- a/cmd/releaseagent/internal/releaseui/process_input_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_input_test.go
@@ -22,14 +22,13 @@ func TestNormalizeProcessInputs(t *testing.T) {
 			ID: "build", Type: "number", Label: "Build", Required: true,
 			VisibleWhen: &ProcessCondition{InputID: "mode", Equals: "rollback"},
 		},
-		{ID: "note", Type: "text", Label: "Note"},
 	}
 	for _, test := range []struct {
 		name  string
 		input string
 		want  map[string]string
 	}{
-		{name: "defaults and trims", input: `{"note":"  hello  "}`, want: map[string]string{"mode": "normal", "note": "hello"}},
+		{name: "default choice", input: `{}`, want: map[string]string{"mode": "normal"}},
 		{name: "conditional number", input: `{"mode":"rollback","build":"42"}`, want: map[string]string{"mode": "rollback", "build": "42"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -64,6 +63,8 @@ func TestNormalizeProcessInputsRejectsSchemaViolations(t *testing.T) {
 		`{"mode":"other","build":"42"}`,
 		`{"mode":"normal"}`,
 		`{"mode":"normal","build":"NaN"}`,
+		`{"mode":"normal","build":"0"}`,
+		`{"mode":"normal","build":"1.5"}`,
 		`{"mode":"normal","build":42}`,
 		`{"mode":"normal","build":"42","extra":"value"}`,
 		`{"mode":"other","build":"42"}`,

--- a/cmd/releaseagent/internal/releaseui/process_registry.go
+++ b/cmd/releaseagent/internal/releaseui/process_registry.go
@@ -6,7 +6,6 @@ package releaseui
 import (
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -18,16 +17,13 @@ var (
 	inputIDPattern   = regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)
 )
 
-// ProcessDefinition describes one release process. Available processes are served at /{ID}
-// through the shared process page.
+// ProcessDefinition describes one release process served at /{ID} through the shared process page.
 type ProcessDefinition struct {
 	ID               string
 	Name             string
 	Mark             string
 	Description      string
-	Status           string
 	DocumentationURL string
-	Available        bool
 	Workflow         *ProcessWorkflow
 }
 
@@ -80,7 +76,6 @@ type ProcessCondition struct {
 
 type processRegistry struct {
 	ordered []ProcessDefinition
-	byPath  map[string]ProcessDefinition
 	byID    map[string]ProcessDefinition
 }
 
@@ -90,7 +85,6 @@ func newProcessRegistry(definitions ...ProcessDefinition) (*processRegistry, err
 	}
 	registry := &processRegistry{
 		ordered: make([]ProcessDefinition, 0, len(definitions)),
-		byPath:  make(map[string]ProcessDefinition),
 		byID:    make(map[string]ProcessDefinition),
 	}
 	ids := make(map[string]struct{}, len(definitions))
@@ -102,14 +96,10 @@ func newProcessRegistry(definitions ...ProcessDefinition) (*processRegistry, err
 			return nil, fmt.Errorf("duplicate release process ID %q", definition.ID)
 		}
 		ids[definition.ID] = struct{}{}
-		registry.byID[definition.ID] = definition
 		if strings.TrimSpace(definition.Name) == "" || strings.TrimSpace(definition.Mark) == "" ||
-			strings.TrimSpace(definition.Description) == "" || strings.TrimSpace(definition.Status) == "" {
+			strings.TrimSpace(definition.Description) == "" {
 
 			return nil, fmt.Errorf("release process %q has incomplete catalog metadata", definition.ID)
-		}
-		if definition.Available {
-			registry.byPath[processPath(definition.ID)] = definition
 		}
 		if definition.DocumentationURL != "" && !strings.HasPrefix(definition.DocumentationURL, "https://") {
 			return nil, fmt.Errorf("release process %q has an invalid documentation URL", definition.ID)
@@ -117,6 +107,7 @@ func newProcessRegistry(definitions ...ProcessDefinition) (*processRegistry, err
 		if err := validateProcessWorkflow(definition.ID, definition.Workflow); err != nil {
 			return nil, err
 		}
+		registry.byID[definition.ID] = definition
 		registry.ordered = append(registry.ordered, definition)
 	}
 	return registry, nil
@@ -125,7 +116,7 @@ func newProcessRegistry(definitions ...ProcessDefinition) (*processRegistry, err
 func defaultProcessRegistry() (*processRegistry, error) {
 	return newProcessRegistry(
 		ProcessDefinition{
-			ID: "go-images", Name: "Go images", Mark: "GI", Available: true, Status: "Available",
+			ID: "go-images", Name: "Go images", Mark: "GI",
 			Description:      "Build, sign, publish, test, or republish the Microsoft Build of Go container images.",
 			DocumentationURL: "https://github.com/microsoft/go-lab/tree/main/docs/release#golang-toolset-images",
 			Workflow: &ProcessWorkflow{
@@ -155,7 +146,7 @@ func defaultProcessRegistry() (*processRegistry, error) {
 			},
 		},
 		ProcessDefinition{
-			ID: "go-infra", Name: "Go infrastructure", Mark: "IN", Status: "Available", Available: true,
+			ID: "go-infra", Name: "Go infrastructure", Mark: "IN",
 			Description:      "Create the next microsoft/go-infra patch release through its GitHub release workflow.",
 			DocumentationURL: "https://github.com/microsoft/go-lab/tree/main/docs/release#microsoftgo-infra",
 			Workflow: &ProcessWorkflow{
@@ -197,16 +188,12 @@ func defaultProcessRegistry() (*processRegistry, error) {
 				DurableAction: true,
 			},
 		},
-		ProcessDefinition{
-			ID: "microsoft-go", Name: "Microsoft Build of Go", Mark: "MS", Status: "Future",
-			Description: "The complete Microsoft Build of Go release process is intentionally out of scope for now.",
-		},
 	)
 }
 
 func validateProcessWorkflow(processID string, workflow *ProcessWorkflow) error {
 	if workflow == nil {
-		return nil
+		return fmt.Errorf("release process %q has no workflow", processID)
 	}
 	if strings.TrimSpace(workflow.Heading) == "" {
 		return fmt.Errorf("release process %q has an incomplete workflow", processID)
@@ -229,7 +216,7 @@ func validateProcessWorkflow(processID string, workflow *ProcessWorkflow) error 
 	inputs := make(map[string]ProcessInput, len(workflow.Inputs))
 	for _, input := range workflow.Inputs {
 		if !inputIDPattern.MatchString(input.ID) || strings.TrimSpace(input.Label) == "" ||
-			input.Type != "choice" && input.Type != "number" && input.Type != "text" {
+			input.Type != "choice" && input.Type != "number" {
 
 			return fmt.Errorf("release process %q has an invalid input %q", processID, input.ID)
 		}
@@ -257,8 +244,8 @@ func validateProcessWorkflow(processID string, workflow *ProcessWorkflow) error 
 			}
 		}
 		if input.Default != "" && input.Type == "number" {
-			value, err := strconv.ParseFloat(input.Default, 64)
-			if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+			value, err := strconv.ParseUint(input.Default, 10, 64)
+			if err != nil || value == 0 {
 				return fmt.Errorf("release process %q input %q has an invalid default", processID, input.ID)
 			}
 		}
@@ -288,30 +275,23 @@ func processPath(id string) string {
 }
 
 func (r *processRegistry) page(path string) (string, bool) {
-	_, ok := r.byPath[path]
+	id := strings.TrimPrefix(path, "/")
+	_, ok := r.byID[id]
+	ok = ok && path == processPath(id)
 	return "process.html", ok
 }
 
 func (r *processRegistry) process(id string) (ProcessDefinition, bool) {
-	for _, definition := range r.ordered {
-		if definition.ID == id {
-			return definition, true
-		}
-	}
-	return ProcessDefinition{}, false
+	definition, ok := r.byID[id]
+	return definition, ok
 }
 
 func (r *processRegistry) summaries() []processSummary {
 	summaries := make([]processSummary, 0, len(r.ordered))
 	for _, definition := range r.ordered {
-		href := ""
-		if definition.Available {
-			href = processPath(definition.ID)
-		}
 		summaries = append(summaries, processSummary{
 			ID: definition.ID, Name: definition.Name, Mark: definition.Mark,
-			Description: definition.Description, Href: href,
-			Available: definition.Available, Status: definition.Status,
+			Description: definition.Description, Href: processPath(definition.ID),
 		})
 	}
 	return summaries

--- a/cmd/releaseagent/internal/releaseui/processes_test.go
+++ b/cmd/releaseagent/internal/releaseui/processes_test.go
@@ -11,12 +11,13 @@ import (
 func TestProcessRegistry(t *testing.T) {
 	registry, err := newProcessRegistry(
 		ProcessDefinition{
-			ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available",
-			Available:        true,
+			ID: "one", Name: "One", Mark: "O", Description: "First process",
 			DocumentationURL: "https://example.com/docs",
+			Workflow:         &ProcessWorkflow{Heading: "Configure one"},
 		},
 		ProcessDefinition{
-			ID: "two", Name: "Two", Mark: "T", Description: "Second process", Status: "Future",
+			ID: "two", Name: "Two", Mark: "T", Description: "Second process",
+			Workflow: &ProcessWorkflow{Heading: "Configure two"},
 		},
 	)
 	if err != nil {
@@ -25,22 +26,22 @@ func TestProcessRegistry(t *testing.T) {
 	if page, ok := registry.page("/one"); !ok || page != "process.html" {
 		t.Fatalf("page = %q, ok = %v", page, ok)
 	}
-	if _, ok := registry.page("/two"); ok {
-		t.Fatal("unavailable process has a page")
+	if page, ok := registry.page("/two"); !ok || page != "process.html" {
+		t.Fatalf("page = %q, ok = %v", page, ok)
 	}
 	if process, ok := registry.process("one"); !ok || process.Name != "One" {
 		t.Fatalf("process = %#v, ok = %v", process, ok)
 	}
 	summaries := registry.summaries()
-	if len(summaries) != 2 || summaries[0].Mark != "O" || summaries[1].Available {
+	if len(summaries) != 2 || summaries[0].Mark != "O" || summaries[1].Href != "/two" {
 		t.Fatalf("summaries = %#v", summaries)
 	}
 }
 
 func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 	valid := ProcessDefinition{
-		ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available",
-		Available: true,
+		ID: "one", Name: "One", Mark: "O", Description: "First process",
+		Workflow: &ProcessWorkflow{Heading: "Configure"},
 	}
 	for _, test := range []struct {
 		name        string
@@ -49,7 +50,10 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 		{name: "empty"},
 		{name: "duplicate ID", definitions: []ProcessDefinition{valid, valid}},
 		{name: "invalid ID", definitions: []ProcessDefinition{{
-			ID: "One", Name: "One", Mark: "O", Description: "First", Status: "Future",
+			ID: "One", Name: "One", Mark: "O", Description: "First", Workflow: &ProcessWorkflow{Heading: "Configure"},
+		}}},
+		{name: "missing workflow", definitions: []ProcessDefinition{{
+			ID: "one", Name: "One", Mark: "O", Description: "First",
 		}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -63,7 +67,7 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 func TestProcessRegistryValidatesWorkflowInputs(t *testing.T) {
 	prepare := func(*Server, http.ResponseWriter, *http.Request) {}
 	definition := ProcessDefinition{
-		ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available", Available: true,
+		ID: "one", Name: "One", Mark: "O", Description: "First process",
 		Workflow: &ProcessWorkflow{
 			Heading: "Configure", SubmitLabel: "Prepare", GetPlan: prepare, Prepare: prepare,
 			Inputs: []ProcessInput{{
@@ -89,10 +93,13 @@ func TestProcessRegistryValidatesWorkflowInputs(t *testing.T) {
 func TestProcessRegistryValidatesDurableAction(t *testing.T) {
 	handler := func(*Server, http.ResponseWriter, *http.Request) {}
 	definition := ProcessDefinition{
-		ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available", Available: true,
+		ID: "one", Name: "One", Mark: "O", Description: "First process",
 		Workflow: &ProcessWorkflow{
 			Heading: "Configure", SubmitLabel: "Review", DurableAction: true,
-			Inputs: []ProcessInput{{ID: "mode", Type: "text", Label: "Mode", Required: true}},
+			Inputs: []ProcessInput{{
+				ID: "mode", Type: "choice", Label: "Mode", Required: true,
+				Options: []ProcessInputOption{{Value: "run", Name: "Run", Description: "Run now"}},
+			}},
 		},
 	}
 	if _, err := newProcessRegistry(definition); err != nil {

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -259,15 +259,9 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.handlePage)
 	for _, definition := range s.processes.ordered {
-		if !definition.Available {
-			continue
-		}
 		processID := definition.ID
 		mux.HandleFunc("GET "+processPath(processID), s.handlePage)
 		workflow := definition.Workflow
-		if workflow == nil {
-			continue
-		}
 		prefix := "/api/processes/" + processID
 		preflight := workflow.Preflight
 		if workflow.DurableAction {
@@ -505,9 +499,7 @@ type processSummary struct {
 	Name        string `json:"name"`
 	Mark        string `json:"mark"`
 	Description string `json:"description"`
-	Href        string `json:"href,omitempty"`
-	Available   bool   `json:"available"`
-	Status      string `json:"status"`
+	Href        string `json:"href"`
 }
 
 type processDetail struct {
@@ -532,16 +524,14 @@ type workflowDetail struct {
 
 func (s *Server) handleProcess(response http.ResponseWriter, request *http.Request) {
 	definition, ok := s.processes.process(request.PathValue("id"))
-	if !ok || !definition.Available {
+	if !ok {
 		http.NotFound(response, request)
 		return
 	}
 	detail := processDetail{
 		ID: definition.ID, Name: definition.Name, Mark: definition.Mark,
 		Description: definition.Description, DocumentationURL: definition.DocumentationURL,
-	}
-	if definition.Workflow != nil {
-		detail.Workflow = &workflowDetail{
+		Workflow: &workflowDetail{
 			Heading: definition.Workflow.Heading, Description: definition.Workflow.Description,
 			SubmitLabel:  definition.Workflow.SubmitLabel,
 			Inputs:       append([]ProcessInput(nil), definition.Workflow.Inputs...),
@@ -549,7 +539,7 @@ func (s *Server) handleProcess(response http.ResponseWriter, request *http.Reque
 			CanPrepare:   definition.Workflow.Prepare != nil || definition.Workflow.DurableAction,
 			CanSimulate:  definition.Workflow.Simulate != nil,
 			CanStart:     definition.Workflow.Start != nil || definition.Workflow.DurableAction,
-		}
+		},
 	}
 	writeJSON(response, http.StatusOK, detail)
 }

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -101,11 +101,11 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	}
 	var dashboard dashboardResponse
 	decodeResponse(t, response, &dashboard)
-	if response.StatusCode != http.StatusOK || len(dashboard.Processes) != 3 {
+	if response.StatusCode != http.StatusOK || len(dashboard.Processes) != 2 {
 		t.Fatalf("dashboard = %#v", dashboard)
 	}
-	if !dashboard.Processes[0].Available || dashboard.Processes[0].ID != goImagesProcessID ||
-		!dashboard.Processes[1].Available || dashboard.Processes[1].ID != "go-infra" {
+	if dashboard.Processes[0].ID != goImagesProcessID || dashboard.Processes[0].Href != "/go-images" ||
+		dashboard.Processes[1].ID != "go-infra" || dashboard.Processes[1].Href != "/go-infra" {
 
 		t.Fatalf("processes = %#v", dashboard.Processes)
 	}
@@ -167,7 +167,8 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 func TestDashboardShowsDurableProcessRun(t *testing.T) {
 	ui := newTestUI(t)
 	registry, err := newProcessRegistry(ProcessDefinition{
-		ID: "example", Name: "Example", Mark: "EX", Description: "Example process", Status: "Available", Available: true,
+		ID: "example", Name: "Example", Mark: "EX", Description: "Example process",
+		Workflow: &ProcessWorkflow{Heading: "Run example"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -215,12 +216,10 @@ func TestProcessRoutesIsolatePreparedPlans(t *testing.T) {
 	}
 	registry, err := newProcessRegistry(
 		ProcessDefinition{
-			ID: "one", Name: "One", Mark: "O", Description: "First process", Status: "Available",
-			Available: true, Workflow: workflow("one"),
+			ID: "one", Name: "One", Mark: "O", Description: "First process", Workflow: workflow("one"),
 		},
 		ProcessDefinition{
-			ID: "two", Name: "Two", Mark: "T", Description: "Second process", Status: "Available",
-			Available: true, Workflow: workflow("two"),
+			ID: "two", Name: "Two", Mark: "T", Description: "Second process", Workflow: workflow("two"),
 		},
 	)
 	if err != nil {

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -4,13 +4,11 @@ const ongoingReleases = document.querySelector("#ongoing-releases");
 const recentSection = document.querySelector("#recent-section");
 const recentReleases = document.querySelector("#recent-releases");
 const processGrid = document.querySelector("#process-grid");
-const availableCount = document.querySelector("#available-count");
 
 loadDashboard();
 
 async function loadDashboard() {
   const dashboardState = await requestJSON("/api/dashboard");
-  availableCount.textContent = String(dashboardState.processes.filter((process) => process.available).length);
   renderReleases(ongoingReleases, dashboardState.ongoing, "No release is currently being tracked in this local session.");
   processGrid.replaceChildren(...dashboardState.processes.map(createProcessCard));
   recentSection.hidden = dashboardState.recent.length === 0;
@@ -68,18 +66,13 @@ function createReleaseCard(release) {
 }
 
 function createProcessCard(process) {
-  const card = document.createElement(process.available ? "a" : "article");
+  const card = document.createElement("a");
   card.className = "process-card";
-  card.dataset.available = String(process.available);
-  if (process.available) card.href = process.href;
+  card.href = process.href;
 
   const mark = document.createElement("span");
   mark.className = "process-mark";
   mark.textContent = process.mark;
-
-  const status = document.createElement("span");
-  status.className = "process-status";
-  status.textContent = process.status;
 
   const title = document.createElement("h3");
   title.textContent = process.name;
@@ -87,9 +80,9 @@ function createProcessCard(process) {
   description.textContent = process.description;
   const action = document.createElement("span");
   action.className = "process-action";
-  action.textContent = process.available ? "Open release process →" : "Not available yet";
+  action.textContent = "Open release process →";
 
-  card.append(mark, status, title, description, action);
+  card.append(mark, title, description, action);
   return card;
 }
 

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -35,10 +35,6 @@
           Release documentation <span aria-hidden="true">↗</span>
         </a>
       </div>
-      <div class="hero-stat" aria-label="Available release processes">
-        <strong id="available-count">1</strong>
-        <span>process available</span>
-      </div>
     </section>
 
     <section class="dashboard-section" aria-labelledby="ongoing-title">
@@ -59,7 +55,7 @@
         <div>
           <p class="eyebrow">Start new work</p>
           <h2 id="processes-title">Release processes</h2>
-          <p>Choose the product to release. More processes can be added without changing this dashboard.</p>
+          <p>Choose a release process.</p>
         </div>
       </div>
       <div id="process-grid" class="process-grid" aria-live="polite"></div>

--- a/cmd/releaseagent/internal/releaseui/web/styles.css
+++ b/cmd/releaseagent/internal/releaseui/web/styles.css
@@ -275,18 +275,13 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .release-card-title strong { font-size: 15px; }
 .release-card-body p { margin: 6px 0 0; color: var(--muted); font-size: 13px; }
 .compact-button { min-height: 34px; padding: 0 12px; text-decoration: none; }
-.process-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.process-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
 .process-card { position: relative; min-height: 236px; padding: 21px; overflow: hidden; border: 1px solid var(--border); border-radius: 17px; background: linear-gradient(145deg, rgb(13 35 55 / 84%), rgb(6 19 33 / 78%)); color: inherit; text-decoration: none; transition: border-color .18s, transform .18s, background .18s; }
 a.process-card:hover { transform: translateY(-3px); border-color: rgb(57 213 255 / 46%); background: linear-gradient(145deg, rgb(19 51 73 / 90%), rgb(7 23 40 / 84%)); }
-.process-card[data-available="false"] { opacity: .52; }
 .process-mark { width: 48px; height: 48px; margin-bottom: 28px; font-size: 12px; }
-.process-card[data-available="false"] .process-mark { background: var(--surface-soft); color: var(--muted); }
-.process-status { position: absolute; top: 20px; right: 20px; padding: 6px 9px; border-radius: 99px; background: rgb(72 213 151 / 12%); color: var(--green); font-size: 11px; font-weight: 900; text-transform: uppercase; letter-spacing: 0; }
-.process-card[data-available="false"] .process-status { background: rgb(146 169 190 / 10%); color: var(--muted); }
 .process-card h3 { margin: 0; font-size: 20px; }
 .process-card p { min-height: 52px; margin: 9px 0 24px; color: var(--muted); font-size: 14px; line-height: 1.55; }
 .process-action { color: var(--cyan); font-size: 13px; font-weight: 800; }
-.process-card[data-available="false"] .process-action { color: var(--muted); }
 /* Executable release process */
 .release-main { width: min(1480px, 100%); }
 .release-hero { display: grid; grid-template-columns: auto minmax(0, 1fr) minmax(300px, 380px); align-items: center; gap: 24px; padding: 44px 0 34px; }

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -149,7 +149,11 @@
       control.placeholder = input.placeholder || "";
       control.value = input.default || "";
       control.autocomplete = "off";
-      if (input.type === "number") control.inputMode = "numeric";
+      if (input.type === "number") {
+        control.inputMode = "numeric";
+        control.min = "1";
+        control.step = "1";
+      }
       wrapper.append(label, control);
       record.controls.push(control);
       if (input.description) {


### PR DESCRIPTION
Stacked on #569.

Narrows the registry to the two release processes the UI can run today. Every registry entry must have a workflow, and the dashboard no longer carries unavailable-process status fields.

Browser inputs are limited to the contracts currently used by go-images and go-infra: fixed choices and positive integer IDs. The browser and server enforce the same positive-integer rule. The README now documents only the remaining command and supported contracts.

Validation:
- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- `git diff --check`