### PR TITLE
releaseagent: narrow workflow metadata

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -32,9 +32,9 @@ For a reviewed, durable external action, describe the form with `ProcessInput`, 
 ```go
 ProcessDefinition{
     ID: "example", Name: "Example", Mark: "EX", Description: "Release the example.",
-    Workflow: &ProcessWorkflow{
+    Workflow: ProcessWorkflow{
         Heading: "Configure release", SubmitLabel: "Prepare release",
-    Inputs: []ProcessInput{{ID: "run", Type: "number", Label: "Run ID", Required: true}},
+      Inputs: []ProcessInput{{ID: "run", Type: "number", Label: "Run ID"}},
         DurableAction: true,
     },
 }
@@ -42,9 +42,9 @@ ProcessDefinition{
 
   Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store holds the server's single current durable external action. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart behavior, state APIs, and event streaming.
 
-  Before preparation, the shared lifecycle validates request keys, required and conditional fields, choice values, positive integer syntax, and defaults. Executors then apply process-specific semantic and fixed-target validation.
+  Before preparation, the shared lifecycle validates request keys, visible and conditional fields, choice values, positive integer syntax, and defaults. Executors then apply process-specific semantic and fixed-target validation.
 
-  `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` remain available for custom lifecycles. Do not combine these handlers with `DurableAction`.
+  `Preflight`, `GetPlan`/`Prepare`, `Simulate`, and `Start` define the custom go-images lifecycle. Do not combine these handlers with `DurableAction`.
 
 ## Go-images release modes
 

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -34,7 +34,7 @@ ProcessDefinition{
     ID: "example", Name: "Example", Mark: "EX", Description: "Release the example.",
     Workflow: ProcessWorkflow{
         Heading: "Configure release", SubmitLabel: "Prepare release",
-      Inputs: []ProcessInput{{ID: "run", Type: "number", Label: "Run ID"}},
+        Inputs: []ProcessInput{{ID: "run", Type: "number", Label: "Run ID"}},
         DurableAction: true,
     },
 }

--- a/cmd/releaseagent/internal/releaseui/process_execution_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution_test.go
@@ -54,10 +54,10 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 	}
 	registry, err := newProcessRegistry(ProcessDefinition{
 		ID: "example", Name: "Example", Mark: "EX", Description: "Example process",
-		Workflow: &ProcessWorkflow{
+		Workflow: ProcessWorkflow{
 			Heading: "Run example", SubmitLabel: "Review", DurableAction: true,
 			Inputs: []ProcessInput{{
-				ID: "mode", Type: "choice", Label: "Mode", Required: true,
+				ID: "mode", Type: "choice", Label: "Mode",
 				Options: []ProcessInputOption{{Value: "run", Name: "Run", Description: "Run example"}},
 			}},
 		},

--- a/cmd/releaseagent/internal/releaseui/process_input.go
+++ b/cmd/releaseagent/internal/releaseui/process_input.go
@@ -56,11 +56,8 @@ func normalizeProcessInputs(inputs []ProcessInput, data json.RawMessage) (json.R
 			continue
 		}
 		value := values[input.ID]
-		if input.Required && value == "" {
-			return nil, fmt.Errorf("process input %q is required", input.ID)
-		}
 		if value == "" {
-			continue
+			return nil, fmt.Errorf("process input %q is required", input.ID)
 		}
 		switch input.Type {
 		case "choice":

--- a/cmd/releaseagent/internal/releaseui/process_input_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_input_test.go
@@ -12,14 +12,14 @@ import (
 func TestNormalizeProcessInputs(t *testing.T) {
 	inputs := []ProcessInput{
 		{
-			ID: "mode", Type: "choice", Label: "Mode", Default: "normal", Required: true,
+			ID: "mode", Type: "choice", Label: "Mode", Default: "normal",
 			Options: []ProcessInputOption{
 				{Value: "normal", Name: "Normal", Description: "Normal mode"},
 				{Value: "rollback", Name: "Rollback", Description: "Rollback mode"},
 			},
 		},
 		{
-			ID: "build", Type: "number", Label: "Build", Required: true,
+			ID: "build", Type: "number", Label: "Build",
 			VisibleWhen: &ProcessCondition{InputID: "mode", Equals: "rollback"},
 		},
 	}
@@ -50,11 +50,11 @@ func TestNormalizeProcessInputs(t *testing.T) {
 func TestNormalizeProcessInputsRejectsSchemaViolations(t *testing.T) {
 	inputs := []ProcessInput{
 		{
-			ID: "mode", Type: "choice", Label: "Mode", Required: true,
+			ID: "mode", Type: "choice", Label: "Mode",
 			Options: []ProcessInputOption{{Value: "normal", Name: "Normal", Description: "Normal mode"}},
 		},
 		{
-			ID: "build", Type: "number", Label: "Build", Required: true,
+			ID: "build", Type: "number", Label: "Build",
 			VisibleWhen: &ProcessCondition{InputID: "mode", Equals: "normal"},
 		},
 	}
@@ -75,7 +75,7 @@ func TestNormalizeProcessInputsRejectsSchemaViolations(t *testing.T) {
 	}
 	hidden := []ProcessInput{
 		{
-			ID: "mode", Type: "choice", Label: "Mode", Default: "normal", Required: true,
+			ID: "mode", Type: "choice", Label: "Mode", Default: "normal",
 			Options: []ProcessInputOption{
 				{Value: "normal", Name: "Normal", Description: "Normal mode"},
 				{Value: "rollback", Name: "Rollback", Description: "Rollback mode"},

--- a/cmd/releaseagent/internal/releaseui/process_registry.go
+++ b/cmd/releaseagent/internal/releaseui/process_registry.go
@@ -24,7 +24,7 @@ type ProcessDefinition struct {
 	Mark             string
 	Description      string
 	DocumentationURL string
-	Workflow         *ProcessWorkflow
+	Workflow         ProcessWorkflow
 }
 
 // ProcessWorkflow describes an in-UI workflow. DurableAction uses the shared confirmed execution
@@ -53,7 +53,6 @@ type ProcessInput struct {
 	Description string               `json:"description,omitempty"`
 	Default     string               `json:"default,omitempty"`
 	Placeholder string               `json:"placeholder,omitempty"`
-	Required    bool                 `json:"required,omitempty"`
 	Options     []ProcessInputOption `json:"options,omitempty"`
 	VisibleWhen *ProcessCondition    `json:"visibleWhen,omitempty"`
 }
@@ -119,12 +118,12 @@ func defaultProcessRegistry() (*processRegistry, error) {
 			ID: "go-images", Name: "Go images", Mark: "GI",
 			Description:      "Build, sign, publish, test, or republish the Microsoft Build of Go container images.",
 			DocumentationURL: "https://github.com/microsoft/go-lab/tree/main/docs/release#golang-toolset-images",
-			Workflow: &ProcessWorkflow{
+			Workflow: ProcessWorkflow{
 				Heading: "Choose release type", Description: "Only rollback accepts a pipeline input.",
 				SubmitLabel: "Prepare release",
 				Inputs: []ProcessInput{
 					{
-						ID: "mode", Type: "choice", Label: "Release type", Default: "normal", Required: true,
+						ID: "mode", Type: "choice", Label: "Release type", Default: "normal",
 						Options: []ProcessInputOption{
 							{Value: "normal", Name: "Normal release", Mark: "N", Description: "Build current microsoft/main and publish to public/. All parameters are locked.", NoticeTitle: "Normal release is locked.", Notice: "Current main, current-build artifacts, and public/ are selected server-side."},
 							{Value: "rollback", Name: "Rollback / republish", Mark: "R", Description: "Republish artifacts from one successful pipeline 1023 build to public/.", NoticeTitle: "Only the source build is editable.", Notice: "The server locks current main and public/, then validates the selected build."},
@@ -132,7 +131,7 @@ func defaultProcessRegistry() (*processRegistry, error) {
 						},
 					},
 					{
-						ID: "sourceBuildId", Type: "number", Label: "Source build ID", Required: true,
+						ID: "sourceBuildId", Type: "number", Label: "Source build ID",
 						Placeholder: "3034159",
 						Description: "The server verifies that this is a successful pipeline 1023 run which produced its own artifacts.",
 						VisibleWhen: &ProcessCondition{InputID: "mode", Equals: "rollback"},
@@ -149,12 +148,12 @@ func defaultProcessRegistry() (*processRegistry, error) {
 			ID: "go-infra", Name: "Go infrastructure", Mark: "IN",
 			Description:      "Create the next microsoft/go-infra patch release through its GitHub release workflow.",
 			DocumentationURL: "https://github.com/microsoft/go-lab/tree/main/docs/release#microsoftgo-infra",
-			Workflow: &ProcessWorkflow{
+			Workflow: ProcessWorkflow{
 				Heading: "Choose release path", Description: "Review a fixed GitHub action before confirming it.",
 				SubmitLabel: "Review GitHub action",
 				Inputs: []ProcessInput{
 					{
-						ID: "action", Type: "choice", Label: "Release path", Default: goInfraActionReleaseOnMerge, Required: true,
+						ID: "action", Type: "choice", Label: "Release path", Default: goInfraActionReleaseOnMerge,
 						Options: []ProcessInputOption{
 							{
 								Value: goInfraActionReleaseOnMerge, Name: "Release on merge", Mark: "PR",
@@ -171,13 +170,13 @@ func defaultProcessRegistry() (*processRegistry, error) {
 						},
 					},
 					{
-						ID: "pullRequest", Type: "number", Label: "Pull request number", Required: true,
+						ID: "pullRequest", Type: "number", Label: "Pull request number",
 						Placeholder: "123",
 						Description: "The server verifies that the PR is open, targets main, and does not come from a fork.",
 						VisibleWhen: &ProcessCondition{InputID: "action", Equals: goInfraActionReleaseOnMerge},
 					},
 					{
-						ID: "dispatchMode", Type: "choice", Label: "Dispatch mode", Default: goInfraDispatchModeDryRun, Required: true,
+						ID: "dispatchMode", Type: "choice", Label: "Dispatch mode", Default: goInfraDispatchModeDryRun,
 						VisibleWhen: &ProcessCondition{InputID: "action", Equals: goInfraActionManualDispatch},
 						Options: []ProcessInputOption{
 							{Value: goInfraDispatchModeDryRun, Name: "Dry run", Mark: "D", Description: "Calculate the next v0.0.x version without creating a release."},
@@ -191,27 +190,21 @@ func defaultProcessRegistry() (*processRegistry, error) {
 	)
 }
 
-func validateProcessWorkflow(processID string, workflow *ProcessWorkflow) error {
-	if workflow == nil {
-		return fmt.Errorf("release process %q has no workflow", processID)
-	}
+func validateProcessWorkflow(processID string, workflow ProcessWorkflow) error {
 	if strings.TrimSpace(workflow.Heading) == "" {
 		return fmt.Errorf("release process %q has an incomplete workflow", processID)
 	}
-	if workflow.DurableAction && (workflow.GetPlan != nil || workflow.Prepare != nil || workflow.Simulate != nil || workflow.Start != nil) {
-		return fmt.Errorf("release process %q mixes durable execution with custom lifecycle handlers", processID)
-	}
-	if (workflow.Prepare == nil) != (workflow.GetPlan == nil) {
-		return fmt.Errorf("release process %q must define prepare and get-plan handlers together", processID)
-	}
-	if (workflow.Prepare != nil || workflow.DurableAction) && strings.TrimSpace(workflow.SubmitLabel) == "" {
+	if strings.TrimSpace(workflow.SubmitLabel) == "" {
 		return fmt.Errorf("release process %q has no workflow submit label", processID)
 	}
-	if workflow.Simulate != nil && workflow.Prepare == nil {
-		return fmt.Errorf("release process %q simulates without defining preparation", processID)
-	}
-	if workflow.Start != nil && workflow.Prepare == nil {
-		return fmt.Errorf("release process %q starts without defining preparation", processID)
+	if workflow.DurableAction {
+		if workflow.Preflight != nil || workflow.GetPlan != nil || workflow.Prepare != nil ||
+			workflow.Simulate != nil || workflow.Start != nil {
+
+			return fmt.Errorf("release process %q mixes durable execution with custom lifecycle handlers", processID)
+		}
+	} else if workflow.Preflight == nil || workflow.GetPlan == nil || workflow.Prepare == nil || workflow.Start == nil {
+		return fmt.Errorf("release process %q has an incomplete custom lifecycle", processID)
 	}
 	inputs := make(map[string]ProcessInput, len(workflow.Inputs))
 	for _, input := range workflow.Inputs {

--- a/cmd/releaseagent/internal/releaseui/processes_test.go
+++ b/cmd/releaseagent/internal/releaseui/processes_test.go
@@ -8,16 +8,20 @@ import (
 	"testing"
 )
 
+func testDurableWorkflow(heading string) ProcessWorkflow {
+	return ProcessWorkflow{Heading: heading, SubmitLabel: "Review", DurableAction: true}
+}
+
 func TestProcessRegistry(t *testing.T) {
 	registry, err := newProcessRegistry(
 		ProcessDefinition{
 			ID: "one", Name: "One", Mark: "O", Description: "First process",
 			DocumentationURL: "https://example.com/docs",
-			Workflow:         &ProcessWorkflow{Heading: "Configure one"},
+			Workflow:         testDurableWorkflow("Configure one"),
 		},
 		ProcessDefinition{
 			ID: "two", Name: "Two", Mark: "T", Description: "Second process",
-			Workflow: &ProcessWorkflow{Heading: "Configure two"},
+			Workflow: testDurableWorkflow("Configure two"),
 		},
 	)
 	if err != nil {
@@ -41,7 +45,7 @@ func TestProcessRegistry(t *testing.T) {
 func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 	valid := ProcessDefinition{
 		ID: "one", Name: "One", Mark: "O", Description: "First process",
-		Workflow: &ProcessWorkflow{Heading: "Configure"},
+		Workflow: testDurableWorkflow("Configure"),
 	}
 	for _, test := range []struct {
 		name        string
@@ -50,7 +54,7 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 		{name: "empty"},
 		{name: "duplicate ID", definitions: []ProcessDefinition{valid, valid}},
 		{name: "invalid ID", definitions: []ProcessDefinition{{
-			ID: "One", Name: "One", Mark: "O", Description: "First", Workflow: &ProcessWorkflow{Heading: "Configure"},
+			ID: "One", Name: "One", Mark: "O", Description: "First", Workflow: testDurableWorkflow("Configure"),
 		}}},
 		{name: "missing workflow", definitions: []ProcessDefinition{{
 			ID: "one", Name: "One", Mark: "O", Description: "First",
@@ -65,11 +69,12 @@ func TestProcessRegistryRejectsInvalidDefinitions(t *testing.T) {
 }
 
 func TestProcessRegistryValidatesWorkflowInputs(t *testing.T) {
-	prepare := func(*Server, http.ResponseWriter, *http.Request) {}
+	handler := func(*Server, http.ResponseWriter, *http.Request) {}
 	definition := ProcessDefinition{
 		ID: "one", Name: "One", Mark: "O", Description: "First process",
-		Workflow: &ProcessWorkflow{
-			Heading: "Configure", SubmitLabel: "Prepare", GetPlan: prepare, Prepare: prepare,
+		Workflow: ProcessWorkflow{
+			Heading: "Configure", SubmitLabel: "Prepare",
+			Preflight: handler, GetPlan: handler, Prepare: handler, Start: handler,
 			Inputs: []ProcessInput{{
 				ID: "mode", Type: "choice", Label: "Mode", Default: "normal",
 				Options: []ProcessInputOption{{Value: "normal", Name: "Normal", Description: "Run normally"}},
@@ -84,9 +89,12 @@ func TestProcessRegistryValidatesWorkflowInputs(t *testing.T) {
 		t.Fatal("invalid numeric default was accepted")
 	}
 	definition.Workflow.Inputs = nil
-	definition.Workflow.Start = prepare
 	if _, err := newProcessRegistry(definition); err != nil {
 		t.Fatalf("direct confirmed workflow was rejected: %v", err)
+	}
+	definition.Workflow.Start = nil
+	if _, err := newProcessRegistry(definition); err == nil {
+		t.Fatal("incomplete custom lifecycle was accepted")
 	}
 }
 
@@ -94,10 +102,10 @@ func TestProcessRegistryValidatesDurableAction(t *testing.T) {
 	handler := func(*Server, http.ResponseWriter, *http.Request) {}
 	definition := ProcessDefinition{
 		ID: "one", Name: "One", Mark: "O", Description: "First process",
-		Workflow: &ProcessWorkflow{
+		Workflow: ProcessWorkflow{
 			Heading: "Configure", SubmitLabel: "Review", DurableAction: true,
 			Inputs: []ProcessInput{{
-				ID: "mode", Type: "choice", Label: "Mode", Required: true,
+				ID: "mode", Type: "choice", Label: "Mode",
 				Options: []ProcessInputOption{{Value: "run", Name: "Run", Description: "Run now"}},
 			}},
 		},

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -257,11 +257,9 @@ func (s *Server) Handler() http.Handler {
 				server.handleProcessRunPreflight(processID, processName, response, request)
 			}
 		}
-		if preflight != nil {
-			mux.HandleFunc("GET "+prefix+"/preflight", func(response http.ResponseWriter, request *http.Request) {
-				preflight(s, response, request)
-			})
-		}
+		mux.HandleFunc("GET "+prefix+"/preflight", func(response http.ResponseWriter, request *http.Request) {
+			preflight(s, response, request)
+		})
 		getPlan := workflow.GetPlan
 		prepare := workflow.Prepare
 		start := workflow.Start
@@ -276,22 +274,14 @@ func (s *Server) Handler() http.Handler {
 				server.handleStartProcessRun(processID, response, request)
 			}
 		}
-		if getPlan != nil {
-			mux.HandleFunc("GET "+prefix+"/plan", s.getProcessPlan(processID, getPlan))
-		}
-		if prepare != nil {
-			mux.HandleFunc("POST "+prefix+"/plan", s.prepareProcess(processID, prepare))
-		}
+		mux.HandleFunc("GET "+prefix+"/plan", s.getProcessPlan(processID, getPlan))
+		mux.HandleFunc("POST "+prefix+"/plan", s.prepareProcess(processID, prepare))
 		if workflow.Simulate != nil {
 			mux.HandleFunc("POST "+prefix+"/simulate", s.requireActiveProcess(processID, workflow.Simulate))
 		}
-		if start != nil {
-			mux.HandleFunc("POST "+prefix+"/start", s.requireActiveProcess(processID, start))
-		}
-		if getPlan != nil {
-			mux.HandleFunc("GET "+prefix+"/state", s.requireActiveProcess(processID, (*Server).handleState))
-			mux.HandleFunc("GET "+prefix+"/events", s.requireActiveProcess(processID, (*Server).handleEvents))
-		}
+		mux.HandleFunc("POST "+prefix+"/start", s.requireActiveProcess(processID, start))
+		mux.HandleFunc("GET "+prefix+"/state", s.requireActiveProcess(processID, (*Server).handleState))
+		mux.HandleFunc("GET "+prefix+"/events", s.requireActiveProcess(processID, (*Server).handleEvents))
 	}
 	mux.Handle("GET /assets/", http.StripPrefix("/assets/", http.FileServer(http.FS(assets))))
 	mux.HandleFunc("GET /api/dashboard", s.handleDashboard)
@@ -490,23 +480,20 @@ type processSummary struct {
 }
 
 type processDetail struct {
-	ID               string          `json:"id"`
-	Name             string          `json:"name"`
-	Mark             string          `json:"mark"`
-	Description      string          `json:"description"`
-	DocumentationURL string          `json:"documentationUrl"`
-	Workflow         *workflowDetail `json:"workflow,omitempty"`
+	ID               string         `json:"id"`
+	Name             string         `json:"name"`
+	Mark             string         `json:"mark"`
+	Description      string         `json:"description"`
+	DocumentationURL string         `json:"documentationUrl"`
+	Workflow         workflowDetail `json:"workflow"`
 }
 
 type workflowDetail struct {
-	Heading      string         `json:"heading"`
-	Description  string         `json:"description,omitempty"`
-	SubmitLabel  string         `json:"submitLabel,omitempty"`
-	Inputs       []ProcessInput `json:"inputs,omitempty"`
-	HasPreflight bool           `json:"hasPreflight"`
-	CanPrepare   bool           `json:"canPrepare"`
-	CanSimulate  bool           `json:"canSimulate"`
-	CanStart     bool           `json:"canStart"`
+	Heading     string         `json:"heading"`
+	Description string         `json:"description,omitempty"`
+	SubmitLabel string         `json:"submitLabel"`
+	Inputs      []ProcessInput `json:"inputs"`
+	CanSimulate bool           `json:"canSimulate"`
 }
 
 func (s *Server) handleProcess(response http.ResponseWriter, request *http.Request) {
@@ -518,14 +505,11 @@ func (s *Server) handleProcess(response http.ResponseWriter, request *http.Reque
 	detail := processDetail{
 		ID: definition.ID, Name: definition.Name, Mark: definition.Mark,
 		Description: definition.Description, DocumentationURL: definition.DocumentationURL,
-		Workflow: &workflowDetail{
+		Workflow: workflowDetail{
 			Heading: definition.Workflow.Heading, Description: definition.Workflow.Description,
-			SubmitLabel:  definition.Workflow.SubmitLabel,
-			Inputs:       append([]ProcessInput(nil), definition.Workflow.Inputs...),
-			HasPreflight: definition.Workflow.Preflight != nil || definition.Workflow.DurableAction,
-			CanPrepare:   definition.Workflow.Prepare != nil || definition.Workflow.DurableAction,
-			CanSimulate:  definition.Workflow.Simulate != nil,
-			CanStart:     definition.Workflow.Start != nil || definition.Workflow.DurableAction,
+			SubmitLabel: definition.Workflow.SubmitLabel,
+			Inputs:      append([]ProcessInput(nil), definition.Workflow.Inputs...),
+			CanSimulate: definition.Workflow.Simulate != nil,
 		},
 	}
 	writeJSON(response, http.StatusOK, detail)

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -145,8 +145,7 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	}
 	var goImages processDetail
 	decodeResponse(t, response, &goImages)
-	if response.StatusCode != http.StatusOK || goImages.Workflow == nil || !goImages.Workflow.CanPrepare ||
-		!goImages.Workflow.CanStart || len(goImages.Workflow.Inputs) != 2 {
+	if response.StatusCode != http.StatusOK || !goImages.Workflow.CanSimulate || len(goImages.Workflow.Inputs) != 2 {
 
 		t.Fatalf("go-images process = %#v", goImages)
 	}
@@ -156,9 +155,8 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	}
 	var process processDetail
 	decodeResponse(t, response, &process)
-	if response.StatusCode != http.StatusOK || process.ID != "go-infra" || process.Workflow == nil ||
-		!process.Workflow.HasPreflight || !process.Workflow.CanPrepare ||
-		!process.Workflow.CanStart || len(process.Workflow.Inputs) != 3 {
+	if response.StatusCode != http.StatusOK || process.ID != "go-infra" ||
+		process.Workflow.CanSimulate || len(process.Workflow.Inputs) != 3 {
 
 		t.Fatalf("process = %#v", process)
 	}
@@ -168,7 +166,7 @@ func TestDashboardShowsDurableProcessRun(t *testing.T) {
 	ui := newTestUI(t)
 	registry, err := newProcessRegistry(ProcessDefinition{
 		ID: "example", Name: "Example", Mark: "EX", Description: "Example process",
-		Workflow: &ProcessWorkflow{Heading: "Run example"},
+		Workflow: testDurableWorkflow("Run example"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -203,14 +201,20 @@ func TestDashboardShowsDurableProcessRun(t *testing.T) {
 }
 
 func TestProcessRoutesIsolatePreparedPlans(t *testing.T) {
-	workflow := func(processID string) *ProcessWorkflow {
-		return &ProcessWorkflow{
+	workflow := func(processID string) ProcessWorkflow {
+		return ProcessWorkflow{
 			Heading: "Configure", SubmitLabel: "Prepare",
+			Preflight: func(_ *Server, response http.ResponseWriter, _ *http.Request) {
+				writeJSON(response, http.StatusOK, PreflightReport{PlanningEnabled: true})
+			},
 			GetPlan: func(_ *Server, response http.ResponseWriter, _ *http.Request) {
 				writeJSON(response, http.StatusOK, map[string]string{"process": processID})
 			},
 			Prepare: func(_ *Server, response http.ResponseWriter, _ *http.Request) {
 				writeJSON(response, http.StatusOK, map[string]string{"prepared": processID})
+			},
+			Start: func(_ *Server, response http.ResponseWriter, _ *http.Request) {
+				response.WriteHeader(http.StatusAccepted)
 			},
 		}
 	}

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -146,7 +146,6 @@ func TestDashboardShowsProcessCatalog(t *testing.T) {
 	var goImages processDetail
 	decodeResponse(t, response, &goImages)
 	if response.StatusCode != http.StatusOK || !goImages.Workflow.CanSimulate || len(goImages.Workflow.Inputs) != 2 {
-
 		t.Fatalf("go-images process = %#v", goImages)
 	}
 	response, err = ui.client.Get(ui.http.URL + "/api/processes/go-infra")

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -61,7 +61,6 @@
   async function initialize() {
     processDefinition = await globalThis.releaseProcessReady;
     workflow = processDefinition.workflow;
-    if (!workflow) return;
 
     endpointBase = `/api/processes/${encodeURIComponent(processDefinition.id)}`;
     workflowSection.hidden = false;
@@ -69,9 +68,8 @@
     workflowDescription.textContent = workflow.description || "";
     workflowDescription.hidden = !workflow.description;
     planButton.querySelector("span:first-child").textContent = workflow.submitLabel || "Prepare release";
-    form.hidden = !workflow.canPrepare;
     demoButton.hidden = !workflow.canSimulate;
-    if (workflow.hasPreflight) planButton.disabled = true;
+    planButton.disabled = true;
 
     processInputs.replaceChildren(...(workflow.inputs || []).map(createInput));
     updateInputState();
@@ -188,7 +186,7 @@
       const condition = record.schema.visibleWhen;
       const visible = !condition || inputValue(condition.inputId) === condition.equals;
       record.wrapper.hidden = !visible;
-      for (const control of record.controls) control.required = visible && Boolean(record.schema.required);
+      for (const control of record.controls) control.required = visible;
     }
     for (const record of inputRecords.values()) {
       if (record.schema.type !== "choice") continue;
@@ -217,7 +215,7 @@
     for (const [id, record] of inputRecords) {
       if (record.wrapper.hidden) continue;
       const value = inputValue(id);
-      if (value !== "" || record.schema.required) result[id] = value;
+      result[id] = value;
     }
     return result;
   }
@@ -250,7 +248,7 @@
       showError(error.message);
     } finally {
       setBusy(planButton, false, workflow.submitLabel || "Prepare release");
-      if (workflow.hasPreflight && !preflight?.planningEnabled) planButton.disabled = true;
+      if (!preflight?.planningEnabled) planButton.disabled = true;
     }
   }
 
@@ -349,16 +347,15 @@
   }
 
   function renderExecution(execution, view) {
-    const preflightReady = !workflow.hasPreflight || Boolean(preflight?.externalExecutionEnabled);
-    const visible = Boolean(workflow.canStart && execution?.enabled && execution?.eligible && preflightReady);
+    const preflightReady = Boolean(preflight?.externalExecutionEnabled);
+    const visible = Boolean(execution?.enabled && execution?.eligible && preflightReady);
     executionControls.hidden = !visible;
     const unavailableReason = execution?.unavailableReason ||
-      (workflow.canStart && execution?.enabled && !preflightReady
+      (execution?.enabled && !preflightReady
         ? "External execution is not ready. Review the preflight checks."
         : "");
     executionUnavailable.hidden = visible || !unavailableReason;
     executionUnavailable.textContent = unavailableReason;
-    if (!workflow.canStart) return;
 
     if (executionControls.dataset.planDigest !== execution?.planDigest) {
       runConfirmationPending = false;
@@ -616,8 +613,8 @@
 
   function updateExecutionButton() {
     const execution = plan?.execution;
-    const preflightReady = !workflow?.hasPreflight || Boolean(preflight?.externalExecutionEnabled);
-    const enabled = Boolean(workflow?.canStart && execution?.enabled && execution?.eligible && preflightReady);
+    const preflightReady = Boolean(preflight?.externalExecutionEnabled);
+    const enabled = Boolean(execution?.enabled && execution?.eligible && preflightReady);
     const complete = Boolean(execution?.run?.complete);
     runConfirmation.hidden = !runConfirmationPending || complete || executionActive;
     executionCancel.hidden = runConfirmation.hidden;
@@ -672,7 +669,6 @@
   }
 
   async function loadExistingPlan() {
-    if (!workflow.canPrepare) return;
     try {
       const response = await fetch(`${endpointBase}/plan`);
       if (response.status === 204) return;
@@ -686,7 +682,6 @@
   }
 
   async function loadPreflight() {
-    if (!workflow.hasPreflight) return;
     processSafety.hidden = false;
     try {
       preflight = await requestJSON(`${endpointBase}/preflight`);


### PR DESCRIPTION
Stacked on #577.

## Summary

- require every registered process to provide preflight, plan, start, state, and event behavior
- remove capability flags that are constant for both current processes
- make every visible process input required
- retain simulation as the one optional workflow capability

## Why

Go images and go-infra both expose the complete release lifecycle. Modeling those routes and visible-input requirements as optional produced branches the current UI cannot use. Keeping only `CanSimulate` preserves the intentional go-images simulation without carrying hypothetical workflow shapes.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- simulation route and UI coverage remain