### PR TITLE
Add assets module with JSON contract for toolset builds

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,29 @@
+# github.com/microsoft/go-infra/assets
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/microsoft/go-infra/assets.svg)](https://pkg.go.dev/github.com/microsoft/go-infra/assets)
+
+The `assets` module defines JSON contracts for artifacts from the Microsoft build of Go.
+[`ToolsetBuild`](./assets.go) describes the artifacts produced by one toolset build.
+[`Branch`](./branch.go) describes a release branch, its support status, and stable links to its latest artifacts.
+
+Build and release tools use these models to exchange version, platform, URL, checksum, and signature information.
+
+## Why this is a separate module
+
+Some consumers of the asset format must compile with older Go releases.
+For example, a `golang.org/dl`-style version wrapper can help a user upgrade from an old Go release to the current release.
+Such a tool cannot import the main `go-infra` module because that module uses newer Go features and dependencies.
+
+The `assets` module declares Go 1.18 and contains only the data model.
+Code that parses versions, updates repositories, or applies release policy remains in the main `go-infra` module.
+This boundary lets older tools read current asset files without importing the build and release implementation.
+
+## Compatibility
+
+The JSON field names are part of the contract between build producers and consumers.
+Changes to the model must continue to decode existing asset files and support tools that use Go 1.18.
+
+## Origin
+
+The `ToolsetBuild` model was originally based on the [`golang` Docker Official Image `versions.json` model](https://github.com/docker-library/golang/blob/master/versions.json).
+Later changes made the model a general source of release information for the Microsoft build of Go.

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Package assets defines JSON contracts for Microsoft build of Go artifacts.
 package assets
 
 // ToolsetBuild describes the artifacts produced by a toolset build of the Microsoft build of Go.

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package assets
+
+// ToolsetBuild describes the artifacts produced by a toolset build of the Microsoft build of Go.
+type ToolsetBuild struct {
+	// Branch is the Git branch that the build used. Only includes the last segment, e.g.
+	// "release-branch.go1.27".
+	Branch string `json:"branch"`
+
+	// BuildID identifies the Azure DevOps pipeline build that produced the artifacts.
+	BuildID string `json:"buildId"`
+
+	// Version is the Go version and Microsoft revision, such as "1.24.1-2" or "main-1".
+	Version string `json:"version"`
+
+	// Arches contains the artifacts produced for this version. Each binary artifact has a target
+	// operating system and architecture. A source archive has no Env. The field name matches the
+	// versions.json format.
+	Arches []*Arch `json:"arches"`
+
+	// GoSrcURL is the download URL for the source archive used by the build. Arches can also
+	// contain this source archive as an entry with no Env.
+	GoSrcURL string `json:"goSrcURL"`
+
+	// GoSrcSHA256 is the hexadecimal SHA-256 digest of the archive at GoSrcURL.
+	GoSrcSHA256 string `json:"goSrcSHA256"`
+}
+
+// Arch describes one downloadable build artifact.
+type Arch struct {
+	// Env identifies the target environment for a binary artifact.
+	// Env is nil for a source archive.
+	Env *ArchEnv `json:"env,omitempty"`
+
+	// SHA256 is the hexadecimal SHA-256 digest of the artifact at URL.
+	SHA256 string `json:"sha256"`
+
+	// Supported indicates that Docker tooling should generate an image for this artifact. The field
+	// name matches the upstream Go image format.
+	Supported bool `json:"supported,omitempty"`
+
+	// URL is the download URL for the artifact.
+	URL string `json:"url"`
+
+	// SHA256ChecksumURL is the download URL for a checksum file accepted by "sha256sum -c". An
+	// empty value indicates URL with ".sha256" appended.
+	SHA256ChecksumURL string `json:"sha256ChecksumUrl,omitempty"`
+
+	// PGPSignatureURL is the download URL for the artifact's PGP signature. An empty value
+	// indicates URL with ".sig" appended.
+	PGPSignatureURL string `json:"pgpSignatureUrl,omitempty"`
+}
+
+// ArchEnv identifies the Go target environment for a binary artifact.
+type ArchEnv struct {
+	// GOARCH is the target architecture.
+	GOARCH string `json:",omitempty"`
+
+	// GOARM is the target ARM architecture version.
+	GOARM string `json:",omitempty"`
+
+	// GOOS is the target operating system.
+	GOOS string `json:",omitempty"`
+}

--- a/assets/assets_test.go
+++ b/assets/assets_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package assets
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestToolsetBuildJSON(t *testing.T) {
+	value := &ToolsetBuild{
+		Branch:  "release-branch.go1.24",
+		BuildID: "12345",
+		Version: "1.24.1-2",
+		Arches: []*Arch{
+			{
+				Env:       &ArchEnv{GOARCH: "amd64", GOOS: "linux"},
+				SHA256:    "binary-sha256",
+				Supported: true,
+				URL:       "https://example.com/go-linux-amd64.tar.gz",
+			},
+			{
+				SHA256: "source-sha256",
+				URL:    "https://example.com/go-src.tar.gz",
+			},
+		},
+		GoSrcURL:    "https://example.com/go-src.tar.gz",
+		GoSrcSHA256: "source-sha256",
+	}
+	want := `{"branch":"release-branch.go1.24","buildId":"12345","version":"1.24.1-2","arches":[{"env":{"GOARCH":"amd64","GOOS":"linux"},"sha256":"binary-sha256","supported":true,"url":"https://example.com/go-linux-amd64.tar.gz"},{"sha256":"source-sha256","url":"https://example.com/go-src.tar.gz"}],"goSrcURL":"https://example.com/go-src.tar.gz","goSrcSHA256":"source-sha256"}`
+
+	testJSONRoundTrip(t, value, want, &ToolsetBuild{})
+}
+
+func TestBranchJSON(t *testing.T) {
+	value := &Branch{
+		Version:      "1.24",
+		Stable:       true,
+		LatestStable: true,
+		Files: []*LatestLink{
+			{
+				Filename: "go1.24.1.src.tar.gz",
+				Version:  "1.24.1-2",
+				Kind:     Source,
+				URL:      "https://aka.ms/golang/release/latest/go1.24.src.tar.gz",
+			},
+		},
+	}
+	want := `{"version":"1.24","stable":true,"latestStable":true,"files":[{"filename":"go1.24.1.src.tar.gz","version":"1.24.1-2","kind":"source","url":"https://aka.ms/golang/release/latest/go1.24.src.tar.gz"}]}`
+
+	testJSONRoundTrip(t, value, want, &Branch{})
+}
+
+func testJSONRoundTrip(t *testing.T, value any, want string, decoded any) {
+	t.Helper()
+
+	got, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("json.Marshal() = %s, want %s", got, want)
+	}
+
+	if err := json.Unmarshal([]byte(want), decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := reflect.ValueOf(decoded).Elem().Interface(); !reflect.DeepEqual(got, reflect.ValueOf(value).Elem().Interface()) {
+		t.Errorf("json.Unmarshal() = %#v, want %#v", got, value)
+	}
+}

--- a/assets/branch.go
+++ b/assets/branch.go
@@ -51,10 +51,10 @@ type LatestLink struct {
 	Filename string `json:"filename"`
 
 	// OS is the target operating system, if the artifact is platform-specific.
-	OS string `json:"os"`
+	OS string `json:"os,omitempty"`
 
 	// Arch is the target architecture, if the artifact is platform-specific.
-	Arch string `json:"arch"`
+	Arch string `json:"arch,omitempty"`
 
 	// Version is the full Go version available through URL.
 	Version string `json:"version"`

--- a/assets/branch.go
+++ b/assets/branch.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package assets
+
+// Branch describes the support status and available artifacts for one branch of the Microsoft
+// build of Go.
+type Branch struct {
+	// Version is the Go major and minor version for the branch, such as "1.20".
+	Version string `json:"version,omitempty"`
+
+	// Stable indicates that the branch contains a stable release.
+	Stable bool `json:"stable,omitempty"`
+
+	// LatestStable indicates that the branch contains the most recent stable release.
+	LatestStable bool `json:"latestStable,omitempty"`
+
+	// PreviousStable indicates that the branch contains the stable release immediately before the
+	// latest one.
+	PreviousStable bool `json:"previousStable,omitempty"`
+
+	// Files contains the links for the latest artifacts available from the branch.
+	Files []*LatestLink `json:"files,omitempty"`
+}
+
+// ArtifactKind identifies the type of artifact referenced by a LatestLink.
+type ArtifactKind string
+
+const (
+	// Archive identifies a ".zip" or ".tar.gz" toolset archive for a specific platform.
+	Archive ArtifactKind = "archive"
+
+	// Installer identifies a platform-specific installer. The project doesn't currently produce any
+	// installers.
+	Installer ArtifactKind = "installer"
+
+	// Source identifies a ".tar.gz" source archive.
+	Source ArtifactKind = "source"
+
+	// Manifest identifies a JSON file that contains a [ToolsetBuild].
+	Manifest ArtifactKind = "manifest"
+)
+
+// LatestLink describes the stable URLs for the latest version of one artifact on a branch.
+//
+// During a release, aka.ms links can change between downloads, so a checksum or signature
+// downloaded after the artifact can refer to a different build. To avoid this race, download the
+// [Manifest] artifact first and use the URLs from the resulting [ToolsetBuild].
+type LatestLink struct {
+	// Filename is the name of the artifact.
+	Filename string `json:"filename"`
+
+	// OS is the target operating system, if the artifact is platform-specific.
+	OS string `json:"os"`
+
+	// Arch is the target architecture, if the artifact is platform-specific.
+	Arch string `json:"arch"`
+
+	// Version is the full Go version available through URL.
+	Version string `json:"version"`
+
+	// Kind identifies the type of artifact.
+	Kind ArtifactKind `json:"kind"`
+
+	// URL is the aka.ms URL for the latest patch version of the artifact.
+	URL string `json:"url,omitempty"`
+
+	// ChecksumURL is the aka.ms URL for the artifact's checksum file. ChecksumURL is empty if the
+	// artifact has no checksum file.
+	ChecksumURL string `json:"checksumURL,omitempty"`
+
+	// SignatureURL is the aka.ms URL for the artifact's signature file. SignatureURL is empty if
+	// the artifact has no signature file.
+	SignatureURL string `json:"signatureURL,omitempty"`
+}

--- a/assets/go.mod
+++ b/assets/go.mod
@@ -1,0 +1,3 @@
+module github.com/microsoft/go-infra/assets
+
+go 1.18


### PR DESCRIPTION
* For https://github.com/microsoft/go-lab/issues/282
* For https://github.com/microsoft/go/issues/146
* For https://github.com/microsoft/go-lab/issues/201

This module allows us to use this contract from a golang.org/dl style tool without duplicating the definitions.

It also formalizes the `Branch` support structure that's currently only in the obscure `_util` module. We are considering publishing these to a production-ready location (the same CDN as our other artifacts) to remove some concerns with using them.

Next steps after merging:

* Create tag `assets/v0.0.1`.
* Use this module in `go-infra` and `_util` and remove duplicate definitions.
* Use this module in the dl tool with minimized go dependency.