### PR TITLE
releaseagent: keep go-images targets in policy

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -142,7 +142,7 @@ The restored path wraps the execution service in a queue-denying adapter, so it 
 
 The go-images session document is schema-versioned, structurally fingerprinted, atomically replaced, and protected from concurrent cooperative processes by an adjacent lease file.
 It contains no credentials.
-Schema version 7 stores only standalone go-images input and state. It intentionally rejects the
+Schema version 8 stores only standalone go-images input and state. It intentionally rejects the
 older full-release-shaped prototype documents rather than retaining a second domain model and
 migration path. Workflow revision 7 uses unique step names as graph identity. Start with a new
 session file when either version is unsupported.

--- a/cmd/releaseagent/internal/goimagesexecution/queue.go
+++ b/cmd/releaseagent/internal/goimagesexecution/queue.go
@@ -80,8 +80,8 @@ func (c *HTTPQueueClient) QueueRelease(ctx context.Context, request QueueRequest
 		return 0, fmt.Errorf("marshal go-images release variables: %w", err)
 	}
 	body, err := json.Marshal(map[string]any{
-		"definition":         map[string]int{"id": DefinitionID},
-		"sourceBranch":       SourceBranch,
+		"definition":         map[string]int{"id": goimagesworkflow.DefinitionID},
+		"sourceBranch":       goimagesworkflow.SourceBranch,
 		"sourceVersion":      request.SourceVersion,
 		"templateParameters": parameters,
 		// The Build API's legacy parameters field carries pipeline variables as a JSON string.
@@ -91,7 +91,7 @@ func (c *HTTPQueueClient) QueueRelease(ctx context.Context, request QueueRequest
 		return 0, fmt.Errorf("marshal go-images release request: %w", err)
 	}
 	endpoint := c.baseURL + "/" + url.PathEscape(c.project) + "/_apis/build/builds?" + url.Values{
-		"definitionId": {strconv.Itoa(DefinitionID)},
+		"definitionId": {strconv.Itoa(goimagesworkflow.DefinitionID)},
 		"api-version":  {"7.1-preview.7"},
 	}.Encode()
 	token, err := c.tokens.Token(ctx)

--- a/cmd/releaseagent/internal/goimagesexecution/queue_test.go
+++ b/cmd/releaseagent/internal/goimagesexecution/queue_test.go
@@ -55,7 +55,7 @@ func TestQueueReleaseUsesModeDerivedPayload(t *testing.T) {
 				if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 					t.Fatal(err)
 				}
-				if body.Definition.ID != DefinitionID || body.SourceBranch != SourceBranch || body.SourceVersion != testCommit {
+				if body.Definition.ID != goimagesworkflow.DefinitionID || body.SourceBranch != goimagesworkflow.SourceBranch || body.SourceVersion != testCommit {
 					t.Fatalf("identity = %#v", body)
 				}
 				if body.TemplateParameters["sourceBuildPipelineRunId"] != test.wantSource ||

--- a/cmd/releaseagent/internal/goimagesexecution/service.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service.go
@@ -22,11 +22,6 @@ import (
 )
 
 const (
-	// DefinitionID is the microsoft-go-images (official) pipeline.
-	DefinitionID = 1023
-	// SourceBranch is the only source branch accepted by the release service.
-	SourceBranch = "refs/heads/microsoft/main"
-
 	correlationVariable     = "ReleaseUISessionID"
 	executionDigestVariable = "ReleaseUIExecutionDigest"
 	modeVariable            = "ReleaseUIGoImagesMode"
@@ -131,10 +126,7 @@ func New(reader PipelineReader, queue QueueClient, config Config, sleeper Sleepe
 
 // PollMirror waits until the plan's exact source commit is available in the allowlisted
 // internal microsoft-go-images repository.
-func (s *Service) PollMirror(ctx context.Context, target, commit string) error {
-	if target != goimagesworkflow.InternalMirrorTarget {
-		return fmt.Errorf("go-images mirror target %q is not allowlisted", target)
-	}
+func (s *Service) PollMirror(ctx context.Context, commit string) error {
 	if commit != s.config.SourceVersion {
 		return fmt.Errorf("go-images mirror commit %q does not match planned source %q", commit, s.config.SourceVersion)
 	}
@@ -160,12 +152,8 @@ func (s *Service) PollMirror(ctx context.Context, target, commit string) error {
 // QueuePipeline reconciles this session before queueing the hardcoded official pipeline.
 func (s *Service) QueuePipeline(
 	ctx context.Context,
-	pipelineID int,
 	parameters map[string]string,
 ) (string, error) {
-	if pipelineID != DefinitionID {
-		return "", fmt.Errorf("pipeline %d is not the allowlisted go-images definition %d", pipelineID, DefinitionID)
-	}
 	if !maps.Equal(parameters, s.parameters) {
 		return "", fmt.Errorf("go-images release parameters are not allowlisted: %#v", parameters)
 	}
@@ -204,7 +192,7 @@ func (s *Service) QueuePipeline(
 }
 
 func (s *Service) findCorrelatedBuild(ctx context.Context) (*azdopipeline.Build, error) {
-	builds, err := s.reader.ListRecent(ctx, DefinitionID)
+	builds, err := s.reader.ListRecent(ctx, goimagesworkflow.DefinitionID)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile go-images release pipeline run: %w", err)
 	}
@@ -221,13 +209,13 @@ func (s *Service) findCorrelatedBuild(ctx context.Context) (*azdopipeline.Build,
 }
 
 func (s *Service) validateCorrelatedBuild(build *azdopipeline.Build) error {
-	if build == nil || build.ID <= 0 || build.DefinitionID != DefinitionID {
+	if build == nil || build.ID <= 0 || build.DefinitionID != goimagesworkflow.DefinitionID {
 		return fmt.Errorf("correlated go-images release build has invalid identity: %#v", build)
 	}
-	if build.SourceBranch != SourceBranch || build.SourceVersion != s.config.SourceVersion {
+	if build.SourceBranch != goimagesworkflow.SourceBranch || build.SourceVersion != s.config.SourceVersion {
 		return fmt.Errorf(
 			"correlated go-images release build %d has source %s@%s, expected %s@%s",
-			build.ID, build.SourceBranch, build.SourceVersion, SourceBranch, s.config.SourceVersion,
+			build.ID, build.SourceBranch, build.SourceVersion, goimagesworkflow.SourceBranch, s.config.SourceVersion,
 		)
 	}
 	for name, want := range map[string]string{
@@ -265,8 +253,8 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 		if err != nil {
 			return fmt.Errorf("get go-images release build %d: %w", id, err)
 		}
-		if build.DefinitionID != 0 && build.DefinitionID != DefinitionID {
-			return fmt.Errorf("build %d belongs to pipeline %d, expected %d", id, build.DefinitionID, DefinitionID)
+		if build.DefinitionID != goimagesworkflow.DefinitionID {
+			return fmt.Errorf("build %d belongs to pipeline %d, expected %d", id, build.DefinitionID, goimagesworkflow.DefinitionID)
 		}
 		state, err := build.State()
 		if err != nil {

--- a/cmd/releaseagent/internal/goimagesexecution/service_test.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service_test.go
@@ -74,7 +74,7 @@ func TestTriggerQueuesEachAllowlistedMode(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			buildID, err := service.QueuePipeline(context.Background(), DefinitionID, parameters)
+			buildID, err := service.QueuePipeline(context.Background(), parameters)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -111,9 +111,7 @@ func TestPollMirrorWaitsForPlannedCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := service.PollMirror(
-		context.Background(), goimagesworkflow.InternalMirrorTarget, testCommit,
-	); err != nil {
+	if err := service.PollMirror(context.Background(), testCommit); err != nil {
 		t.Fatal(err)
 	}
 	if checks != 3 || sleeps != 2 {
@@ -121,16 +119,9 @@ func TestPollMirrorWaitsForPlannedCommit(t *testing.T) {
 	}
 }
 
-func TestPollMirrorRejectsUnplannedSource(t *testing.T) {
+func TestPollMirrorRejectsUnplannedCommit(t *testing.T) {
 	service := newTestService(t, &fakeReader{}, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
-	if err := service.PollMirror(context.Background(), "other/repo", testCommit); err == nil {
-		t.Fatal("service accepted a different mirror target")
-	}
-	if err := service.PollMirror(
-		context.Background(),
-		goimagesworkflow.InternalMirrorTarget,
-		"2ef65db89e42942c24e3d8f0b8a8eb52bc86857a",
-	); err == nil {
+	if err := service.PollMirror(context.Background(), "2ef65db89e42942c24e3d8f0b8a8eb52bc86857a"); err == nil {
 		t.Fatal("service accepted a different mirror commit")
 	}
 }
@@ -138,11 +129,8 @@ func TestPollMirrorRejectsUnplannedSource(t *testing.T) {
 func TestTriggerRejectsMutatedExecution(t *testing.T) {
 	service := newTestService(t, &fakeReader{}, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
 	parameters, _ := goimagesworkflow.PipelineParameters(goimagesworkflow.ModeNormal, "")
-	if _, err := service.QueuePipeline(context.Background(), 1492, parameters); err == nil {
-		t.Fatal("service accepted the deprecated definition")
-	}
 	parameters["publishRepoPrefix"] = "dev/"
-	if _, err := service.QueuePipeline(context.Background(), DefinitionID, parameters); err == nil {
+	if _, err := service.QueuePipeline(context.Background(), parameters); err == nil {
 		t.Fatal("normal service accepted test parameters")
 	}
 }
@@ -158,14 +146,14 @@ func TestTriggerReconcilesExistingRelease(t *testing.T) {
 		template[name] = value
 	}
 	reader := &fakeReader{recent: [][]*azdopipeline.Build{{{
-		ID: 777, DefinitionID: DefinitionID, SourceBranch: SourceBranch, SourceVersion: testCommit,
+		ID: 777, DefinitionID: goimagesworkflow.DefinitionID, SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 		Parameters: variables, TemplateParameters: template,
 	}}}}
 	queue := &fakeQueueClient{}
 	service := newTestService(t, reader, queue, Config{
 		Mode: goimagesworkflow.ModeRollback, SourceBuildID: "3019035", PreviousQueueAttempt: true,
 	})
-	buildID, err := service.QueuePipeline(context.Background(), DefinitionID, parameters)
+	buildID, err := service.QueuePipeline(context.Background(), parameters)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +175,7 @@ func TestTriggerRetriesReconciliationAfterCheckpointedAttempt(t *testing.T) {
 	reader := &fakeReader{recent: [][]*azdopipeline.Build{
 		nil,
 		{{
-			ID: 778, DefinitionID: DefinitionID, SourceBranch: SourceBranch, SourceVersion: testCommit,
+			ID: 778, DefinitionID: goimagesworkflow.DefinitionID, SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 			Parameters: variables, TemplateParameters: template,
 		}},
 	}}
@@ -202,7 +190,7 @@ func TestTriggerRetriesReconciliationAfterCheckpointedAttempt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	buildID, err := service.QueuePipeline(context.Background(), DefinitionID, parameters)
+	buildID, err := service.QueuePipeline(context.Background(), parameters)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +206,7 @@ func TestReconciliationRejectsConflictingCorrelation(t *testing.T) {
 		template[name] = value
 	}
 	reader := &fakeReader{recent: [][]*azdopipeline.Build{{{
-		ID: 777, DefinitionID: DefinitionID, SourceBranch: SourceBranch, SourceVersion: testCommit,
+		ID: 777, DefinitionID: goimagesworkflow.DefinitionID, SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 		Parameters: map[string]string{
 			correlationVariable: "session", executionDigestVariable: testDigest,
 			modeVariable: "test", versionsVariable: `["1.26.5-2"]`, sourceBuildVariable: "",
@@ -228,7 +216,7 @@ func TestReconciliationRejectsConflictingCorrelation(t *testing.T) {
 	service := newTestService(t, reader, &fakeQueueClient{}, Config{
 		Mode: goimagesworkflow.ModeNormal, PreviousQueueAttempt: true,
 	})
-	_, err := service.QueuePipeline(context.Background(), DefinitionID, parameters)
+	_, err := service.QueuePipeline(context.Background(), parameters)
 	if err == nil || !strings.Contains(err.Error(), modeVariable) {
 		t.Fatalf("error = %v", err)
 	}
@@ -236,8 +224,8 @@ func TestReconciliationRejectsConflictingCorrelation(t *testing.T) {
 
 func TestPollPipeline(t *testing.T) {
 	reader := &fakeReader{builds: []*azdopipeline.Build{
-		{ID: 888, DefinitionID: DefinitionID, Status: "inProgress"},
-		{ID: 888, DefinitionID: DefinitionID, Status: "completed", Result: "succeeded"},
+		{ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "inProgress"},
+		{ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "succeeded"},
 	}}
 	sleeps := 0
 	service, err := New(reader, &fakeQueueClient{}, completeConfig(Config{
@@ -259,7 +247,7 @@ func TestPollPipeline(t *testing.T) {
 
 func TestPollPipelineReportsFailure(t *testing.T) {
 	reader := &fakeReader{builds: []*azdopipeline.Build{{
-		ID: 888, DefinitionID: DefinitionID, Status: "completed", Result: "failed", WebURL: "https://example/build/888",
+		ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "failed", WebURL: "https://example/build/888",
 	}}}
 	service := newTestService(t, reader, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
 	err := service.PollPipeline(context.Background(), strconv.Itoa(888))
@@ -278,7 +266,7 @@ func TestNewRejectsInvalidRollbackBuild(t *testing.T) {
 }
 
 func TestPollHonorsCancellation(t *testing.T) {
-	reader := &fakeReader{builds: []*azdopipeline.Build{{ID: 888, Status: "inProgress"}}}
+	reader := &fakeReader{builds: []*azdopipeline.Build{{ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "inProgress"}}}
 	service, err := New(reader, &fakeQueueClient{}, completeConfig(Config{
 		Mode: goimagesworkflow.ModeNormal,
 	}), func(ctx context.Context, _ time.Duration) error { return ctx.Err() })

--- a/cmd/releaseagent/internal/goimagesrelease/rollback.go
+++ b/cmd/releaseagent/internal/goimagesrelease/rollback.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesworkflow"
 )
 
 // PipelineClient is the Azure DevOps behavior needed to validate a rollback source.
@@ -49,21 +50,20 @@ func ValidateRollbackSource(
 	ctx context.Context,
 	client PipelineClient,
 	resolver VersionResolver,
-	definitionID,
 	buildID int,
 ) (RollbackSource, error) {
 	if client == nil || resolver == nil {
 		return RollbackSource{}, errors.New("rollback pipeline client and version resolver are required")
 	}
-	if definitionID <= 0 || buildID <= 0 {
-		return RollbackSource{}, errors.New("rollback definition and build IDs must be positive")
+	if buildID <= 0 {
+		return RollbackSource{}, errors.New("rollback build ID must be positive")
 	}
 	build, err := client.Get(ctx, buildID)
 	if err != nil {
 		return RollbackSource{}, fmt.Errorf("get rollback source build %d: %w", buildID, err)
 	}
-	if build.DefinitionID != definitionID {
-		return RollbackSource{}, fmt.Errorf("build %d belongs to pipeline %d, expected %d", buildID, build.DefinitionID, definitionID)
+	if build.DefinitionID != goimagesworkflow.DefinitionID {
+		return RollbackSource{}, fmt.Errorf("build %d belongs to pipeline %d, expected %d", buildID, build.DefinitionID, goimagesworkflow.DefinitionID)
 	}
 	state, err := build.State()
 	if err != nil {
@@ -72,7 +72,7 @@ func ValidateRollbackSource(
 	if state != azdopipeline.RunStateSucceeded || build.Result != "succeeded" {
 		return RollbackSource{}, fmt.Errorf("rollback source build %d must have result succeeded", buildID)
 	}
-	if build.SourceBranch != "refs/heads/microsoft/main" || !sourceCommitPattern.MatchString(build.SourceVersion) {
+	if build.SourceBranch != goimagesworkflow.SourceBranch || !sourceCommitPattern.MatchString(build.SourceVersion) {
 		return RollbackSource{}, fmt.Errorf(
 			"rollback source build %d has unsupported source %s@%s",
 			buildID,

--- a/cmd/releaseagent/internal/goimagesrelease/rollback_test.go
+++ b/cmd/releaseagent/internal/goimagesrelease/rollback_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesworkflow"
 )
 
 const testCommit = "81ce9afc2b75ec4e153dd15fc3c7539b12024945"
@@ -23,9 +24,9 @@ func (c *fakePipelineClient) Get(context.Context, int) (*azdopipeline.Build, err
 
 func TestValidateRollbackSource(t *testing.T) {
 	client := &fakePipelineClient{build: &azdopipeline.Build{
-		ID: 3019035, DefinitionID: 1023, Status: "completed", Result: "succeeded",
+		ID: 3019035, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "succeeded",
 		WebURL:       "https://example/build/3019035",
-		SourceBranch: "refs/heads/microsoft/main", SourceVersion: testCommit,
+		SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 		TemplateParameters: map[string]any{
 			"sourceBuildPipelineRunId": "$(Build.BuildId)",
 			"publishRepoPrefix":        "public/",
@@ -37,7 +38,6 @@ func TestValidateRollbackSource(t *testing.T) {
 		VersionResolverFunc(func(context.Context, string) ([]string, error) {
 			return []string{"1.26.5-2", "1.25.12-1"}, nil
 		}),
-		1023,
 		3019035,
 	)
 	if err != nil {
@@ -57,19 +57,19 @@ func TestValidateRollbackSourceRejectsUnsafeBuilds(t *testing.T) {
 	}{
 		{name: "wrong definition", build: &azdopipeline.Build{
 			ID: 1, DefinitionID: 1492, Status: "completed", Result: "succeeded",
-			SourceBranch: "refs/heads/microsoft/main", SourceVersion: testCommit,
+			SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 		}},
 		{name: "failed", build: &azdopipeline.Build{
-			ID: 1, DefinitionID: 1023, Status: "completed", Result: "failed",
-			SourceBranch: "refs/heads/microsoft/main", SourceVersion: testCommit,
+			ID: 1, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "failed",
+			SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 		}},
 		{name: "wrong branch", build: &azdopipeline.Build{
-			ID: 1, DefinitionID: 1023, Status: "completed", Result: "succeeded",
+			ID: 1, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "succeeded",
 			SourceBranch: "refs/heads/feature", SourceVersion: testCommit,
 		}},
 		{name: "already republished", build: &azdopipeline.Build{
-			ID: 1, DefinitionID: 1023, Status: "completed", Result: "succeeded",
-			SourceBranch: "refs/heads/microsoft/main", SourceVersion: testCommit,
+			ID: 1, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "succeeded",
+			SourceBranch: goimagesworkflow.SourceBranch, SourceVersion: testCommit,
 			TemplateParameters: map[string]any{"sourceBuildPipelineRunId": "123"},
 		}},
 	} {
@@ -80,7 +80,6 @@ func TestValidateRollbackSourceRejectsUnsafeBuilds(t *testing.T) {
 				VersionResolverFunc(func(context.Context, string) ([]string, error) {
 					return []string{"1.26.5-2"}, nil
 				}),
-				1023,
 				test.build.ID,
 			)
 			if err == nil {

--- a/cmd/releaseagent/internal/goimagessession/session.go
+++ b/cmd/releaseagent/internal/goimagessession/session.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// CurrentSchemaVersion is the only session document schema understood by this version.
-	CurrentSchemaVersion = 7
+	CurrentSchemaVersion = 8
 	// CurrentWorkflowRevision changes when step behavior becomes incompatible with saved state,
 	// even if step names and dependencies have not changed.
 	CurrentWorkflowRevision = 7

--- a/cmd/releaseagent/internal/goimagessession/session_test.go
+++ b/cmd/releaseagent/internal/goimagessession/session_test.go
@@ -195,9 +195,7 @@ func testDocument(t *testing.T) *Document {
 	t.Helper()
 	input := &goimagesworkflow.Input{
 		Versions: []string{"1.26.1-1"}, Mode: goimagesworkflow.ModeNormal,
-		SourceBranch:  "refs/heads/microsoft/main",
 		SourceVersion: "81ce9afc2b75ec4e153dd15fc3c7539b12024945",
-		MirrorTarget:  goimagesworkflow.InternalMirrorTarget, PipelineID: 1023,
 	}
 	state, err := goimagesworkflow.NewState(input)
 	if err != nil {

--- a/cmd/releaseagent/internal/goimagesworkflow/workflow.go
+++ b/cmd/releaseagent/internal/goimagesworkflow/workflow.go
@@ -21,8 +21,10 @@ import (
 type Mode string
 
 const (
-	// InternalMirrorTarget is the only Azure Repos mirror accepted by this workflow.
-	InternalMirrorTarget = "dnceng/internal/_git/microsoft-go-images"
+	// DefinitionID is the only Azure pipeline this workflow can queue.
+	DefinitionID = 1023
+	// SourceBranch is the only source branch this workflow can release.
+	SourceBranch = "refs/heads/microsoft/main"
 	// ModeNormal builds current microsoft/main and publishes to public/.
 	ModeNormal Mode = "normal"
 	// ModeRollback republishes artifacts from one prior successful build to public/.
@@ -37,11 +39,8 @@ var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 type Input struct {
 	Versions      []string
 	Mode          Mode
-	SourceBranch  string
 	SourceVersion string
 	SourceBuildID string
-	MirrorTarget  string
-	PipelineID    int
 }
 
 func (input Input) checksum() (uint32, error) {
@@ -63,8 +62,8 @@ type State struct {
 
 // Service is the complete external surface available to the standalone go-images workflow.
 type Service interface {
-	PollMirror(context.Context, string, string) error
-	QueuePipeline(context.Context, int, map[string]string) (string, error)
+	PollMirror(context.Context, string) error
+	QueuePipeline(context.Context, map[string]string) (string, error)
 	PollPipeline(context.Context, string) error
 }
 
@@ -153,14 +152,8 @@ func NewGraphWithCheckpoint(
 	service Service,
 	checkpoint CheckpointFunc,
 ) ([]*coordinator.Step, *State, error) {
-	if input == nil || input.PipelineID == 0 {
-		return nil, nil, fmt.Errorf("no go-images pipeline specified")
-	}
-	if input.SourceBranch != "refs/heads/microsoft/main" {
-		return nil, nil, fmt.Errorf("go-images source branch %q is not allowlisted", input.SourceBranch)
-	}
-	if input.MirrorTarget != InternalMirrorTarget {
-		return nil, nil, fmt.Errorf("go-images mirror target %q is not allowlisted", input.MirrorTarget)
+	if input == nil {
+		return nil, nil, fmt.Errorf("go-images input is nil")
 	}
 	if !commitPattern.MatchString(input.SourceVersion) {
 		return nil, nil, fmt.Errorf("invalid go-images source commit %q", input.SourceVersion)
@@ -186,7 +179,7 @@ func NewGraphWithCheckpoint(
 			if stateValue(access, func(state *State) string { return state.BuildID }) != "" {
 				return nil
 			}
-			return service.PollMirror(ctx, input.MirrorTarget, input.SourceVersion)
+			return service.PollMirror(ctx, input.SourceVersion)
 		},
 	)
 	queue := verifyMirror.Then(
@@ -201,7 +194,7 @@ func NewGraphWithCheckpoint(
 					return err
 				}
 			}
-			buildID, err := service.QueuePipeline(ctx, input.PipelineID, parameters)
+			buildID, err := service.QueuePipeline(ctx, parameters)
 			if err != nil {
 				return err
 			}

--- a/cmd/releaseagent/internal/goimagesworkflow/workflow_test.go
+++ b/cmd/releaseagent/internal/goimagesworkflow/workflow_test.go
@@ -16,8 +16,7 @@ const testCommit = "81ce9afc2b75ec4e153dd15fc3c7539b12024945"
 
 var testInput = &Input{
 	Versions: []string{"1.25.12-1", "1.26.5-2"}, Mode: ModeNormal,
-	SourceBranch: "refs/heads/microsoft/main", SourceVersion: testCommit,
-	MirrorTarget: InternalMirrorTarget, PipelineID: 1023,
+	SourceVersion: testCommit,
 }
 
 type fakeService struct {
@@ -27,17 +26,17 @@ type fakeService struct {
 	polls     int
 }
 
-func (service *fakeService) PollMirror(_ context.Context, target, commit string) error {
+func (service *fakeService) PollMirror(_ context.Context, commit string) error {
 	service.mirrors++
-	if target != InternalMirrorTarget || commit != testCommit {
-		return errors.New("unexpected mirror target")
+	if commit != testCommit {
+		return errors.New("unexpected mirror commit")
 	}
 	return service.mirrorErr
 }
 
-func (service *fakeService) QueuePipeline(_ context.Context, pipelineID int, parameters map[string]string) (string, error) {
+func (service *fakeService) QueuePipeline(_ context.Context, parameters map[string]string) (string, error) {
 	service.queues++
-	if pipelineID != 1023 || parameters["publishRepoPrefix"] != "public/" {
+	if parameters["publishRepoPrefix"] != "public/" {
 		return "", errors.New("unexpected queue request")
 	}
 	return "888", nil

--- a/cmd/releaseagent/internal/releaseui/disabled_services.go
+++ b/cmd/releaseagent/internal/releaseui/disabled_services.go
@@ -17,11 +17,11 @@ var ErrExternalExecutionDisabled = errors.New("external release execution is dis
 
 type disabledGoImagesService struct{}
 
-func (disabledGoImagesService) PollMirror(context.Context, string, string) error {
+func (disabledGoImagesService) PollMirror(context.Context, string) error {
 	return ErrExternalExecutionDisabled
 }
 
-func (disabledGoImagesService) QueuePipeline(context.Context, int, map[string]string) (string, error) {
+func (disabledGoImagesService) QueuePipeline(context.Context, map[string]string) (string, error) {
 	return "", ErrExternalExecutionDisabled
 }
 
@@ -36,11 +36,11 @@ type restoredRunMonitor struct {
 	monitor func(context.Context, int) error
 }
 
-func (restoredRunMonitor) PollMirror(context.Context, string, string) error {
+func (restoredRunMonitor) PollMirror(context.Context, string) error {
 	return errors.New("a restored-run monitor cannot verify a source mirror")
 }
 
-func (restoredRunMonitor) QueuePipeline(context.Context, int, map[string]string) (string, error) {
+func (restoredRunMonitor) QueuePipeline(context.Context, map[string]string) (string, error) {
 	return "", errors.New("a restored-run monitor cannot queue a pipeline")
 }
 

--- a/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
@@ -138,7 +138,7 @@ func TestUncertainGoInfraRunDoesNotHideBehindGoImagesSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	first := newTestUI(t, WithSessionStore(sessionStore), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	createTestPlan(t, first, `{"mode":"normal"}`)
 	github := &fakeGoInfraGitHub{pullRequest: testGoInfraPullRequest()}

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -32,8 +32,6 @@ import (
 
 const (
 	sessionCookieName       = "releaseui_session"
-	goImagesPipelineID      = 1023
-	goImagesSourceBranch    = "refs/heads/microsoft/main"
 	goImagesProcessID       = "go-images"
 	goImagesPipelineName    = "microsoft-go-images (official)"
 	goImagesPipelineOrg     = "dnceng"
@@ -97,7 +95,6 @@ type GoImagesRollbackSource struct {
 // GoImagesReadOnlyIntegration is the explicitly enabled Azure read boundary. It resolves current
 // main and validates rollback builds but cannot queue, cancel, approve, or otherwise mutate a run.
 type GoImagesReadOnlyIntegration struct {
-	DefinitionID         int
 	Preflight            func(context.Context) (string, error)
 	ResolveCurrentSource func(context.Context) (GoImagesSource, error)
 	ValidateRollback     func(context.Context, int) (GoImagesRollbackSource, error)
@@ -106,8 +103,7 @@ type GoImagesReadOnlyIntegration struct {
 // GoImagesExecutionIntegration is the only real execution boundary. Its implementation must
 // hardcode definition 1023 and microsoft/main, and derive parameters from the selected mode.
 type GoImagesExecutionIntegration struct {
-	DefinitionID int
-	NewService   func(GoImagesExecutionRequest) (goimagesworkflow.Service, error)
+	NewService func(GoImagesExecutionRequest) (goimagesworkflow.Service, error)
 }
 
 // GoImagesExecutionRequest binds one real run to a confirmed durable plan.
@@ -184,9 +180,6 @@ func New(ctx context.Context, options ...Option) (*Server, error) {
 		if server.sessionStore == nil {
 			return nil, errors.New("go-images source resolution requires a durable session store")
 		}
-		if server.readOnly.DefinitionID != goImagesPipelineID {
-			return nil, fmt.Errorf("go-images definition %d is not allowlisted", server.readOnly.DefinitionID)
-		}
 		if server.readOnly.Preflight == nil || server.readOnly.ResolveCurrentSource == nil ||
 			server.readOnly.ValidateRollback == nil {
 
@@ -196,9 +189,6 @@ func New(ctx context.Context, options ...Option) (*Server, error) {
 	if server.execution != nil {
 		if server.sessionStore == nil || server.readOnly == nil {
 			return nil, errors.New("go-images execution requires durable storage and read-only validation")
-		}
-		if server.execution.DefinitionID != goImagesPipelineID {
-			return nil, fmt.Errorf("go-images execution definition %d is not allowlisted", server.execution.DefinitionID)
 		}
 		if server.execution.NewService == nil {
 			return nil, errors.New("go-images execution integration is incomplete")
@@ -658,11 +648,8 @@ func (s *Server) handlePlan(response http.ResponseWriter, request *http.Request)
 	releaseInput := &goimagesworkflow.Input{
 		Versions:      versions,
 		Mode:          normalized.Mode,
-		SourceBranch:  source.Branch,
 		SourceVersion: source.Commit,
 		SourceBuildID: normalized.SourceBuildID,
-		MirrorTarget:  goimagesworkflow.InternalMirrorTarget,
-		PipelineID:    goImagesPipelineID,
 	}
 	steps, releaseState, err := goimagesworkflow.NewGraphWithCheckpoint(
 		releaseInput, nil, disabledGoImagesService{}, s.checkpointReleaseState,
@@ -768,14 +755,14 @@ func goImagesPlanView(
 		modeName = strings.ToUpper(modeName[:1]) + modeName[1:]
 	}
 	view := ProcessPlanView{
-		Subtitle:    fmt.Sprintf("%s release · pipeline %d · %d steps", modeName, goImagesPipelineID, stepCount),
+		Subtitle:    fmt.Sprintf("%s release · pipeline %d · %d steps", modeName, goimagesworkflow.DefinitionID, stepCount),
 		IntentBadge: parameters["publishRepoPrefix"],
 		Facts: []ProcessPlanFact{{
 			Label: "Pipeline source", Value: source.Branch, Detail: source.Commit,
 		}},
 		Request: &ProcessRequestPreview{
 			Eyebrow: "Azure DevOps request preview · not sent",
-			Title:   fmt.Sprintf("Pipeline %d · %s", goImagesPipelineID, goImagesPipelineName),
+			Title:   fmt.Sprintf("Pipeline %d · %s", goimagesworkflow.DefinitionID, goImagesPipelineName),
 			Target:  goImagesPipelineOrg + "/" + goImagesPipelineProject,
 		},
 	}
@@ -800,7 +787,7 @@ func goImagesPlanView(
 		view.ExecutionButtonLabel = "Run rollback"
 		if rollbackSource != nil {
 			view.Facts = append(view.Facts, ProcessPlanFact{
-				Label: "Artifact source", Value: fmt.Sprintf("Pipeline %d build %d", goImagesPipelineID, rollbackSource.BuildID),
+				Label: "Artifact source", Value: fmt.Sprintf("Pipeline %d build %d", goimagesworkflow.DefinitionID, rollbackSource.BuildID),
 				Href: rollbackSource.URL,
 			})
 		}
@@ -858,19 +845,17 @@ func (s *Server) executionResponseLocked() executionResponse {
 		ExecutionDigest  string
 		Mode             goimagesworkflow.Mode
 		Versions         []string
-		SourceBranch     string
 		SourceVersion    string
 		SourceBuildID    string
-		DefinitionID     int
 		Parameters       map[string]string
 		WorkflowRevision int
 		WorkflowDigest   string
 	}{
 		SessionID: s.goImages.document.ID, ExecutionDigest: s.goImages.document.ExecutionDigest,
 		Mode: s.goImages.workflowInput.Mode, Versions: append([]string(nil), s.goImages.workflowInput.Versions...),
-		SourceBranch: s.goImages.workflowInput.SourceBranch, SourceVersion: s.goImages.workflowInput.SourceVersion,
-		SourceBuildID: s.goImages.workflowInput.SourceBuildID, DefinitionID: goImagesPipelineID,
-		Parameters: parameters, WorkflowRevision: plan.WorkflowRevision, WorkflowDigest: plan.Digest,
+		SourceVersion: s.goImages.workflowInput.SourceVersion,
+		SourceBuildID: s.goImages.workflowInput.SourceBuildID,
+		Parameters:    parameters, WorkflowRevision: plan.WorkflowRevision, WorkflowDigest: plan.Digest,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -912,7 +897,7 @@ func (s *Server) restoreSession() error {
 	s.steps = steps
 	s.goImages.planInput = PlanInput{Mode: input.Mode, SourceBuildID: input.SourceBuildID}
 	s.goImages.source = GoImagesSource{
-		Branch: input.SourceBranch, Commit: input.SourceVersion,
+		Branch: goimagesworkflow.SourceBranch, Commit: input.SourceVersion,
 		Versions: append([]string(nil), input.Versions...),
 	}
 	if input.Mode == goimagesworkflow.ModeRollback {
@@ -1081,7 +1066,7 @@ func (s *Server) handleReleaseStart(response http.ResponseWriter, request *http.
 			writeError(response, http.StatusPreconditionFailed, fmt.Sprintf("re-resolve current microsoft/main: %v", err))
 			return
 		}
-		if current.Branch != input.SourceBranch || current.Commit != input.SourceVersion {
+		if current.Branch != goimagesworkflow.SourceBranch || current.Commit != input.SourceVersion {
 			s.finishRelease()
 			writeError(response, http.StatusConflict, "microsoft/main changed after this plan was prepared; refresh the plan before queueing")
 			return
@@ -1164,7 +1149,7 @@ func normalizePlanInput(input PlanInput) (PlanInput, error) {
 }
 
 func validateCurrentSource(source GoImagesSource) error {
-	if source.Branch != goImagesSourceBranch {
+	if source.Branch != goimagesworkflow.SourceBranch {
 		return fmt.Errorf("resolved go-images branch %q is not allowlisted", source.Branch)
 	}
 	if len(source.Commit) != 40 {

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	testSourceCommit = "81ce9afc2b75ec4e153dd15fc3c7539b12024945"
+	testSourceBranch = goimagesworkflow.SourceBranch
 	testGoImagesAPI  = "/api/processes/go-images"
 )
 
@@ -73,8 +74,7 @@ func newTestUI(t *testing.T, options ...Option) *testUI {
 
 func testReadOnly(source *GoImagesSource, rollbackCalls *int) GoImagesReadOnlyIntegration {
 	return GoImagesReadOnlyIntegration{
-		DefinitionID: goImagesPipelineID,
-		Preflight:    func(context.Context) (string, error) { return "verified", nil },
+		Preflight: func(context.Context) (string, error) { return "verified", nil },
 		ResolveCurrentSource: func(context.Context) (GoImagesSource, error) {
 			return *source, nil
 		},
@@ -290,7 +290,6 @@ func TestExecutionOptionRequiresReadOnlyValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 	execution := GoImagesExecutionIntegration{
-		DefinitionID: goImagesPipelineID,
 		NewService: func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
 			return &fakeExecutionService{}, nil
 		},
@@ -319,7 +318,7 @@ func TestPrepareReleaseModes(t *testing.T) {
 				t.Fatal(err)
 			}
 			source := GoImagesSource{
-				Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2", "1.25.12-1"},
+				Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2", "1.25.12-1"},
 			}
 			rollbackCalls := 0
 			ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, &rollbackCalls)))
@@ -355,7 +354,7 @@ func TestPlanRejectsInputsOutsideSelectedMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	for _, body := range []string{
 		`{"mode":"normal","sourceBuildId":"123"}`,
@@ -376,7 +375,7 @@ func TestPersistAndRestoreModePlan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	first := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	created := createTestPlan(t, first, `{"mode":"test"}`)
 	if created.SessionID == "" || strings.Contains(created.View.Subtitle, "restored from disk") {
@@ -410,7 +409,7 @@ func TestRestoredQueuedReleaseAutomaticallyResumesMonitoring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	first := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	createTestPlan(t, first, `{"mode":"test"}`)
 	document, err := store.Load(context.Background())
@@ -433,7 +432,6 @@ func TestRestoredQueuedReleaseAutomaticallyResumesMonitoring(t *testing.T) {
 		WithSessionStore(store),
 		WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)),
 		WithGoImagesExecutionIntegration(GoImagesExecutionIntegration{
-			DefinitionID: goImagesPipelineID,
 			NewService: func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
 				return service, nil
 			},
@@ -461,19 +459,16 @@ type fakeExecutionService struct {
 	mirrorErr   error
 }
 
-func (s *fakeExecutionService) PollMirror(_ context.Context, target, commit string) error {
+func (s *fakeExecutionService) PollMirror(_ context.Context, commit string) error {
 	s.mirrors++
-	if target != goimagesworkflow.InternalMirrorTarget || commit != testSourceCommit {
+	if commit != testSourceCommit {
 		return errors.New("unexpected mirror source")
 	}
 	return s.mirrorErr
 }
 
-func (s *fakeExecutionService) QueuePipeline(_ context.Context, pipelineID int, parameters map[string]string) (string, error) {
+func (s *fakeExecutionService) QueuePipeline(_ context.Context, parameters map[string]string) (string, error) {
 	s.queued++
-	if pipelineID != goImagesPipelineID {
-		return "", errors.New("unsafe execution request")
-	}
 	want, err := goimagesworkflow.PipelineParameters(s.mode, s.sourceBuild)
 	if err != nil {
 		return "", err
@@ -497,7 +492,7 @@ func TestRealReleaseRequiresExactIntent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	service := &fakeExecutionService{mode: goimagesworkflow.ModeNormal}
 	preflightCalls := 0
 	readOnly := testReadOnly(&source, nil)
@@ -509,7 +504,6 @@ func TestRealReleaseRequiresExactIntent(t *testing.T) {
 		WithSessionStore(store),
 		WithGoImagesReadOnlyIntegration(readOnly),
 		WithGoImagesExecutionIntegration(GoImagesExecutionIntegration{
-			DefinitionID: goImagesPipelineID,
 			NewService: func(request GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
 				if request.Mode != goimagesworkflow.ModeNormal || request.SourceVersion != testSourceCommit ||
 					len(request.ExecutionDigest) != 64 || request.SourceBuildID != "" {
@@ -577,7 +571,7 @@ func TestReleaseDoesNotQueueWhenMirrorVerificationFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	service := &fakeExecutionService{
 		mode:      goimagesworkflow.ModeNormal,
 		mirrorErr: errors.New("commit is not available in the internal mirror"),
@@ -586,7 +580,6 @@ func TestReleaseDoesNotQueueWhenMirrorVerificationFails(t *testing.T) {
 		WithSessionStore(store),
 		WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)),
 		WithGoImagesExecutionIntegration(GoImagesExecutionIntegration{
-			DefinitionID: goImagesPipelineID,
 			NewService: func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
 				return service, nil
 			},
@@ -610,14 +603,13 @@ func TestReleaseRejectsWhenMainAdvances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	service := &fakeExecutionService{mode: goimagesworkflow.ModeTest}
 	ui := newTestUI(t,
 		WithSessionStore(store),
 		WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)),
 		WithGoImagesExecutionIntegration(GoImagesExecutionIntegration{
-			DefinitionID: goImagesPipelineID,
-			NewService:   func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) { return service, nil },
+			NewService: func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) { return service, nil },
 		}),
 	)
 	plan := createTestPlan(t, ui, `{"mode":"test"}`)
@@ -635,7 +627,7 @@ func TestCreatePlanAndRunSimulation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	plan := createTestPlan(t, ui, `{"mode":"normal"}`)
 	if plan.Execution.Enabled || len(plan.Steps) != 4 {
@@ -676,7 +668,7 @@ func TestEventsSendInitialSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	source := GoImagesSource{Branch: goImagesSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	createTestPlan(t, ui, `{"mode":"normal"}`)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/releaseagent/serve.go
+++ b/cmd/releaseagent/serve.go
@@ -146,9 +146,8 @@ func handleServe(parse subcmd.ParseFunc) error {
 		return releaseui.GoImagesSource{Branch: tip.Name, Commit: tip.ObjectID, Versions: versions}, nil
 	}
 	options = append(options, releaseui.WithGoImagesReadOnlyIntegration(releaseui.GoImagesReadOnlyIntegration{
-		DefinitionID: 1023,
 		Preflight: func(ctx context.Context) (string, error) {
-			definition, err := azureClient.GetDefinition(ctx, 1023)
+			definition, err := azureClient.GetDefinition(ctx, goimagesworkflow.DefinitionID)
 			if err != nil {
 				return "", err
 			}
@@ -164,7 +163,7 @@ func handleServe(parse subcmd.ParseFunc) error {
 		},
 		ResolveCurrentSource: resolveCurrentSource,
 		ValidateRollback: func(ctx context.Context, buildID int) (releaseui.GoImagesRollbackSource, error) {
-			source, err := goimagesrelease.ValidateRollbackSource(ctx, azureClient, versionResolver, 1023, buildID)
+			source, err := goimagesrelease.ValidateRollbackSource(ctx, azureClient, versionResolver, buildID)
 			if err != nil {
 				return releaseui.GoImagesRollbackSource{}, err
 			}
@@ -184,7 +183,6 @@ func handleServe(parse subcmd.ParseFunc) error {
 	}
 	options = append(options, releaseui.WithGoImagesExecutionIntegration(
 		releaseui.GoImagesExecutionIntegration{
-			DefinitionID: goimagesexecution.DefinitionID,
 			NewService: func(request releaseui.GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
 				return goimagesexecution.New(azureClient, queueClient, goimagesexecution.Config{
 					Mode:                 request.Mode,


### PR DESCRIPTION
Stacked on #579.

## Summary

- remove pipeline ID, source branch, and mirror target from persisted go-images input and callback arguments
- define pipeline `1023` and `refs/heads/microsoft/main` once in go-images policy
- make rollback, queue, reconciliation, and polling validate those fixed targets
- advance the unreleased go-images session schema to version 8

## Why

The UI never permits an operator to select these targets. Passing and persisting them as data made fixed policy look configurable, then required every layer to reject alternate values. This change keeps target validation at the Azure boundary while making unsafe targets impossible to express inside the workflow.

Polling now requires the returned build to identify pipeline 1023 rather than accepting a missing definition ID.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- queue-response reconciliation and restart tests pass