### PR TITLE
releaseagent: remove optional Azure timeline detail

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -121,12 +121,12 @@ Test runs are fixed to `dev/`.
 Do not confirm a real execution without authorization.
 
 The review page renders the coordinator DAG as a left-to-right dependency graph.
-Steps at the same dependency depth are grouped vertically and labeled as parallel work, so future release processes can expose fan-out and fan-in directly.
-During the pipeline wait step, the existing SSE stream also shows the active Azure stage/job/task paths, stage/job/task completion counts, and a stage progress bar.
-Lightweight build status is checked every five seconds; the much larger Azure timeline is refreshed every 30 seconds.
-Timeline detail is ephemeral UI state and is not written to the durable session file.
+The current go-images graph is a linear mirror, queue, and monitor sequence.
+During the pipeline wait step, the existing SSE stream reports whether the Azure build is queued,
+running, or complete. Build status is checked every five seconds, and the UI links to Azure DevOps
+for stage, job, and task details.
 
-Azure Pipeline definition metadata and timelines, plus Azure Repos reads, use the official Azure DevOps Go SDK.
+Azure Pipeline definition metadata and Azure Repos reads use the official Azure DevOps Go SDK.
 The generated SDK's `build.Build` model omits run-level `templateParameters`.
 Custom REST calls are therefore limited to build retrieval and listing, where those parameters are required, and parameterized queueing.
 The generated `Build.Parameters` field can carry the legacy correlation variables, but `QueueBuild` cannot emit the `templateParameters` required for the full queue payload.

--- a/cmd/releaseagent/internal/azdopipeline/client.go
+++ b/cmd/releaseagent/internal/azdopipeline/client.go
@@ -43,15 +43,10 @@ type Client struct {
 	http                HTTPDoer
 	tokens              TokenProvider
 	newDefinitionClient func(context.Context) (definitionClient, string, error)
-	newTimelineClient   func(context.Context) (timelineClient, string, error)
 }
 
 type definitionClient interface {
 	GetDefinition(context.Context, azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error)
-}
-
-type timelineClient interface {
-	GetBuildTimeline(context.Context, azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error)
 }
 
 // Build is the release UI's stable view of an Azure Pipelines run.
@@ -76,23 +71,6 @@ type Definition struct {
 	DefaultBranch string
 	Repository    string
 	YAMLPath      string
-}
-
-// Timeline is the execution hierarchy of an Azure Pipelines build.
-type Timeline struct {
-	Records []TimelineRecord
-}
-
-// TimelineRecord is one stage, phase, job, task, or other timeline node. ParentID links records
-// into the hierarchy returned by Azure DevOps.
-type TimelineRecord struct {
-	ID       string
-	ParentID string
-	Type     string
-	Name     string
-	State    string
-	Result   string
-	Order    int
 }
 
 // RunState is the normalized lifecycle of an Azure Pipelines run.
@@ -140,7 +118,6 @@ func NewClient(baseURL, project string, httpClient HTTPDoer, tokens TokenProvide
 		tokens:  tokens,
 	}
 	client.newDefinitionClient = client.createDefinitionClient
-	client.newTimelineClient = client.createTimelineClient
 	return client, nil
 }
 
@@ -155,45 +132,6 @@ func (c *Client) Get(ctx context.Context, buildID int) (*Build, error) {
 		return nil, err
 	}
 	return response.build()
-}
-
-// GetTimeline returns the current stage, job, and task hierarchy for one pipeline run.
-func (c *Client) GetTimeline(ctx context.Context, buildID int) (*Timeline, error) {
-	if buildID <= 0 {
-		return nil, errors.New("build ID must be positive")
-	}
-	client, token, err := c.newTimelineClient(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("create Azure DevOps Build client: %w", redactError(err, token))
-	}
-	response, err := client.GetBuildTimeline(ctx, azdobuild.GetBuildTimelineArgs{
-		Project: &c.project, BuildId: &buildID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get Azure DevOps build timeline: %w", redactError(err, token))
-	}
-	timeline := &Timeline{}
-	if response == nil || response.Records == nil {
-		return timeline, nil
-	}
-	timeline.Records = make([]TimelineRecord, 0, len(*response.Records))
-	for _, record := range *response.Records {
-		mapped := TimelineRecord{
-			Type: stringValue(record.Type), Name: stringValue(record.Name),
-			State: enumValue(record.State), Result: enumValue(record.Result),
-		}
-		if record.Id != nil {
-			mapped.ID = record.Id.String()
-		}
-		if record.ParentId != nil {
-			mapped.ParentID = record.ParentId.String()
-		}
-		if record.Order != nil {
-			mapped.Order = *record.Order
-		}
-		timeline.Records = append(timeline.Records, mapped)
-	}
-	return timeline, nil
 }
 
 // GetDefinition returns read-only metadata used to verify an allowlisted pipeline target.
@@ -225,11 +163,6 @@ func (c *Client) GetDefinition(ctx context.Context, definitionID int) (*Definiti
 }
 
 func (c *Client) createDefinitionClient(ctx context.Context) (definitionClient, string, error) {
-	client, token, err := c.createBuildClient(ctx)
-	return client, token, err
-}
-
-func (c *Client) createTimelineClient(ctx context.Context) (timelineClient, string, error) {
 	client, token, err := c.createBuildClient(ctx)
 	return client, token, err
 }

--- a/cmd/releaseagent/internal/azdopipeline/client_test.go
+++ b/cmd/releaseagent/internal/azdopipeline/client_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	azdobuild "github.com/microsoft/azure-devops-go-api/azuredevops/build"
 )
 
@@ -22,12 +21,6 @@ func (t staticToken) Token(context.Context) (string, error) { return string(t), 
 type definitionClientFunc func(context.Context, azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error)
 
 func (f definitionClientFunc) GetDefinition(ctx context.Context, args azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error) {
-	return f(ctx, args)
-}
-
-type timelineClientFunc func(context.Context, azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error)
-
-func (f timelineClientFunc) GetBuildTimeline(ctx context.Context, args azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error) {
 	return f(ctx, args)
 }
 
@@ -98,43 +91,6 @@ func TestGetDefinition(t *testing.T) {
 }
 
 func idPointer(value int) *int { return &value }
-
-func stringPointer(value string) *string { return &value }
-
-func TestGetTimeline(t *testing.T) {
-	client, err := NewClient("https://example.invalid", "internal", http.DefaultClient, staticToken("test-token"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	stageID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	jobID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
-	taskID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
-	inProgress := azdobuild.TimelineRecordStateValues.InProgress
-	succeeded := azdobuild.TaskResultValues.Succeeded
-	client.newTimelineClient = func(context.Context) (timelineClient, string, error) {
-		return timelineClientFunc(func(_ context.Context, args azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error) {
-			if args.Project == nil || *args.Project != "internal" || args.BuildId == nil || *args.BuildId != 888 {
-				t.Fatalf("timeline args = %#v", args)
-			}
-			records := []azdobuild.TimelineRecord{
-				{Id: &stageID, Type: stringPointer("Stage"), Name: stringPointer("Build"), State: &inProgress, Order: idPointer(1)},
-				{Id: &jobID, ParentId: &stageID, Type: stringPointer("Job"), Name: stringPointer("linux-amd64"), State: &inProgress, Order: idPointer(2)},
-				{Id: &taskID, ParentId: &jobID, Type: stringPointer("Task"), Name: stringPointer("Build image"), State: &inProgress, Result: &succeeded, Order: idPointer(3)},
-			}
-			return &azdobuild.Timeline{Records: &records}, nil
-		}), "test-token", nil
-	}
-	timeline, err := client.GetTimeline(context.Background(), 888)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(timeline.Records) != 3 || timeline.Records[2].Name != "Build image" ||
-		timeline.Records[2].ParentID != jobID.String() || timeline.Records[0].Type != "Stage" ||
-		timeline.Records[2].Result != "succeeded" || timeline.Records[2].Order != 3 {
-
-		t.Fatalf("timeline = %#v", timeline)
-	}
-}
 
 func TestRunState(t *testing.T) {
 	for _, test := range []struct {

--- a/cmd/releaseagent/internal/coordinator/runner.go
+++ b/cmd/releaseagent/internal/coordinator/runner.go
@@ -42,15 +42,13 @@ type StepSnapshot struct {
 	FinishedAt *time.Time    `json:"finishedAt,omitempty"`
 }
 
-// StepProgress is optional live detail reported by a running step. Summary and Detail are short
-// human-readable strings. Items contains active sub-operations, while Completed and Total can be
-// used to render a determinate progress indicator when Total is positive.
+// StepProgress is optional live detail reported by a running step. Completed and Total can render
+// a determinate progress indicator when Total is positive.
 type StepProgress struct {
-	Summary   string   `json:"summary,omitempty"`
-	Detail    string   `json:"detail,omitempty"`
-	Items     []string `json:"items,omitempty"`
-	Completed int      `json:"completed,omitempty"`
-	Total     int      `json:"total,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+	Completed int    `json:"completed,omitempty"`
+	Total     int    `json:"total,omitempty"`
 }
 
 type progressReporterKey struct{}
@@ -191,7 +189,7 @@ func (r *StepRunner) snapshotLocked() Snapshot {
 			DependsOn: make([]string, len(state.step.DependsOn)),
 		}
 		if state.progress != nil {
-			progress := cloneStepProgress(*state.progress)
+			progress := *state.progress
 			stepSnapshot.Progress = &progress
 		}
 		for i, dependency := range state.step.DependsOn {
@@ -234,26 +232,15 @@ func (r *StepRunner) reportProgress(state *stepState, progress StepProgress) {
 	if state.status != StepStatusRunning || stepProgressEqual(state.progress, progress) {
 		return
 	}
-	cloned := cloneStepProgress(progress)
-	state.progress = &cloned
+	state.progress = &progress
 	r.publishLocked()
-}
-
-func cloneStepProgress(progress StepProgress) StepProgress {
-	progress.Items = append([]string(nil), progress.Items...)
-	return progress
 }
 
 func stepProgressEqual(current *StepProgress, next StepProgress) bool {
 	if current == nil || current.Summary != next.Summary || current.Detail != next.Detail ||
-		current.Completed != next.Completed || current.Total != next.Total || len(current.Items) != len(next.Items) {
+		current.Completed != next.Completed || current.Total != next.Total {
 
 		return false
-	}
-	for index := range current.Items {
-		if current.Items[index] != next.Items[index] {
-			return false
-		}
 	}
 	return true
 }

--- a/cmd/releaseagent/internal/coordinator/runner_test.go
+++ b/cmd/releaseagent/internal/coordinator/runner_test.go
@@ -100,16 +100,13 @@ func TestStepRunnerSnapshots(t *testing.T) {
 func TestStepRunnerProgressSnapshots(t *testing.T) {
 	reported := make(chan struct{})
 	releaseStep := make(chan struct{})
-	items := []string{"Build › linux-amd64 › Compile"}
 	step := NewRootStep("Progress step", NoTimeout, func(ctx context.Context) error {
 		ReportProgress(ctx, StepProgress{
 			Summary:   "Running one pipeline task",
 			Detail:    "1/3 stages complete",
-			Items:     items,
 			Completed: 1,
 			Total:     3,
 		})
-		items[0] = "mutated after reporting"
 		close(reported)
 		select {
 		case <-ctx.Done():
@@ -137,14 +134,10 @@ func TestStepRunnerProgressSnapshots(t *testing.T) {
 		t.Fatalf("snapshot has no progress: %#v", snapshot)
 	}
 	progress := snapshot.Steps[0].Progress
-	if progress.Summary != "Running one pipeline task" || progress.Completed != 1 || progress.Total != 3 ||
-		len(progress.Items) != 1 || progress.Items[0] != "Build › linux-amd64 › Compile" {
+	if progress.Summary != "Running one pipeline task" || progress.Detail != "1/3 stages complete" ||
+		progress.Completed != 1 || progress.Total != 3 {
 
 		t.Fatalf("progress = %#v", progress)
-	}
-	progress.Items[0] = "mutated snapshot"
-	if got := runner.Snapshot().Steps[0].Progress.Items[0]; got != "Build › linux-amd64 › Compile" {
-		t.Fatalf("snapshot mutation changed runner state: %q", got)
 	}
 
 	sawProgressUpdate := false

--- a/cmd/releaseagent/internal/goimagesexecution/service.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service.go
@@ -12,9 +12,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
@@ -41,7 +39,6 @@ var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 // PipelineReader is the read-only Azure DevOps behavior required for reconciliation and polling.
 type PipelineReader interface {
 	Get(context.Context, int) (*azdopipeline.Build, error)
-	GetTimeline(context.Context, int) (*azdopipeline.Timeline, error)
 	ListRecent(context.Context, int) ([]*azdopipeline.Build, error)
 }
 
@@ -71,7 +68,6 @@ type Config struct {
 	VerifyMirrorCommit   func(context.Context, string) error
 	MirrorPollInterval   time.Duration
 	PollInterval         time.Duration
-	TimelinePollInterval time.Duration
 	PreviousQueueAttempt bool
 	ReconcileAttempts    int
 	ReconcileInterval    time.Duration
@@ -82,13 +78,12 @@ type Sleeper func(context.Context, time.Duration) error
 
 // Service implements only the queue-and-monitor surface required by the focused DAG.
 type Service struct {
-	reader            PipelineReader
-	queue             QueueClient
-	config            Config
-	parameters        map[string]string
-	versionSet        string
-	sleep             Sleeper
-	timelinePollEvery int
+	reader     PipelineReader
+	queue      QueueClient
+	config     Config
+	parameters map[string]string
+	versionSet string
+	sleep      Sleeper
 }
 
 // New validates and creates a go-images release service.
@@ -119,9 +114,6 @@ func New(reader PipelineReader, queue QueueClient, config Config, sleeper Sleepe
 	if config.MirrorPollInterval <= 0 {
 		config.MirrorPollInterval = 5 * time.Second
 	}
-	if config.TimelinePollInterval <= 0 {
-		config.TimelinePollInterval = 30 * time.Second
-	}
 	if config.ReconcileAttempts <= 0 {
 		config.ReconcileAttempts = 6
 	}
@@ -131,13 +123,9 @@ func New(reader PipelineReader, queue QueueClient, config Config, sleeper Sleepe
 	if sleeper == nil {
 		sleeper = sleepContext
 	}
-	timelinePollEvery := int((config.TimelinePollInterval + config.PollInterval - 1) / config.PollInterval)
-	if timelinePollEvery < 1 {
-		timelinePollEvery = 1
-	}
 	return &Service{
 		reader: reader, queue: queue, config: config, parameters: parameters, versionSet: versionSet,
-		sleep: sleeper, timelinePollEvery: timelinePollEvery,
+		sleep: sleeper,
 	}, nil
 }
 
@@ -272,7 +260,6 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 	if err != nil || id <= 0 {
 		return fmt.Errorf("invalid go-images release build ID %q", buildID)
 	}
-	pollsUntilTimeline := 0
 	for {
 		build, err := s.reader.Get(ctx, id)
 		if err != nil {
@@ -301,11 +288,7 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 			})
 			return fmt.Errorf("go-images release build %d finished with state %q and result %q: %s", id, state, build.Result, build.WebURL)
 		case azdopipeline.RunStateWaiting, azdopipeline.RunStateRunning:
-			if pollsUntilTimeline == 0 {
-				s.reportPipelineProgress(ctx, id, state)
-				pollsUntilTimeline = s.timelinePollEvery
-			}
-			pollsUntilTimeline--
+			s.reportPipelineProgress(ctx, id, state)
 			if err := s.sleep(ctx, s.config.PollInterval); err != nil {
 				return err
 			}
@@ -322,137 +305,9 @@ func (s *Service) reportPipelineProgress(ctx context.Context, buildID int, state
 	}
 	if state == azdopipeline.RunStateRunning {
 		progress.Summary = "Azure pipeline is running"
-		progress.Detail = fmt.Sprintf("Reading live stage details for build %d", buildID)
-	}
-	timeline, err := s.reader.GetTimeline(ctx, buildID)
-	if err == nil && timeline != nil {
-		progress = timelineStepProgress(buildID, state, timeline.Records)
-	} else if state == azdopipeline.RunStateRunning {
-		progress.Detail = "Detailed Azure stage status is not available yet"
+		progress.Detail = fmt.Sprintf("Build %d is in progress", buildID)
 	}
 	coordinator.ReportProgress(ctx, progress)
-}
-
-func timelineStepProgress(
-	buildID int,
-	state azdopipeline.RunState,
-	records []azdopipeline.TimelineRecord,
-) coordinator.StepProgress {
-	progress := coordinator.StepProgress{
-		Summary: "Azure pipeline is running",
-		Detail:  fmt.Sprintf("Build %d is running", buildID),
-	}
-	if state == azdopipeline.RunStateWaiting {
-		progress.Summary = "Azure pipeline is queued"
-		progress.Detail = fmt.Sprintf("Build %d is waiting to start", buildID)
-	}
-	byID := make(map[string]azdopipeline.TimelineRecord, len(records))
-	byType := make(map[string][]azdopipeline.TimelineRecord)
-	for _, record := range records {
-		byID[record.ID] = record
-		typeName := strings.ToLower(record.Type)
-		switch typeName {
-		case "stage", "job", "task":
-			byType[typeName] = append(byType[typeName], record)
-		}
-	}
-
-	var countDetails []string
-	for _, typeName := range []string{"stage", "job", "task"} {
-		total := len(byType[typeName])
-		if total == 0 {
-			continue
-		}
-		completed := 0
-		for _, record := range byType[typeName] {
-			if strings.EqualFold(record.State, "completed") {
-				completed++
-			}
-		}
-		countDetails = append(countDetails, fmt.Sprintf("%d/%d %ss", completed, total, typeName))
-		if typeName == "stage" {
-			progress.Completed = completed
-			progress.Total = total
-		}
-	}
-	if len(countDetails) != 0 {
-		progress.Detail = fmt.Sprintf("Build %d · %s complete", buildID, strings.Join(countDetails, " · "))
-	}
-
-	activeType := ""
-	var active []azdopipeline.TimelineRecord
-	for _, typeName := range []string{"task", "job", "stage"} {
-		for _, record := range byType[typeName] {
-			if strings.EqualFold(record.State, "inProgress") {
-				active = append(active, record)
-			}
-		}
-		if len(active) != 0 {
-			activeType = typeName
-			break
-		}
-	}
-	sort.SliceStable(active, func(left, right int) bool {
-		if active[left].Order != active[right].Order {
-			return active[left].Order < active[right].Order
-		}
-		return active[left].Name < active[right].Name
-	})
-
-	seen := make(map[string]struct{}, len(active))
-	const maxItems = 8
-	for _, record := range active {
-		path := timelineRecordPath(record, byID)
-		if path == "" {
-			continue
-		}
-		if _, exists := seen[path]; exists {
-			continue
-		}
-		seen[path] = struct{}{}
-		if len(progress.Items) < maxItems {
-			progress.Items = append(progress.Items, path)
-		}
-	}
-	if len(seen) == 1 && len(active) != 0 {
-		progress.Summary = "Running: " + active[0].Name
-	} else if len(seen) > 1 {
-		progress.Summary = fmt.Sprintf("Running %d pipeline %ss in parallel", len(seen), activeType)
-	}
-	if hidden := len(seen) - len(progress.Items); hidden > 0 {
-		progress.Items = append(progress.Items, fmt.Sprintf("… and %d more active %ss", hidden, activeType))
-	}
-	return progress
-}
-
-func timelineRecordPath(
-	record azdopipeline.TimelineRecord,
-	byID map[string]azdopipeline.TimelineRecord,
-) string {
-	var reversed []string
-	visited := make(map[string]struct{})
-	for current := record; current.ID != ""; {
-		if _, exists := visited[current.ID]; exists {
-			break
-		}
-		visited[current.ID] = struct{}{}
-		switch strings.ToLower(current.Type) {
-		case "stage", "job", "task":
-			if current.Name != "" {
-				reversed = append(reversed, current.Name)
-			}
-		}
-		parent, exists := byID[current.ParentID]
-		if !exists {
-			break
-		}
-		current = parent
-	}
-	path := make([]string, len(reversed))
-	for index := range reversed {
-		path[len(reversed)-1-index] = reversed[index]
-	}
-	return strings.Join(path, " › ")
 }
 
 func sleepContext(ctx context.Context, duration time.Duration) error {

--- a/cmd/releaseagent/internal/goimagesexecution/service_test.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service_test.go
@@ -12,17 +12,14 @@ import (
 	"time"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
-	"github.com/microsoft/go-infra/cmd/releaseagent/internal/coordinator"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesworkflow"
 )
 
 type fakeReader struct {
-	builds       []*azdopipeline.Build
-	recent       [][]*azdopipeline.Build
-	timelines    []*azdopipeline.Timeline
-	gets         int
-	lists        int
-	timelineGets int
+	builds []*azdopipeline.Build
+	recent [][]*azdopipeline.Build
+	gets   int
+	lists  int
 }
 
 func (r *fakeReader) Get(context.Context, int) (*azdopipeline.Build, error) {
@@ -44,18 +41,6 @@ func (r *fakeReader) ListRecent(context.Context, int) ([]*azdopipeline.Build, er
 		index = len(r.recent) - 1
 	}
 	return r.recent[index], nil
-}
-
-func (r *fakeReader) GetTimeline(context.Context, int) (*azdopipeline.Timeline, error) {
-	index := r.timelineGets
-	r.timelineGets++
-	if len(r.timelines) == 0 {
-		return &azdopipeline.Timeline{}, nil
-	}
-	if index >= len(r.timelines) {
-		index = len(r.timelines) - 1
-	}
-	return r.timelines[index], nil
 }
 
 type fakeQueueClient struct {
@@ -253,11 +238,7 @@ func TestPollPipeline(t *testing.T) {
 	reader := &fakeReader{builds: []*azdopipeline.Build{
 		{ID: 888, DefinitionID: DefinitionID, Status: "inProgress"},
 		{ID: 888, DefinitionID: DefinitionID, Status: "completed", Result: "succeeded"},
-	}, timelines: []*azdopipeline.Timeline{{Records: []azdopipeline.TimelineRecord{
-		{ID: "stage", Type: "Stage", Name: "Build and test", State: "inProgress", Order: 1},
-		{ID: "job", ParentID: "stage", Type: "Job", Name: "linux-amd64", State: "inProgress", Order: 2},
-		{ID: "task", ParentID: "job", Type: "Task", Name: "Build image", State: "inProgress", Order: 3},
-	}}}}
+	}}
 	sleeps := 0
 	service, err := New(reader, &fakeQueueClient{}, completeConfig(Config{
 		Mode: goimagesworkflow.ModeNormal,
@@ -268,80 +249,11 @@ func TestPollPipeline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	step := coordinator.NewRootStep("Wait", coordinator.NoTimeout, func(ctx context.Context) error {
-		return service.PollPipeline(ctx, "888")
-	})
-	var runner coordinator.StepRunner
-	_, updates, unsubscribe := runner.Subscribe(32)
-	defer unsubscribe()
-	if err := runner.Execute(context.Background(), []*coordinator.Step{step}); err != nil {
-		t.Fatal(err)
-	}
-	if reader.gets != 2 || reader.timelineGets != 1 || sleeps != 1 {
-		t.Fatalf("gets = %d, timeline gets = %d, sleeps = %d", reader.gets, reader.timelineGets, sleeps)
-	}
-	foundTimelineProgress := false
-drain:
-	for {
-		select {
-		case snapshot := <-updates:
-			for _, candidate := range snapshot.Steps {
-				if candidate.Progress != nil && len(candidate.Progress.Items) == 1 &&
-					candidate.Progress.Items[0] == "Build and test › linux-amd64 › Build image" {
-
-					foundTimelineProgress = true
-				}
-			}
-		default:
-			break drain
-		}
-	}
-	if !foundTimelineProgress {
-		t.Fatal("runner snapshots did not include the active Azure timeline path")
-	}
-}
-
-func TestTimelineStepProgressShowsParallelWork(t *testing.T) {
-	progress := timelineStepProgress(888, azdopipeline.RunStateRunning, []azdopipeline.TimelineRecord{
-		{ID: "stage", Type: "Stage", Name: "Publish", State: "inProgress"},
-		{ID: "job-a", ParentID: "stage", Type: "Job", Name: "linux-amd64", State: "inProgress", Order: 1},
-		{ID: "task-a", ParentID: "job-a", Type: "Task", Name: "Push image", State: "inProgress", Order: 2},
-		{ID: "job-b", ParentID: "stage", Type: "Job", Name: "windows-amd64", State: "inProgress", Order: 3},
-		{ID: "task-b", ParentID: "job-b", Type: "Task", Name: "Push image", State: "inProgress", Order: 4},
-		{ID: "done", Type: "Stage", Name: "Build", State: "completed", Result: "succeeded"},
-	})
-	if progress.Summary != "Running 2 pipeline tasks in parallel" || progress.Completed != 1 || progress.Total != 2 {
-		t.Fatalf("progress = %#v", progress)
-	}
-	if len(progress.Items) != 2 || progress.Items[0] != "Publish › linux-amd64 › Push image" ||
-		progress.Items[1] != "Publish › windows-amd64 › Push image" {
-
-		t.Fatalf("items = %#v", progress.Items)
-	}
-}
-
-func TestTimelinePollingIsThrottled(t *testing.T) {
-	reader := &fakeReader{timelines: []*azdopipeline.Timeline{{}}}
-	for range 7 {
-		reader.builds = append(reader.builds, &azdopipeline.Build{
-			ID: 888, DefinitionID: DefinitionID, Status: "inProgress",
-		})
-	}
-	reader.builds = append(reader.builds, &azdopipeline.Build{
-		ID: 888, DefinitionID: DefinitionID, Status: "completed", Result: "succeeded",
-	})
-	config := completeConfig(Config{Mode: goimagesworkflow.ModeNormal})
-	config.PollInterval = time.Millisecond
-	config.TimelinePollInterval = 3 * time.Millisecond
-	service, err := New(reader, &fakeQueueClient{}, config, func(context.Context, time.Duration) error { return nil })
-	if err != nil {
-		t.Fatal(err)
-	}
 	if err := service.PollPipeline(context.Background(), "888"); err != nil {
 		t.Fatal(err)
 	}
-	if reader.gets != 8 || reader.timelineGets != 3 {
-		t.Fatalf("build polls = %d, timeline polls = %d; want 8 and 3", reader.gets, reader.timelineGets)
+	if reader.gets != 2 || sleeps != 1 {
+		t.Fatalf("gets = %d, sleeps = %d", reader.gets, sleeps)
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/web/styles.css
+++ b/cmd/releaseagent/internal/releaseui/web/styles.css
@@ -247,10 +247,6 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .step-progress-detail { margin: 5px 0 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
 .step-progress-track { height: 4px; margin-top: 9px; overflow: hidden; border-radius: 99px; background: #1a3045; }
 .step-progress-track span { display: block; width: 0; height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--cyan-deep), var(--green)); transition: width .25s ease; }
-.step-progress-items { display: grid; gap: 5px; margin: 9px 0 0; padding: 0; list-style: none; }
-.step-progress-items li { position: relative; padding-left: 11px; color: #b8cede; font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
-.step-progress-items li::before { position: absolute; top: .55em; left: 0; width: 4px; height: 4px; border-radius: 50%; background: var(--cyan); box-shadow: 0 0 7px rgb(57 213 255 / 55%); content: ""; }
-
 .toast { position: fixed; right: 24px; bottom: 24px; z-index: 30; max-width: min(440px, calc(100vw - 48px)); padding: 14px 17px; border: 1px solid rgb(255 123 135 / 40%); border-radius: 12px; background: #381824; color: #ffdce0; box-shadow: var(--shadow); font-size: 12px; line-height: 1.45; }
 
 /* Release dashboard */

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -423,9 +423,7 @@
     progressTrack.hidden = true;
     const progressFill = document.createElement("span");
     progressTrack.append(progressFill);
-    const progressItems = document.createElement("ul");
-    progressItems.className = "step-progress-items";
-    liveProgress.append(progressSummary, progressDetail, progressTrack, progressItems);
+    liveProgress.append(progressSummary, progressDetail, progressTrack);
     item.append(head, liveProgress);
     return item;
   }
@@ -570,13 +568,6 @@
     track.querySelector("span").style.width = progress.total > 0
       ? `${Math.max(0, Math.min(100, Math.round((progress.completed / progress.total) * 100)))}%`
       : "0";
-    const items = container.querySelector(".step-progress-items");
-    items.replaceChildren(...(progress.items || []).map((item) => {
-      const row = document.createElement("li");
-      row.textContent = item;
-      return row;
-    }));
-    items.hidden = !(progress.items || []).length;
   }
 
   function updateProgress(snapshot) {

--- a/cmd/releaseagent/serve.go
+++ b/cmd/releaseagent/serve.go
@@ -216,7 +216,6 @@ func handleServe(parse subcmd.ParseFunc) error {
 					VerifyMirrorCommit:   repoClient.VerifyCommit,
 					MirrorPollInterval:   5 * time.Second,
 					PollInterval:         5 * time.Second,
-					TimelinePollInterval: 30 * time.Second,
 					PreviousQueueAttempt: request.PreviousQueueAttempt,
 					ReconcileAttempts:    6,
 					ReconcileInterval:    5 * time.Second,


### PR DESCRIPTION
## Summary

- remove Azure stage, job, and task timeline retrieval and rendering
- keep polling the exact build status every five seconds
- keep terminal result handling, restart monitoring, and the exact Azure run link

## Why

The release process only needs to know whether its correlated build is queued, running, or complete. Azure DevOps already provides the detailed task view, so duplicating its timeline hierarchy in the local UI added another SDK path, polling interval, parser, browser model, and tests without affecting release decisions.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- browser smoke test

This is the first PR in the cleanup stack.