### PR TITLE
releaseagent: remove no-op completion step

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -144,7 +144,7 @@ The go-images session document is schema-versioned, structurally fingerprinted, 
 It contains no credentials.
 Schema version 8 stores only standalone go-images input and state. It intentionally rejects the
 older full-release-shaped prototype documents rather than retaining a second domain model and
-migration path. Workflow revision 7 uses unique step names as graph identity. Start with a new
+migration path. Workflow revision 8 uses unique step names as graph identity. Start with a new
 session file when either version is unsupported.
 
 The current session and process-run stores together own one active durable release at a time.

--- a/cmd/releaseagent/internal/coordinator/step.go
+++ b/cmd/releaseagent/internal/coordinator/step.go
@@ -40,35 +40,6 @@ func NewRootStep(name string, timeout time.Duration, f StepFunc) *Step {
 	}
 }
 
-// NewStep creates a new step with the given name, implementation, and dependencies. dependsOn must
-// contain at least one step or NewStep will panic.
-//
-// If there are no dependencies, use NewRootStep instead. These funcs are separate to prevent
-// accidentally creating a root step by omitting dependencies.
-func NewStep(name string, timeout time.Duration, f StepFunc, dependsOn ...*Step) *Step {
-	if len(dependsOn) < 1 {
-		panic("at least one dependency required to create " + name)
-	}
-	return &Step{
-		Name:      name,
-		Timeout:   timeout,
-		Func:      f,
-		DependsOn: dependsOn,
-	}
-}
-
-// NewIndicatorStep creates a new step with the given name and no implementation. An indicator step
-// generally helps a release runner understand the step graph more easily by indicating what it
-// means for a set of steps to complete, and clarify what other steps take a dependency on.
-func NewIndicatorStep(name string, dependsOnAdditional ...*Step) *Step {
-	return NewStep(
-		name,
-		NoTimeout,
-		func(context.Context) error { return nil },
-		dependsOnAdditional...,
-	)
-}
-
 // Then creates a new step that depends on s and returns the new step. This can be used when
 // defining a step graph to chain a sequence of steps together without as much syntactic clutter.
 func (s *Step) Then(name string, timeout time.Duration, f StepFunc, dependsOnAdditional ...*Step) *Step {

--- a/cmd/releaseagent/internal/coordinator/step_test.go
+++ b/cmd/releaseagent/internal/coordinator/step_test.go
@@ -29,10 +29,10 @@ func TestTransitiveDependenciesValidation(t *testing.T) {
 		step *Step
 		want string
 	}{
-		{name: "valid", step: NewStep("B", NoTimeout, nop, a)},
-		{name: "nil dependency", step: NewStep("B", NoTimeout, nop, nil), want: "nil dependency"},
-		{name: "duplicate dependency", step: NewStep("B", NoTimeout, nop, a, a), want: "more than once"},
-		{name: "duplicate name", step: NewStep("A", NoTimeout, nop, a), want: "not unique"},
+		{name: "valid", step: a.Then("B", NoTimeout, nop)},
+		{name: "nil dependency", step: &Step{Name: "B", Func: nop, DependsOn: []*Step{nil}}, want: "nil dependency"},
+		{name: "duplicate dependency", step: &Step{Name: "B", Func: nop, DependsOn: []*Step{a, a}}, want: "more than once"},
+		{name: "duplicate name", step: a.Then("A", NoTimeout, nop), want: "not unique"},
 		{name: "empty name", step: &Step{Func: nop}, want: "empty name"},
 		{name: "nil implementation", step: &Step{Name: "Nil func"}, want: "no implementation"},
 	} {

--- a/cmd/releaseagent/internal/goimagessession/session.go
+++ b/cmd/releaseagent/internal/goimagessession/session.go
@@ -23,7 +23,7 @@ const (
 	CurrentSchemaVersion = 8
 	// CurrentWorkflowRevision changes when step behavior becomes incompatible with saved state,
 	// even if step names and dependencies have not changed.
-	CurrentWorkflowRevision = 7
+	CurrentWorkflowRevision = 8
 )
 
 // Document is the durable, non-secret state needed to reconstruct a release plan.

--- a/cmd/releaseagent/internal/goimagessession/session_test.go
+++ b/cmd/releaseagent/internal/goimagessession/session_test.go
@@ -210,6 +210,6 @@ func testDocument(t *testing.T) *Document {
 
 func testSteps() []*coordinator.Step {
 	root := coordinator.NewRootStep("Root", coordinator.NoTimeout, func(context.Context) error { return nil })
-	leaf := coordinator.NewStep("Leaf", time.Minute, func(context.Context) error { return nil }, root)
+	leaf := root.Then("Leaf", time.Minute, func(context.Context) error { return nil })
 	return []*coordinator.Step{root, leaf}
 }

--- a/cmd/releaseagent/internal/goimagesworkflow/workflow.go
+++ b/cmd/releaseagent/internal/goimagesworkflow/workflow.go
@@ -220,8 +220,7 @@ func NewGraphWithCheckpoint(
 			})
 		},
 	)
-	complete := coordinator.NewIndicatorStep("✅ Go-images release complete", wait)
-	steps, err := complete.TransitiveDependencies()
+	steps, err := wait.TransitiveDependencies()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -325,7 +325,7 @@ func TestPrepareReleaseModes(t *testing.T) {
 			response := postJSON(t, ui, testGoImagesAPI+"/plan", test.body)
 			var plan planResponse
 			decodeResponse(t, response, &plan)
-			if response.StatusCode != http.StatusOK || plan.Input.Mode != test.wantMode || len(plan.Steps) != 4 {
+			if response.StatusCode != http.StatusOK || plan.Input.Mode != test.wantMode || len(plan.Steps) != 3 {
 				t.Fatalf("status = %d, plan = %#v", response.StatusCode, plan)
 			}
 			fields := make(map[string]string)
@@ -630,7 +630,7 @@ func TestCreatePlanAndRunSimulation(t *testing.T) {
 	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
 	ui := newTestUI(t, WithSessionStore(store), WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)))
 	plan := createTestPlan(t, ui, `{"mode":"normal"}`)
-	if plan.Execution.Enabled || len(plan.Steps) != 4 {
+	if plan.Execution.Enabled || len(plan.Steps) != 3 {
 		t.Fatalf("plan = %#v", plan)
 	}
 	response := postJSON(t, ui, testGoImagesAPI+"/simulate", `{}`)


### PR DESCRIPTION
Stacked on #580.

## Summary

- remove the no-op fourth node from the focused go-images graph
- let the real pipeline-monitoring step represent successful completion
- remove coordinator constructors that become unused
- advance the unreleased workflow revision to version 8

## Why

The indicator step performed no release work and repeated the completion already recorded by the wait step. Removing it reduces the displayed and persisted graph to its three executable operations: verify the mirror, queue the pipeline, and monitor the build.

This does not remove or sequentialize the coordinator. Dependency validation, `Then` joins, concurrent execution, snapshots, and simulation remain intact.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- golangci-lint v2.10.0
- simulation coverage remains