### PR TITLE
Add compliance assessment completion tool

### DIFF
--- a/cmd/compliance/README.md
+++ b/cmd/compliance/README.md
@@ -1,0 +1,39 @@
+# Compliance assessment completion tool
+
+`compliance` copies questionnaire answers from the most recent earlier completed assessment for each policy in an Azure DevOps compliance assessment group. It then saves each assessment, generates its work items, and completes child work items whose matching source activity was completed.
+
+The command uses the Azure DevOps API directly. Authentication comes from `az login`, or from `AZURE_DEVOPS_EXT_PAT` when using a PAT configured for the Azure DevOps CLI.
+
+Start with a read-only dry run:
+
+```sh
+go run ./cmd/compliance \
+  -url https://dev.azure.com/ORGANIZATION/PROJECT/_compliance/product/PRODUCT-ID/assessments
+```
+
+The dry run selects the newest assessment group, identifies the latest completed source for each policy, checks current question IDs, and validates the prior work-item configuration. It does not save assessments or create work items.
+
+After reviewing the output, pin the group and apply it:
+
+```sh
+go run ./cmd/compliance \
+  -url https://dev.azure.com/ORGANIZATION/PROJECT/_compliance/product/PRODUCT-ID/assessments \
+  -assessment-group ASSESSMENT-GROUP \
+  -apply
+```
+
+Safety behavior:
+
+- Completed assessments are skipped.
+- Assessments whose last completion session failed are retried on the next apply run.
+- Generated child work items are completed only when the same activity node was completed in the selected source assessment. Parent work items are left open, matching the source assessment behavior.
+- In-progress assessments are skipped unless `-overwrite` is supplied.
+- Prior answers are copied only when their question IDs still exist and their question definitions are unchanged in the current questionnaire.
+- A changed questionnaire blocks that assessment when answers would be dropped. Use `-allow-partial` only after reviewing the dry-run output.
+- `-answers-only` saves copied answers but does not generate work items or mark the assessment complete.
+- `-source-group NAME` restricts all answers and work-item settings to one prior group.
+- `-answers-file PATH` supplies complete answer overrides for assessments whose questionnaires changed. The file is a JSON object keyed by assessment name, with arrays of `{ "questionId": "...", "answers": ["..."] }` objects. Dry run rejects missing questions, unknown IDs, duplicate IDs, empty answers, and invalid option values.
+- `-complete-activity ASSESSMENT=NODE-ID` explicitly approves completion of a current-only activity after review. It may be repeated, and dry run rejects IDs that are not present in the resulting assessment work.
+- New work items use the current Azure Boards project root for area and iteration rather than historical child paths that may have been deleted.
+
+The signed-in identity needs read and write access to compliance assessments and permission to create or update the configured Azure Boards work items.

--- a/cmd/compliance/client.go
+++ b/cmd/compliance/client.go
@@ -1,0 +1,363 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	complianceAPIVersion = "3.0-preview.1"
+	maxResponseSize      = 64 << 20
+)
+
+type complianceClient struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	token      string
+}
+
+func newComplianceClient(baseURL, token string, httpClient *http.Client) (*complianceClient, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse compliance API URL: %w", err)
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil, fmt.Errorf("compliance API URL must use HTTP or HTTPS: %q", baseURL)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("compliance API URL has no host: %q", baseURL)
+	}
+	if token == "" {
+		return nil, errors.New("access token for Azure DevOps is empty")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &complianceClient{baseURL: parsed, httpClient: httpClient, token: token}, nil
+}
+
+func (c *complianceClient) getScope(ctx context.Context, scopeID string) (*scope, error) {
+	query := url.Values{
+		"$expand": {"assessmentGroups($expand=modifiedByUser,assessments($expand=modifiedByUser))"},
+	}
+	var result scope
+	if err := c.doJSON(ctx, http.MethodGet, "scopes('"+encodeODataSegment(scopeID)+"')", query, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+type assessmentWork struct {
+	ID        string            `json:"id"`
+	Answers   []json.RawMessage `json:"answers"`
+	Work      []json.RawMessage `json:"work"`
+	Questions []question        `json:"questions"`
+}
+
+type question struct {
+	NodeID string          `json:"nodeId"`
+	Raw    json.RawMessage `json:"-"`
+}
+
+func (q *question) UnmarshalJSON(data []byte) error {
+	type questionFields question
+
+	var fields questionFields
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*q = question(fields)
+	q.Raw = append(q.Raw[:0], data...)
+	return nil
+}
+
+type assessmentWorkRequest struct {
+	Answers           []json.RawMessage `json:"answers"`
+	UseLatestGraph    bool              `json:"useLatestGraph"`
+	ScopeID           string            `json:"scopeId"`
+	PolicyNodeID      string            `json:"policyNodeId"`
+	AssessmentGroupID string            `json:"assessmentGroupId"`
+}
+
+func (c *complianceClient) getAssessmentWork(ctx context.Context, target *assessment, answers []json.RawMessage) (*assessmentWork, error) {
+	request := assessmentWorkRequest{
+		Answers:           answers,
+		UseLatestGraph:    true,
+		ScopeID:           target.ScopeID,
+		PolicyNodeID:      target.PolicyNodeID,
+		AssessmentGroupID: target.AssessmentGroupID,
+	}
+	query := url.Values{"$expand": {"work,questions"}}
+	var result assessmentWork
+	resource := "assessments('" + encodeODataSegment(target.ID) + "')/work.retrieve"
+	if err := c.doJSON(ctx, http.MethodPost, resource, query, request, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *complianceClient) getPolicyQuestions(ctx context.Context, policyID string, graphVersion int64) ([]question, error) {
+	query := url.Values{
+		"includePaqQuestions": {"false"},
+		"graphVersion":        {strconv.FormatInt(graphVersion, 10)},
+	}
+	resource := "questions/questions.getPolicyQuestions(policyId=('" + encodeODataSegment(policyID) + "'))"
+	var result collection[question]
+	if err := c.doJSON(ctx, http.MethodGet, resource, query, nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Value, nil
+}
+
+func (c *complianceClient) writeAssessment(ctx context.Context, target *assessment, answers []json.RawMessage) (*assessment, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(target.Raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode assessment %q for update: %w", target.Name, err)
+	}
+	encodedAnswers, err := json.Marshal(answers)
+	if err != nil {
+		return nil, fmt.Errorf("encode answers for assessment %q: %w", target.Name, err)
+	}
+	payload["answers"] = encodedAnswers
+	delete(payload, "modifiedByUser")
+	delete(payload, "createdByUser")
+	for key := range payload {
+		if strings.HasPrefix(key, "@odata.") {
+			delete(payload, key)
+		}
+	}
+
+	var result assessment
+	if err := c.doJSON(ctx, http.MethodPut, "assessments", nil, payload, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+type session struct {
+	ID             string            `json:"id"`
+	AssessmentID   string            `json:"assessmentId"`
+	State          string            `json:"state"`
+	FailureMessage string            `json:"failureMessage"`
+	IsInterrupted  bool              `json:"isInterrupted"`
+	ProjectID      string            `json:"projectId"`
+	WITConfigID    string            `json:"witConfigId"`
+	AreaPath       string            `json:"areaPath"`
+	IterationPath  string            `json:"iterationPath"`
+	ServerURL      string            `json:"serverUrl"`
+	WorkItems      []sessionWorkItem `json:"workItems"`
+}
+
+type sessionWorkItem struct {
+	ItemType      string        `json:"itemType"`
+	NodeID        string        `json:"nodeId"`
+	WorkItemID    string        `json:"workItemId"`
+	WorkItemState workItemState `json:"workItemState"`
+}
+
+type workItemState struct {
+	State               string `json:"state"`
+	IsCompletedCategory bool   `json:"isCompletedCategory"`
+}
+
+type collection[T any] struct {
+	Value []T `json:"value"`
+}
+
+func (c *complianceClient) getSession(ctx context.Context, sessionID string) (*session, error) {
+	query := url.Values{
+		"$filter":              {"id eq '" + escapeODataString(sessionID) + "'"},
+		"refreshWorkItemState": {"true"},
+	}
+	var result collection[session]
+	if err := c.doJSON(ctx, http.MethodGet, "sessions", query, nil, &result); err != nil {
+		return nil, err
+	}
+	if len(result.Value) != 1 {
+		return nil, fmt.Errorf("session %q: got %d results, want 1", sessionID, len(result.Value))
+	}
+	return &result.Value[0], nil
+}
+
+func (c *complianceClient) generateSession(ctx context.Context, assessmentID string, payload map[string]json.RawMessage) error {
+	resource := "assessments('" + encodeODataSegment(assessmentID) + "')/sessions.generate"
+	return c.doJSON(ctx, http.MethodPost, resource, nil, payload, nil)
+}
+
+func (c *complianceClient) getLatestSession(ctx context.Context, assessmentID string) (*session, error) {
+	query := url.Values{
+		"$filter":              {"assessmentId eq '" + escapeODataString(assessmentID) + "'"},
+		"$orderby":             {"createdDateTime desc"},
+		"$top":                 {"1"},
+		"refreshWorkItemState": {"true"},
+	}
+	var result collection[session]
+	if err := c.doJSON(ctx, http.MethodGet, "sessions", query, nil, &result); err != nil {
+		return nil, err
+	}
+	if len(result.Value) == 0 {
+		return nil, nil
+	}
+	return &result.Value[0], nil
+}
+
+func (c *complianceClient) setWorkItemState(ctx context.Context, serverURL, workItemID, state string) error {
+	parsedID, err := strconv.ParseInt(workItemID, 10, 64)
+	if err != nil || parsedID <= 0 {
+		return fmt.Errorf("invalid work item ID %q", workItemID)
+	}
+	if state == "" {
+		return errors.New("work item state is empty")
+	}
+
+	endpoint, err := url.Parse(serverURL)
+	if err != nil {
+		return fmt.Errorf("parse work item server URL: %w", err)
+	}
+	trustedTestHost := c.baseURL.Scheme == "http" && endpoint.Scheme == "http" && endpoint.Host == c.baseURL.Host
+	hostname := strings.ToLower(endpoint.Hostname())
+	trustedAzureDevOpsHost := endpoint.Scheme == "https" && (hostname == "dev.azure.com" || strings.HasSuffix(hostname, ".visualstudio.com"))
+	if endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Host == "" || !trustedTestHost && !trustedAzureDevOpsHost {
+		return fmt.Errorf("untrusted work item server URL %q", serverURL)
+	}
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/_apis/wit/workitems/" + strconv.FormatInt(parsedID, 10)
+	endpoint.RawQuery = url.Values{"api-version": {"7.1"}}.Encode()
+
+	patch := []struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value string `json:"value"`
+	}{{Op: "replace", Path: "/fields/System.State", Value: state}}
+	body, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("encode work item state update: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create work item state update: %w", err)
+	}
+	request.SetBasicAuth("", c.token)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json-patch+json")
+	request.Header.Set("X-TFS-FedAuthRedirect", "Suppress")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("update work item %s state: %w", workItemID, err)
+	}
+	defer response.Body.Close()
+	responseData, err := io.ReadAll(io.LimitReader(response.Body, maxResponseSize+1))
+	if err != nil {
+		return fmt.Errorf("read work item %s update response: %w", workItemID, err)
+	}
+	if len(responseData) > maxResponseSize {
+		return fmt.Errorf("read work item %s update response: body exceeds %d bytes", workItemID, maxResponseSize)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		message := jsonErrorMessage(response.Header.Get("Content-Type"), responseData)
+		if message != "" {
+			return fmt.Errorf("update work item %s state: HTTP %d: %s", workItemID, response.StatusCode, message)
+		}
+		return fmt.Errorf("update work item %s state: HTTP %d", workItemID, response.StatusCode)
+	}
+	return nil
+}
+
+func (c *complianceClient) doJSON(ctx context.Context, method, resource string, query url.Values, requestBody, responseBody any) error {
+	endpoint := *c.baseURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/v2/_odata/" + resource
+	endpoint.RawQuery = query.Encode()
+
+	var body io.Reader
+	if requestBody != nil {
+		encoded, err := json.Marshal(requestBody)
+		if err != nil {
+			return fmt.Errorf("encode %s request: %w", resource, err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), body)
+	if err != nil {
+		return fmt.Errorf("create %s request: %w", resource, err)
+	}
+	request.SetBasicAuth("", c.token)
+	request.Header.Set("Accept", "application/json;api-version="+complianceAPIVersion+";excludeUrls=true")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-TFS-FedAuthRedirect", "Suppress")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("send %s request: %w", resource, err)
+	}
+	defer response.Body.Close()
+
+	responseData, err := io.ReadAll(io.LimitReader(response.Body, maxResponseSize+1))
+	if err != nil {
+		return fmt.Errorf("read %s response: %w", resource, err)
+	}
+	if len(responseData) > maxResponseSize {
+		return fmt.Errorf("read %s response: body exceeds %d bytes", resource, maxResponseSize)
+	}
+
+	mediaType, _, mediaTypeErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		message := jsonErrorMessage(response.Header.Get("Content-Type"), responseData)
+		if message != "" {
+			return fmt.Errorf("%s %s: HTTP %d: %s", method, resource, response.StatusCode, message)
+		}
+		return fmt.Errorf("%s %s: HTTP %d", method, resource, response.StatusCode)
+	}
+	if responseBody == nil || len(responseData) == 0 {
+		return nil
+	}
+	if mediaTypeErr != nil || mediaType != "application/json" {
+		return fmt.Errorf("decode %s response: unexpected content type %q", resource, response.Header.Get("Content-Type"))
+	}
+	if err := json.Unmarshal(responseData, responseBody); err != nil {
+		return fmt.Errorf("decode %s response: %w", resource, err)
+	}
+	return nil
+}
+
+func jsonErrorMessage(contentType string, data []byte) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
+		return ""
+	}
+	var apiError struct {
+		Message string `json:"message"`
+		Error   struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(data, &apiError) != nil {
+		return ""
+	}
+	if apiError.Message != "" {
+		return apiError.Message
+	}
+	return apiError.Error.Message
+}
+
+func encodeODataSegment(value string) string {
+	value = strings.ReplaceAll(value, "/", "∕")
+	value = strings.ReplaceAll(value, "+", "➕")
+	return escapeODataString(value)
+}
+
+func escapeODataString(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}

--- a/cmd/compliance/client.go
+++ b/cmd/compliance/client.go
@@ -248,7 +248,7 @@ func (c *complianceClient) setWorkItemState(ctx context.Context, serverURL, work
 	if err != nil {
 		return fmt.Errorf("create work item state update: %w", err)
 	}
-	request.SetBasicAuth("", c.token)
+	c.setAuthorization(request)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json-patch+json")
 	request.Header.Set("X-TFS-FedAuthRedirect", "Suppress")
@@ -293,7 +293,7 @@ func (c *complianceClient) doJSON(ctx context.Context, method, resource string, 
 	if err != nil {
 		return fmt.Errorf("create %s request: %w", resource, err)
 	}
-	request.SetBasicAuth("", c.token)
+	c.setAuthorization(request)
 	request.Header.Set("Accept", "application/json;api-version="+complianceAPIVersion+";excludeUrls=true")
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("X-TFS-FedAuthRedirect", "Suppress")
@@ -330,6 +330,20 @@ func (c *complianceClient) doJSON(ctx context.Context, method, resource string, 
 		return fmt.Errorf("decode %s response: %w", resource, err)
 	}
 	return nil
+}
+
+func (c *complianceClient) setAuthorization(request *http.Request) {
+	if isJWT(c.token) {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+		return
+	}
+	request.SetBasicAuth("", c.token)
+}
+
+// isJWT distinguishes Azure CLI access tokens from opaque Azure DevOps PATs.
+func isJWT(token string) bool {
+	parts := strings.Split(token, ".")
+	return len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != ""
 }
 
 func jsonErrorMessage(contentType string, data []byte) string {

--- a/cmd/compliance/client_test.go
+++ b/cmd/compliance/client_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestComplianceClientWorkflowRequests(t *testing.T) {
+	const token = "test-token"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "" || password != token {
+			t.Errorf("unexpected basic authentication: ok=%v username=%q", ok, username)
+		}
+		expectedAccept := "application/json;api-version=3.0-preview.1;excludeUrls=true"
+		if strings.Contains(r.URL.Path, "/_apis/wit/") {
+			expectedAccept = "application/json"
+		}
+		if got := r.Header.Get("Accept"); got != expectedAccept {
+			t.Errorf("Accept = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json; odata.metadata=minimal")
+
+		switch requests {
+		case 1:
+			if r.Method != http.MethodGet || r.URL.Path != "/account/v2/_odata/scopes('scope-id')" {
+				t.Fatalf("scope request = %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query().Get("$expand"); got != "assessmentGroups($expand=modifiedByUser,assessments($expand=modifiedByUser))" {
+				t.Errorf("scope expansion = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"scope-id","name":"Product","assessmentGroups":[]}`))
+		case 2:
+			if r.Method != http.MethodPost || r.URL.Path != "/account/v2/_odata/assessments('assessment-id')/work.retrieve" {
+				t.Fatalf("work request = %s %s", r.Method, r.URL.Path)
+			}
+			var body assessmentWorkRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if !body.UseLatestGraph || body.ScopeID != "scope-id" || body.PolicyNodeID != "policy-id" || len(body.Answers) != 1 {
+				t.Errorf("work request body = %+v", body)
+			}
+			_, _ = w.Write([]byte(`{"id":"assessment-id","answers":[],"work":[],"questions":[{"nodeId":"question-id"}]}`))
+		case 3:
+			if r.Method != http.MethodGet || r.URL.Path != "/account/v2/_odata/questions/questions.getPolicyQuestions(policyId=('cai-security∕policy-id'))" {
+				t.Fatalf("questions request = %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query().Get("graphVersion"); got != "123" {
+				t.Errorf("graph version = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"value":[{"nodeId":"question-id"}]}`))
+		case 4:
+			if r.Method != http.MethodPut || r.URL.Path != "/account/v2/_odata/assessments" {
+				t.Fatalf("assessment request = %s %s", r.Method, r.URL.Path)
+			}
+			var body map[string]json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := body["modifiedByUser"]; ok {
+				t.Error("assessment update includes expanded modifiedByUser")
+			}
+			if got := rawArrayLength(t, body["answers"]); got != 1 {
+				t.Errorf("assessment answer count = %d, want 1", got)
+			}
+			_, _ = w.Write([]byte(`{"id":"assessment-id","name":"Policy","scopeId":"scope-id","assessmentGroupId":"group-id","policyNodeId":"policy-id","answers":[]}`))
+		case 5:
+			if r.Method != http.MethodGet || r.URL.Path != "/account/v2/_odata/sessions" {
+				t.Fatalf("session request = %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query().Get("$filter"); got != "id eq 'session-id'" {
+				t.Errorf("session filter = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"value":[{"id":"session-id","state":"complete","workItems":[]}]}`))
+		case 6:
+			if r.Method != http.MethodPost || r.URL.Path != "/account/v2/_odata/assessments('assessment-id')/sessions.generate" {
+				t.Fatalf("generate request = %s %s", r.Method, r.URL.Path)
+			}
+			_, _ = w.Write([]byte(`null`))
+		case 7:
+			if r.Method != http.MethodGet || r.URL.Path != "/account/v2/_odata/sessions" {
+				t.Fatalf("latest session request = %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.URL.Query().Get("$filter"); got != "assessmentId eq 'assessment-id'" {
+				t.Errorf("latest session filter = %q", got)
+			}
+			if got := r.URL.Query().Get("$orderby"); got != "createdDateTime desc" {
+				t.Errorf("latest session order = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"value":[{"id":"new-session","assessmentId":"assessment-id","state":"complete","workItems":[]}]}`))
+		case 8:
+			if r.Method != http.MethodPatch || r.URL.Path != "/project/_apis/wit/workitems/123" {
+				t.Fatalf("work item update = %s %s", r.Method, r.URL.Path)
+			}
+			if got := r.Header.Get("Content-Type"); got != "application/json-patch+json" {
+				t.Errorf("work item update content type = %q", got)
+			}
+			var patch []struct {
+				Op    string `json:"op"`
+				Path  string `json:"path"`
+				Value string `json:"value"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+				t.Fatal(err)
+			}
+			if len(patch) != 1 || patch[0].Op != "replace" || patch[0].Path != "/fields/System.State" || patch[0].Value != "Completed" {
+				t.Errorf("work item patch = %+v", patch)
+			}
+			_, _ = w.Write([]byte(`{"id":123,"fields":{"System.State":"Completed"}}`))
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requests, r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newComplianceClient(server.URL+"/account", token, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := client.getScope(ctx, "scope-id"); err != nil {
+		t.Fatal(err)
+	}
+	answer := json.RawMessage(`{"questionId":"question-id","answers":["yes"]}`)
+	targetJSON := `{"id":"assessment-id","name":"Policy","scopeId":"scope-id","assessmentGroupId":"group-id","policyNodeId":"policy-id","answers":[],"modifiedByUser":{"id":"user"}}`
+	var target assessment
+	if err := json.Unmarshal([]byte(targetJSON), &target); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.getAssessmentWork(ctx, &target, []json.RawMessage{answer}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.getPolicyQuestions(ctx, "cai-security/policy-id", 123); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.writeAssessment(ctx, &target, []json.RawMessage{answer}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.getSession(ctx, "session-id"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.generateSession(ctx, "assessment-id", map[string]json.RawMessage{"name": json.RawMessage(`"session"`)}); err != nil {
+		t.Fatal(err)
+	}
+	latest, err := client.getLatestSession(ctx, "assessment-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latest.ID != "new-session" {
+		t.Fatalf("latest session ID = %q", latest.ID)
+	}
+	if err := client.setWorkItemState(ctx, server.URL+"/project", "123", "Completed"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 8 {
+		t.Fatalf("request count = %d, want 8", requests)
+	}
+}
+
+func TestComplianceClientRejectsNonJSONErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("<html>sensitive proxy response</html>"))
+	}))
+	defer server.Close()
+
+	client, err := newComplianceClient(server.URL, "test-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.getScope(context.Background(), "scope-id")
+	if err == nil {
+		t.Fatal("getScope succeeded, want error")
+	}
+	if got := err.Error(); got != "GET scopes('scope-id'): HTTP 503" {
+		t.Fatalf("error = %q", got)
+	}
+	if strings.Contains(err.Error(), "sensitive") {
+		t.Fatal("error includes non-JSON response body")
+	}
+}
+
+func rawArrayLength(t *testing.T, data json.RawMessage) int {
+	t.Helper()
+	var values []json.RawMessage
+	if err := json.Unmarshal(data, &values); err != nil {
+		t.Fatal(err)
+	}
+	return len(values)
+}

--- a/cmd/compliance/client_test.go
+++ b/cmd/compliance/client_test.go
@@ -191,6 +191,41 @@ func TestComplianceClientRejectsNonJSONErrorBody(t *testing.T) {
 	}
 }
 
+func TestComplianceClientUsesBearerAuthForJWT(t *testing.T) {
+	const token = "header.payload.signature"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Errorf("Authorization = %q", got)
+		}
+		if _, _, ok := r.BasicAuth(); ok {
+			t.Error("request unexpectedly uses basic authentication")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/_apis/wit/") {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"scope-id","name":"Product","assessmentGroups":[]}`))
+	}))
+	defer server.Close()
+
+	client, err := newComplianceClient(server.URL+"/account", token, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.getScope(context.Background(), "scope-id"); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.setWorkItemState(context.Background(), server.URL+"/project", "123", "Completed"); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("request count = %d, want 2", requests)
+	}
+}
+
 func rawArrayLength(t *testing.T, data json.RawMessage) int {
 	t.Helper()
 	var values []json.RawMessage

--- a/cmd/compliance/complete.go
+++ b/cmd/compliance/complete.go
@@ -365,6 +365,14 @@ func planWorkItemClosures(source, target *session, approvedCurrentNodes map[stri
 	}
 
 	sourceByNode := make(map[string]sessionWorkItem)
+	normalizedApprovals := make(map[string]string, len(approvedCurrentNodes))
+	for nodeID := range approvedCurrentNodes {
+		normalizedNodeID := normalizeActivityNodeID(nodeID)
+		if previous, exists := normalizedApprovals[normalizedNodeID]; exists {
+			return nil, fmt.Errorf("approved current nodes %q and %q are duplicates", previous, nodeID)
+		}
+		normalizedApprovals[normalizedNodeID] = nodeID
+	}
 	completedState := ""
 	for _, item := range source.WorkItems {
 		if item.ItemType != "child" {
@@ -400,12 +408,12 @@ func planWorkItemClosures(source, target *session, approvedCurrentNodes map[stri
 				return nil, fmt.Errorf("source child node %q was not completed", item.NodeID)
 			}
 			state = sourceItem.WorkItemState.State
-		} else if _, approved := approvedCurrentNodes[item.NodeID]; approved {
+		} else if _, approved := normalizedApprovals[normalizeActivityNodeID(item.NodeID)]; approved {
 			if completedState == "" {
 				return nil, fmt.Errorf("cannot determine a single completed state for approved current node %q", item.NodeID)
 			}
 			state = completedState
-			usedApprovals[item.NodeID] = struct{}{}
+			usedApprovals[normalizeActivityNodeID(item.NodeID)] = struct{}{}
 		} else {
 			return nil, fmt.Errorf("generated child node %q has no matching source work item", item.NodeID)
 		}
@@ -417,9 +425,9 @@ func planWorkItemClosures(source, target *session, approvedCurrentNodes map[stri
 		}
 		closures = append(closures, workItemClosure{WorkItemID: item.WorkItemID, State: state})
 	}
-	for nodeID := range approvedCurrentNodes {
-		if _, used := usedApprovals[nodeID]; !used {
-			return nil, fmt.Errorf("approved current node %q is not an open generated child", nodeID)
+	for normalizedNodeID, originalNodeID := range normalizedApprovals {
+		if _, used := usedApprovals[normalizedNodeID]; !used {
+			return nil, fmt.Errorf("approved current node %q is not an open generated child", originalNodeID)
 		}
 	}
 	if len(closures) > 0 && target.ServerURL == "" {

--- a/cmd/compliance/complete.go
+++ b/cmd/compliance/complete.go
@@ -1,0 +1,706 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"time"
+)
+
+type complianceAPI interface {
+	getAssessmentWork(context.Context, *assessment, []json.RawMessage) (*assessmentWork, error)
+	getPolicyQuestions(context.Context, string, int64) ([]question, error)
+	writeAssessment(context.Context, *assessment, []json.RawMessage) (*assessment, error)
+	getSession(context.Context, string) (*session, error)
+	getLatestSession(context.Context, string) (*session, error)
+	generateSession(context.Context, string, map[string]json.RawMessage) error
+	setWorkItemState(context.Context, string, string, string) error
+}
+
+type completionOptions struct {
+	Apply              bool
+	AnswersOnly        bool
+	AllowPartial       bool
+	AnswerOverrides    map[string][]json.RawMessage
+	CompleteActivities map[string]map[string]struct{}
+	PollInterval       time.Duration
+}
+
+type completionResult struct {
+	AssessmentName string
+	SourceGroup    string
+	CopiedAnswers  int
+	DroppedAnswers int
+	QuestionCount  int
+	WorkCount      int
+	WorkItemCount  int
+	SessionID      string
+	Status         string
+	Err            error
+}
+
+func runCompletionPlan(ctx context.Context, api complianceAPI, s *scope, plan *completionPlan, options completionOptions) ([]completionResult, error) {
+	results := make([]completionResult, 0, len(plan.Items))
+	var resultErrors []error
+
+	for _, item := range plan.Items {
+		result := completionResult{AssessmentName: item.Target.Name}
+		if item.SourceGroup != nil {
+			result.SourceGroup = item.SourceGroup.Name
+		}
+		if item.SkipReason != "" {
+			result.Status = "skipped: " + item.SkipReason
+			results = append(results, result)
+			continue
+		}
+		if item.ExistingSession != nil {
+			result.WorkItemCount = childWorkItemCount(item.ExistingSession)
+			sourceSession, err := api.getSession(ctx, item.Source.LastSession.SessionID)
+			if err != nil {
+				result.Status = "failed"
+				result.Err = fmt.Errorf("read source completion session: %w", err)
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+			closures, err := planWorkItemClosures(sourceSession, item.ExistingSession, options.CompleteActivities[item.Target.Name])
+			if err != nil {
+				result.Status = "needs review"
+				result.Err = err
+				if options.Apply {
+					resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+				}
+				results = append(results, result)
+				continue
+			}
+			if options.AnswersOnly {
+				result.Status = "skipped: completion session already generated"
+				results = append(results, result)
+				continue
+			}
+			if !options.Apply {
+				result.Status = fmt.Sprintf("ready to complete %d work items", len(closures))
+				results = append(results, result)
+				continue
+			}
+			completed, err := applyWorkItemClosures(ctx, api, item.ExistingSession, closures, options.PollInterval)
+			if err != nil {
+				result.Status = "work-item completion failed"
+				result.Err = err
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+				results = append(results, result)
+				continue
+			}
+			result.SessionID = completed.ID
+			result.WorkItemCount = childWorkItemCount(completed)
+			result.Status = "complete"
+			results = append(results, result)
+			continue
+		}
+
+		candidateAnswers := item.Source.Answers
+		explicitAnswers := false
+		if override, ok := options.AnswerOverrides[item.Target.Name]; ok {
+			candidateAnswers = override
+			explicitAnswers = true
+		}
+		work, err := api.getAssessmentWork(ctx, item.Target, candidateAnswers)
+		if err != nil {
+			result.Status = "failed"
+			result.Err = fmt.Errorf("retrieve current assessment work: %w", err)
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+			results = append(results, result)
+			continue
+		}
+
+		var sourceQuestions []question
+		if explicitAnswers {
+			if err := validateExplicitAnswers(candidateAnswers, work.Questions); err != nil {
+				result.Status = "failed"
+				result.Err = fmt.Errorf("validate answer override: %w", err)
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+		}
+		compareQuestionDetails := !explicitAnswers && !sameGraphVersion(item.Source.GraphVersion, item.Target.GraphVersion)
+		if compareQuestionDetails && len(item.Source.Answers) > 0 {
+			if item.Source.GraphVersion == nil {
+				result.Status = "failed"
+				result.Err = errors.New("source assessment has answers but no graph version")
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+			sourceQuestions, err = api.getPolicyQuestions(ctx, policyIdentifier(item.Source), *item.Source.GraphVersion)
+			if err != nil {
+				result.Status = "failed"
+				result.Err = fmt.Errorf("read source questionnaire: %w", err)
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+		}
+
+		answers, dropped, err := filterAnswersForQuestions(candidateAnswers, sourceQuestions, work.Questions, compareQuestionDetails)
+		if err != nil {
+			result.Status = "failed"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		if dropped > 0 {
+			work, err = api.getAssessmentWork(ctx, item.Target, answers)
+			if err != nil {
+				result.Status = "failed"
+				result.Err = fmt.Errorf("recompute assessment work with compatible answers: %w", err)
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+		}
+		result.CopiedAnswers = len(answers)
+		result.DroppedAnswers = dropped
+		result.QuestionCount = len(work.Questions)
+		result.WorkCount = len(work.Work)
+		if err := validateCompleteActivities(options.CompleteActivities[item.Target.Name], work.Work); err != nil {
+			result.Status = "failed"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		if dropped > 0 && !options.AllowPartial {
+			result.Status = "needs review"
+			result.Err = fmt.Errorf("%d previous answers are incompatible with the current questionnaire", dropped)
+			if options.Apply {
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+			}
+			results = append(results, result)
+			continue
+		}
+
+		var sourceSession *session
+		var generationPayload map[string]json.RawMessage
+		if !options.AnswersOnly {
+			sourceSession, err = api.getSession(ctx, item.Source.LastSession.SessionID)
+			if err != nil {
+				result.Status = "failed"
+				result.Err = fmt.Errorf("read source completion session: %w", err)
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+				results = append(results, result)
+				continue
+			}
+			generationPayload, err = makeSessionGenerationPayload(sourceSession, s, plan.TargetGroup, item.Target)
+			if err != nil {
+				result.Status = "failed"
+				result.Err = err
+				resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+				results = append(results, result)
+				continue
+			}
+		}
+
+		if !options.Apply {
+			result.Status = "ready"
+			results = append(results, result)
+			continue
+		}
+
+		saved, err := api.writeAssessment(ctx, item.Target, answers)
+		if err != nil {
+			result.Status = "failed"
+			result.Err = fmt.Errorf("save assessment: %w", err)
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+			results = append(results, result)
+			continue
+		}
+		if options.AnswersOnly {
+			result.Status = "answers saved"
+			results = append(results, result)
+			continue
+		}
+
+		previousSessionID := ""
+		if item.Target.LastSession != nil {
+			previousSessionID = item.Target.LastSession.SessionID
+		}
+		if err := api.generateSession(ctx, saved.ID, generationPayload); err != nil {
+			result.Status = "answers saved; session failed"
+			result.Err = fmt.Errorf("generate completion session: %w", err)
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, result.Err))
+			results = append(results, result)
+			continue
+		}
+		generated, err := waitForNewSession(ctx, api, saved.ID, previousSessionID, options.PollInterval)
+		if err != nil {
+			result.Status = "answers saved; session failed"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		completed, err := waitForSession(ctx, api, generated, options.PollInterval)
+		if err != nil {
+			result.Status = "answers saved; session failed"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		result.SessionID = completed.ID
+		result.WorkItemCount = childWorkItemCount(completed)
+		closures, err := planWorkItemClosures(sourceSession, completed, options.CompleteActivities[item.Target.Name])
+		if err != nil {
+			result.Status = "session generated; work-item completion needs review"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		completed, err = applyWorkItemClosures(ctx, api, completed, closures, options.PollInterval)
+		if err != nil {
+			result.Status = "session generated; work-item completion failed"
+			result.Err = err
+			resultErrors = append(resultErrors, fmt.Errorf("%s: %w", item.Target.Name, err))
+			results = append(results, result)
+			continue
+		}
+		result.WorkItemCount = childWorkItemCount(completed)
+		result.Status = "complete"
+		results = append(results, result)
+	}
+
+	return results, errors.Join(resultErrors...)
+}
+
+func validateExplicitAnswers(answers []json.RawMessage, questions []question) error {
+	questionByID := make(map[string]question, len(questions))
+	for _, question := range questions {
+		if question.NodeID == "" {
+			return errors.New("questionnaire contains a question with no node ID")
+		}
+		questionByID[question.NodeID] = question
+	}
+
+	answered := make(map[string]struct{}, len(answers))
+	for _, raw := range answers {
+		var answer struct {
+			QuestionID string   `json:"questionId"`
+			Answers    []string `json:"answers"`
+		}
+		if err := json.Unmarshal(raw, &answer); err != nil {
+			return fmt.Errorf("decode answer override: %w", err)
+		}
+		if answer.QuestionID == "" {
+			return errors.New("answer override has no question ID")
+		}
+		if _, duplicate := answered[answer.QuestionID]; duplicate {
+			return fmt.Errorf("answer override contains duplicate question ID %q", answer.QuestionID)
+		}
+		question, ok := questionByID[answer.QuestionID]
+		if !ok {
+			return fmt.Errorf("answer override contains unknown question ID %q", answer.QuestionID)
+		}
+		if len(answer.Answers) == 0 {
+			return fmt.Errorf("answer override for question %q is empty", answer.QuestionID)
+		}
+
+		var fields struct {
+			AnswerTemplate struct {
+				Options []struct {
+					Value string `json:"value"`
+				} `json:"options"`
+			} `json:"answerTemplate"`
+		}
+		if err := json.Unmarshal(question.Raw, &fields); err != nil {
+			return fmt.Errorf("decode question %q answer options: %w", answer.QuestionID, err)
+		}
+		if len(fields.AnswerTemplate.Options) > 0 {
+			allowed := make(map[string]struct{}, len(fields.AnswerTemplate.Options))
+			for _, option := range fields.AnswerTemplate.Options {
+				allowed[option.Value] = struct{}{}
+			}
+			for _, value := range answer.Answers {
+				if _, ok := allowed[value]; !ok {
+					return fmt.Errorf("answer %q is not allowed for question %q", value, answer.QuestionID)
+				}
+			}
+		}
+		answered[answer.QuestionID] = struct{}{}
+	}
+
+	var missing []string
+	for questionID := range questionByID {
+		if _, ok := answered[questionID]; !ok {
+			missing = append(missing, questionID)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return fmt.Errorf("answer override is missing question IDs: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+type workItemClosure struct {
+	WorkItemID string
+	State      string
+}
+
+func planWorkItemClosures(source, target *session, approvedCurrentNodes map[string]struct{}) ([]workItemClosure, error) {
+	if source == nil || !strings.EqualFold(source.State, "complete") {
+		return nil, errors.New("source completion session is not complete")
+	}
+	if target == nil || !strings.EqualFold(target.State, "complete") {
+		return nil, errors.New("target generation session is not complete")
+	}
+
+	sourceByNode := make(map[string]sessionWorkItem)
+	completedState := ""
+	for _, item := range source.WorkItems {
+		if item.ItemType != "child" {
+			continue
+		}
+		if item.NodeID == "" {
+			return nil, errors.New("source completion session contains a child with no node ID")
+		}
+		nodeID := normalizeActivityNodeID(item.NodeID)
+		if _, exists := sourceByNode[nodeID]; exists {
+			return nil, fmt.Errorf("source completion session contains duplicate child node %q", item.NodeID)
+		}
+		sourceByNode[nodeID] = item
+		if item.WorkItemState.IsCompletedCategory && item.WorkItemState.State != "" {
+			if completedState == "" {
+				completedState = item.WorkItemState.State
+			} else if !strings.EqualFold(completedState, item.WorkItemState.State) {
+				completedState = ""
+			}
+		}
+	}
+
+	var closures []workItemClosure
+	usedApprovals := make(map[string]struct{})
+	for _, item := range target.WorkItems {
+		if item.ItemType != "child" || item.WorkItemState.IsCompletedCategory {
+			continue
+		}
+		sourceItem, ok := sourceByNode[normalizeActivityNodeID(item.NodeID)]
+		state := ""
+		if ok {
+			if !sourceItem.WorkItemState.IsCompletedCategory {
+				return nil, fmt.Errorf("source child node %q was not completed", item.NodeID)
+			}
+			state = sourceItem.WorkItemState.State
+		} else if _, approved := approvedCurrentNodes[item.NodeID]; approved {
+			if completedState == "" {
+				return nil, fmt.Errorf("cannot determine a single completed state for approved current node %q", item.NodeID)
+			}
+			state = completedState
+			usedApprovals[item.NodeID] = struct{}{}
+		} else {
+			return nil, fmt.Errorf("generated child node %q has no matching source work item", item.NodeID)
+		}
+		if item.WorkItemID == "" {
+			return nil, fmt.Errorf("generated child node %q has no work item ID", item.NodeID)
+		}
+		if state == "" {
+			return nil, fmt.Errorf("source child node %q has no work item state", item.NodeID)
+		}
+		closures = append(closures, workItemClosure{WorkItemID: item.WorkItemID, State: state})
+	}
+	for nodeID := range approvedCurrentNodes {
+		if _, used := usedApprovals[nodeID]; !used {
+			return nil, fmt.Errorf("approved current node %q is not an open generated child", nodeID)
+		}
+	}
+	if len(closures) > 0 && target.ServerURL == "" {
+		return nil, errors.New("target generation session has no work item server URL")
+	}
+	return closures, nil
+}
+
+func validateCompleteActivities(approved map[string]struct{}, work []json.RawMessage) error {
+	if len(approved) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{}, len(work))
+	for _, raw := range work {
+		var activity struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(raw, &activity); err != nil {
+			return fmt.Errorf("decode assessment activity: %w", err)
+		}
+		if activity.ID != "" {
+			available[activity.ID] = struct{}{}
+		}
+	}
+	for nodeID := range approved {
+		if _, ok := available[nodeID]; !ok {
+			return fmt.Errorf("approved current node %q is not in the assessment work", nodeID)
+		}
+	}
+	return nil
+}
+
+func normalizeActivityNodeID(nodeID string) string {
+	return strings.TrimPrefix(strings.TrimSpace(nodeID), "Activity ")
+}
+
+func applyWorkItemClosures(ctx context.Context, api complianceAPI, target *session, closures []workItemClosure, pollInterval time.Duration) (*session, error) {
+	for _, closure := range closures {
+		if err := api.setWorkItemState(ctx, target.ServerURL, closure.WorkItemID, closure.State); err != nil {
+			return nil, err
+		}
+	}
+	if len(closures) == 0 {
+		return target, nil
+	}
+	return waitForChildWorkItemsComplete(ctx, api, target.ID, pollInterval)
+}
+
+func waitForChildWorkItemsComplete(ctx context.Context, api complianceAPI, sessionID string, pollInterval time.Duration) (*session, error) {
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
+	for {
+		current, err := api.getSession(ctx, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("refresh work items for completion session %s: %w", sessionID, err)
+		}
+		if current == nil {
+			return nil, fmt.Errorf("refresh work items for completion session %s: empty response", sessionID)
+		}
+		if !hasIncompleteChildWorkItems(current) {
+			return current, nil
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, fmt.Errorf("wait for child work items in session %s: %w", sessionID, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func childWorkItemCount(s *session) int {
+	count := 0
+	for _, item := range s.WorkItems {
+		if item.ItemType == "child" {
+			count++
+		}
+	}
+	return count
+}
+
+func filterAnswersForQuestions(answers []json.RawMessage, sourceQuestions, currentQuestions []question, compareDetails bool) ([]json.RawMessage, int, error) {
+	currentQuestionByID := make(map[string]question, len(currentQuestions))
+	for _, question := range currentQuestions {
+		if question.NodeID == "" {
+			return nil, 0, errors.New("current questionnaire contains a question with no node ID")
+		}
+		currentQuestionByID[question.NodeID] = question
+	}
+	sourceQuestionByID := make(map[string]question, len(sourceQuestions))
+	for _, question := range sourceQuestions {
+		if question.NodeID != "" {
+			sourceQuestionByID[question.NodeID] = question
+		}
+	}
+
+	filtered := make([]json.RawMessage, 0, len(answers))
+	dropped := 0
+	for _, answer := range answers {
+		var fields struct {
+			QuestionID string `json:"questionId"`
+		}
+		if err := json.Unmarshal(answer, &fields); err != nil {
+			return nil, 0, fmt.Errorf("decode previous answer: %w", err)
+		}
+		if fields.QuestionID == "" {
+			return nil, 0, errors.New("previous answer has no question ID")
+		}
+		currentQuestion, ok := currentQuestionByID[fields.QuestionID]
+		if !ok {
+			dropped++
+			continue
+		}
+		if compareDetails {
+			sourceQuestion, ok := sourceQuestionByID[fields.QuestionID]
+			if !ok {
+				dropped++
+				continue
+			}
+			equal, err := equalQuestionDetails(sourceQuestion, currentQuestion)
+			if err != nil {
+				return nil, 0, err
+			}
+			if !equal {
+				dropped++
+				continue
+			}
+		}
+		filtered = append(filtered, answer)
+	}
+	return filtered, dropped, nil
+}
+
+type questionDetails struct {
+	AnswerTemplate        any `json:"answerTemplate"`
+	AutoApplicableAnswers any `json:"autoApplicableAnswers"`
+	Question              any `json:"question"`
+	QuestionPlainText     any `json:"questionPlainText"`
+	QuestionRaw           any `json:"questionRaw"`
+}
+
+func equalQuestionDetails(a, b question) (bool, error) {
+	decode := func(value question) (questionDetails, error) {
+		var details questionDetails
+		if err := json.Unmarshal(value.Raw, &details); err != nil {
+			return questionDetails{}, fmt.Errorf("decode question %q details: %w", value.NodeID, err)
+		}
+		return details, nil
+	}
+	aDetails, err := decode(a)
+	if err != nil {
+		return false, err
+	}
+	bDetails, err := decode(b)
+	if err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(aDetails, bDetails), nil
+}
+
+func sameGraphVersion(a, b *int64) bool {
+	return a != nil && b != nil && *a == *b
+}
+
+func policyIdentifier(a *assessment) string {
+	if a.GraphID == nil || *a.GraphID == "" {
+		return a.PolicyNodeID
+	}
+	return *a.GraphID + "/" + a.PolicyNodeID
+}
+
+func makeSessionGenerationPayload(source *session, s *scope, targetGroup *assessmentGroup, target *assessment) (map[string]json.RawMessage, error) {
+	if !strings.EqualFold(source.State, "complete") {
+		return nil, fmt.Errorf("source session %q is not complete", source.ID)
+	}
+	if source.ProjectID == "" || source.WITConfigID == "" || source.AreaPath == "" || source.IterationPath == "" {
+		return nil, fmt.Errorf("source session %q has incomplete work-item configuration", source.ID)
+	}
+	areaRoot := classificationRoot(source.AreaPath)
+	iterationRoot := classificationRoot(source.IterationPath)
+	if areaRoot == "" || iterationRoot == "" || !strings.EqualFold(areaRoot, iterationRoot) {
+		return nil, fmt.Errorf("source session %q has inconsistent area and iteration projects", source.ID)
+	}
+
+	values := map[string]any{
+		"areaPath":         areaRoot,
+		"assignedTo":       nil,
+		"iterationPath":    iterationRoot,
+		"linkedWorkItem":   nil,
+		"projectId":        source.ProjectID,
+		"relatedWorkItems": []any{},
+		"serverUrl":        nil,
+		"witConfigId":      source.WITConfigID,
+		"workItemTags":     []any{},
+		"name":             fmt.Sprintf("%s for %s of %s", target.Name, targetGroup.Name, s.Name),
+	}
+	payload := make(map[string]json.RawMessage, len(values))
+	for key, value := range values {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("encode completion session field %q: %w", key, err)
+		}
+		payload[key] = encoded
+	}
+	return payload, nil
+}
+
+func classificationRoot(path string) string {
+	path = strings.Trim(path, "\\")
+	root, _, _ := strings.Cut(path, "\\")
+	return root
+}
+
+func waitForNewSession(ctx context.Context, api complianceAPI, assessmentID, previousSessionID string, pollInterval time.Duration) (*session, error) {
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
+	for {
+		current, err := api.getLatestSession(ctx, assessmentID)
+		if err != nil {
+			return nil, fmt.Errorf("find generated completion session for assessment %s: %w", assessmentID, err)
+		}
+		if current != nil && current.ID != "" {
+			state := strings.ToLower(current.State)
+			if current.ID != previousSessionID || state != "failed" && state != "archived" {
+				return current, nil
+			}
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, fmt.Errorf("find generated completion session for assessment %s: %w", assessmentID, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func waitForSession(ctx context.Context, api complianceAPI, current *session, pollInterval time.Duration) (*session, error) {
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
+	for {
+		if current == nil {
+			return nil, errors.New("completion session response is empty")
+		}
+		if current.ID == "" {
+			return nil, errors.New("completion session response has no ID")
+		}
+		switch strings.ToLower(current.State) {
+		case "complete":
+			return current, nil
+		case "failed":
+			if current.FailureMessage != "" {
+				return nil, fmt.Errorf("completion session %s failed: %s", current.ID, current.FailureMessage)
+			}
+			return nil, fmt.Errorf("completion session %s failed", current.ID)
+		}
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, fmt.Errorf("wait for completion session %s: %w", current.ID, ctx.Err())
+		case <-timer.C:
+		}
+		sessionID := current.ID
+		refreshed, err := api.getSession(ctx, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("refresh completion session %s: %w", sessionID, err)
+		}
+		current = refreshed
+	}
+}

--- a/cmd/compliance/complete_test.go
+++ b/cmd/compliance/complete_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -144,7 +145,7 @@ func TestValidateExplicitAnswers(t *testing.T) {
 
 func TestPlanWorkItemClosuresNormalizesAndApprovesCurrentNode(t *testing.T) {
 	source := decodeSession(t, `{"id":"source","state":"complete","workItems":[{"itemType":"child","nodeId":"Activity existing","workItemId":"1","workItemState":{"state":"Completed","isCompletedCategory":true}}]}`)
-	target := decodeSession(t, `{"id":"target","state":"complete","serverUrl":"https://dev.azure.com/org/project","workItems":[{"itemType":"child","nodeId":"existing","workItemId":"2","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"new","workItemId":"3","workItemState":{"state":"Proposed"}}]}`)
+	target := decodeSession(t, `{"id":"target","state":"complete","serverUrl":"https://dev.azure.com/org/project","workItems":[{"itemType":"child","nodeId":"existing","workItemId":"2","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"Activity new","workItemId":"3","workItemState":{"state":"Proposed"}}]}`)
 
 	closures, err := planWorkItemClosures(source, target, map[string]struct{}{"new": {}})
 	if err != nil {
@@ -152,6 +153,16 @@ func TestPlanWorkItemClosuresNormalizesAndApprovesCurrentNode(t *testing.T) {
 	}
 	if len(closures) != 2 || closures[0].State != "Completed" || closures[1].State != "Completed" {
 		t.Fatalf("closures = %+v", closures)
+	}
+}
+
+func TestPlanWorkItemClosuresRejectsDuplicateNormalizedApprovals(t *testing.T) {
+	source := decodeSession(t, `{"id":"source","state":"complete"}`)
+	target := decodeSession(t, `{"id":"target","state":"complete"}`)
+
+	_, err := planWorkItemClosures(source, target, map[string]struct{}{"new": {}, "Activity new": {}})
+	if err == nil || !strings.Contains(err.Error(), "are duplicates") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/cmd/compliance/complete_test.go
+++ b/cmd/compliance/complete_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestRunCompletionPlanDryRun(t *testing.T) {
+	answer := json.RawMessage(`{"questionId":"question-1","answers":["yes"]}`)
+	target := decodeAssessment(t, `{"id":"target","name":"Policy","scopeId":"scope","assessmentGroupId":"current","policyNodeId":"policy","graphVersion":1,"answers":[]}`)
+	source := decodeAssessment(t, `{"id":"source","name":"Policy","graphVersion":1,"answers":[{"questionId":"question-1","answers":["yes"]}],"lastSession":{"sessionId":"source-session"}}`)
+	api := &fakeComplianceAPI{
+		work:          &assessmentWork{Questions: []question{{NodeID: "question-1"}}, Work: []json.RawMessage{json.RawMessage(`{}`)}},
+		sourceSession: decodeSession(t, `{"id":"source-session","state":"complete","projectId":"project","witConfigId":"config","areaPath":"Project\\Old Area","iterationPath":"Project\\Old Iteration"}`),
+	}
+	plan := &completionPlan{
+		TargetGroup: &assessmentGroup{ID: "current", Name: "Current"},
+		Items: []completionPlanItem{{
+			Target:      target,
+			Source:      source,
+			SourceGroup: &assessmentGroup{Name: "Previous"},
+		}},
+	}
+
+	results, err := runCompletionPlan(context.Background(), api, &scope{ID: "scope", Name: "Product"}, plan, completionOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.writeCalls != 0 || api.generateCalls != 0 {
+		t.Fatalf("dry run made writes: assessment=%d session=%d", api.writeCalls, api.generateCalls)
+	}
+	result := results[0]
+	if result.Status != "ready" || result.CopiedAnswers != 1 || result.QuestionCount != 1 || result.WorkCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := len(api.workAnswers); got != len([]json.RawMessage{answer}) {
+		t.Fatalf("work answer count = %d, want 1", got)
+	}
+}
+
+func TestRunCompletionPlanAppliesAndGeneratesSession(t *testing.T) {
+	target := decodeAssessment(t, `{"id":"target","name":"Policy","scopeId":"scope","assessmentGroupId":"current","policyNodeId":"policy","graphVersion":1,"answers":[]}`)
+	source := decodeAssessment(t, `{"id":"source","name":"Policy","graphVersion":1,"answers":[{"questionId":"question-1","answers":["yes"]}],"lastSession":{"sessionId":"source-session"}}`)
+	api := &fakeComplianceAPI{
+		work:          &assessmentWork{Questions: []question{{NodeID: "question-1"}}},
+		sourceSession: decodeSession(t, `{"id":"source-session","state":"complete","projectId":"project","witConfigId":"config","areaPath":"Project\\Old Area","iterationPath":"Project\\Old Iteration","workItems":[{"itemType":"child","nodeId":"activity","workItemId":"old","workItemState":{"state":"Completed","isCompletedCategory":true}}]}`),
+		generated:     decodeSession(t, `{"id":"generated-session","assessmentId":"target","state":"complete","serverUrl":"https://dev.azure.com/org/project","workItems":[{"itemType":"parent","workItemId":"122","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"activity","workItemId":"123","workItemState":{"state":"Proposed"}}]}`),
+	}
+	plan := &completionPlan{
+		TargetGroup: &assessmentGroup{ID: "current", Name: "Current"},
+		Items: []completionPlanItem{{
+			Target:      target,
+			Source:      source,
+			SourceGroup: &assessmentGroup{Name: "Previous"},
+		}},
+	}
+
+	results, err := runCompletionPlan(context.Background(), api, &scope{ID: "scope", Name: "Product"}, plan, completionOptions{Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.writeCalls != 1 || api.generateCalls != 1 {
+		t.Fatalf("writes: assessment=%d session=%d", api.writeCalls, api.generateCalls)
+	}
+	if got := string(api.generationPayload["name"]); got != `"Policy for Current of Product"` {
+		t.Fatalf("session name = %s", got)
+	}
+	if got := string(api.generationPayload["projectId"]); got != `"project"` {
+		t.Fatalf("project ID = %s", got)
+	}
+	if got := string(api.generationPayload["areaPath"]); got != `"Project"` {
+		t.Fatalf("area path = %s, want project root", got)
+	}
+	if got := string(api.generationPayload["iterationPath"]); got != `"Project"` {
+		t.Fatalf("iteration path = %s, want project root", got)
+	}
+	if got := string(api.generationPayload["workItemTags"]); got != `[]` {
+		t.Fatalf("work item tags = %s, want []", got)
+	}
+	result := results[0]
+	if result.Status != "complete" || result.SessionID != "generated-session" || result.WorkItemCount != 1 {
+		t.Fatalf("result = %+v", result)
+	}
+	if got := api.stateUpdates["123"]; got != "Completed" {
+		t.Fatalf("work item state update = %q, want Completed", got)
+	}
+}
+
+func TestRunCompletionPlanBlocksDroppedAnswers(t *testing.T) {
+	target := decodeAssessment(t, `{"id":"target","name":"Policy","scopeId":"scope","assessmentGroupId":"current","policyNodeId":"policy","graphVersion":1,"answers":[]}`)
+	source := decodeAssessment(t, `{"id":"source","name":"Policy","graphVersion":1,"answers":[{"questionId":"old-question","answers":["yes"]}],"lastSession":{"sessionId":"source-session"}}`)
+	api := &fakeComplianceAPI{work: &assessmentWork{Questions: []question{{NodeID: "new-question"}}}}
+	plan := &completionPlan{
+		TargetGroup: &assessmentGroup{ID: "current", Name: "Current"},
+		Items:       []completionPlanItem{{Target: target, Source: source, SourceGroup: &assessmentGroup{Name: "Previous"}}},
+	}
+
+	results, err := runCompletionPlan(context.Background(), api, &scope{Name: "Product"}, plan, completionOptions{Apply: true})
+	if err == nil {
+		t.Fatal("runCompletionPlan succeeded, want incompatibility error")
+	}
+	if results[0].Status != "needs review" || results[0].DroppedAnswers != 1 {
+		t.Fatalf("result = %+v", results[0])
+	}
+	if api.writeCalls != 0 || api.generateCalls != 0 {
+		t.Fatal("incompatible answer plan made writes")
+	}
+}
+
+func TestFilterAnswersForQuestionsRejectsChangedDefinition(t *testing.T) {
+	answer := json.RawMessage(`{"questionId":"question-1","answers":["yes"]}`)
+	source := decodeQuestion(t, `{"nodeId":"question-1","questionPlainText":"Old question","answerTemplate":{"type":"boolean"}}`)
+	current := decodeQuestion(t, `{"nodeId":"question-1","questionPlainText":"New question","answerTemplate":{"type":"boolean"}}`)
+
+	answers, dropped, err := filterAnswersForQuestions([]json.RawMessage{answer}, []question{source}, []question{current}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(answers) != 0 || dropped != 1 {
+		t.Fatalf("answers = %d, dropped = %d; want 0, 1", len(answers), dropped)
+	}
+}
+
+func TestValidateExplicitAnswers(t *testing.T) {
+	questions := []question{
+		decodeQuestion(t, `{"nodeId":"choice","answerTemplate":{"options":[{"value":"Yes"},{"value":"No"}]}}`),
+		decodeQuestion(t, `{"nodeId":"text","answerTemplate":{"type":"text"}}`),
+	}
+	answers := []json.RawMessage{
+		json.RawMessage(`{"questionId":"choice","answers":["Yes"]}`),
+		json.RawMessage(`{"questionId":"text","answers":["Go"]}`),
+	}
+	if err := validateExplicitAnswers(answers, questions); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateExplicitAnswers(answers[:1], questions); err == nil {
+		t.Fatal("incomplete answer override succeeded")
+	}
+}
+
+func TestPlanWorkItemClosuresNormalizesAndApprovesCurrentNode(t *testing.T) {
+	source := decodeSession(t, `{"id":"source","state":"complete","workItems":[{"itemType":"child","nodeId":"Activity existing","workItemId":"1","workItemState":{"state":"Completed","isCompletedCategory":true}}]}`)
+	target := decodeSession(t, `{"id":"target","state":"complete","serverUrl":"https://dev.azure.com/org/project","workItems":[{"itemType":"child","nodeId":"existing","workItemId":"2","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"new","workItemId":"3","workItemState":{"state":"Proposed"}}]}`)
+
+	closures, err := planWorkItemClosures(source, target, map[string]struct{}{"new": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(closures) != 2 || closures[0].State != "Completed" || closures[1].State != "Completed" {
+		t.Fatalf("closures = %+v", closures)
+	}
+}
+
+func TestWaitForSessionRejectsEmptyResponse(t *testing.T) {
+	_, err := waitForSession(context.Background(), &fakeComplianceAPI{}, nil, 0)
+	if err == nil || err.Error() != "completion session response is empty" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWaitForNewSessionAcceptsReusedFailedSessionID(t *testing.T) {
+	api := &fakeComplianceAPI{generated: &session{ID: "reused-session", State: "complete"}}
+
+	got, err := waitForNewSession(context.Background(), api, "assessment", "reused-session", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "reused-session" || got.State != "complete" {
+		t.Fatalf("session = %+v", got)
+	}
+}
+
+func TestRunCompletionPlanReconcilesExistingSession(t *testing.T) {
+	targetSession := decodeSession(t, `{"id":"target-session","state":"complete","serverUrl":"https://dev.azure.com/org/project","workItems":[{"itemType":"parent","workItemId":"200","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"activity","workItemId":"201","workItemState":{"state":"Proposed"}}]}`)
+	target := decodeAssessment(t, `{"id":"target","name":"Policy","lastSession":{"sessionId":"target-session"}}`)
+	source := decodeAssessment(t, `{"id":"source","name":"Policy","lastSession":{"sessionId":"source-session"}}`)
+	api := &fakeComplianceAPI{
+		sourceSession: decodeSession(t, `{"id":"source-session","state":"complete","workItems":[{"itemType":"parent","workItemId":"100","workItemState":{"state":"Proposed"}},{"itemType":"child","nodeId":"activity","workItemId":"101","workItemState":{"state":"Completed","isCompletedCategory":true}}]}`),
+		generated:     targetSession,
+	}
+	plan := &completionPlan{
+		TargetGroup: &assessmentGroup{Name: "Current"},
+		Items:       []completionPlanItem{{Target: target, Source: source, SourceGroup: &assessmentGroup{Name: "Previous"}, ExistingSession: targetSession}},
+	}
+
+	results, err := runCompletionPlan(context.Background(), api, &scope{Name: "Product"}, plan, completionOptions{Apply: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.writeCalls != 0 || api.generateCalls != 0 {
+		t.Fatalf("reconciliation regenerated assessment: writes=%d generations=%d", api.writeCalls, api.generateCalls)
+	}
+	if got := api.stateUpdates["201"]; got != "Completed" {
+		t.Fatalf("child state update = %q, want Completed", got)
+	}
+	if _, exists := api.stateUpdates["200"]; exists {
+		t.Fatal("parent work item was updated")
+	}
+	if results[0].Status != "complete" || results[0].WorkItemCount != 1 {
+		t.Fatalf("result = %+v", results[0])
+	}
+}
+
+type fakeComplianceAPI struct {
+	work              *assessmentWork
+	sourceSession     *session
+	generated         *session
+	workAnswers       []json.RawMessage
+	generationPayload map[string]json.RawMessage
+	stateUpdates      map[string]string
+	writeCalls        int
+	generateCalls     int
+}
+
+func (f *fakeComplianceAPI) getAssessmentWork(_ context.Context, _ *assessment, answers []json.RawMessage) (*assessmentWork, error) {
+	f.workAnswers = answers
+	return f.work, nil
+}
+
+func (f *fakeComplianceAPI) getPolicyQuestions(_ context.Context, _ string, _ int64) ([]question, error) {
+	return nil, nil
+}
+
+func (f *fakeComplianceAPI) writeAssessment(_ context.Context, target *assessment, _ []json.RawMessage) (*assessment, error) {
+	f.writeCalls++
+	return target, nil
+}
+
+func (f *fakeComplianceAPI) getSession(_ context.Context, sessionID string) (*session, error) {
+	if f.sourceSession != nil && sessionID == f.sourceSession.ID {
+		return f.sourceSession, nil
+	}
+	if f.generated != nil && sessionID == f.generated.ID {
+		return f.generated, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeComplianceAPI) getLatestSession(_ context.Context, _ string) (*session, error) {
+	return f.generated, nil
+}
+
+func (f *fakeComplianceAPI) generateSession(_ context.Context, _ string, payload map[string]json.RawMessage) error {
+	f.generateCalls++
+	f.generationPayload = payload
+	return nil
+}
+
+func (f *fakeComplianceAPI) setWorkItemState(_ context.Context, _ string, workItemID, state string) error {
+	if f.stateUpdates == nil {
+		f.stateUpdates = make(map[string]string)
+	}
+	f.stateUpdates[workItemID] = state
+	if f.generated != nil {
+		for index := range f.generated.WorkItems {
+			if f.generated.WorkItems[index].WorkItemID == workItemID {
+				f.generated.WorkItems[index].WorkItemState.State = state
+				f.generated.WorkItems[index].WorkItemState.IsCompletedCategory = true
+			}
+		}
+	}
+	return nil
+}
+
+func decodeAssessment(t *testing.T, data string) *assessment {
+	t.Helper()
+	var result assessment
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		t.Fatal(err)
+	}
+	return &result
+}
+
+func decodeSession(t *testing.T, data string) *session {
+	t.Helper()
+	var result session
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		t.Fatal(err)
+	}
+	return &result
+}
+
+func decodeQuestion(t *testing.T, data string) question {
+	t.Helper()
+	var result question
+	if err := json.Unmarshal([]byte(data), &result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/cmd/compliance/main.go
+++ b/cmd/compliance/main.go
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Compliance copies answers from prior completed Azure DevOps compliance
+// assessments and optionally generates the completion work-item session.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+)
+
+const azureDevOpsResource = "499b84ac-1321-427f-aa17-267ca6975798"
+
+type portalTarget struct {
+	Organization string
+	Project      string
+	ProductID    string
+}
+
+type cliOptions struct {
+	PortalURL          string
+	AssessmentGroup    string
+	SourceGroup        string
+	AnswersFile        string
+	CompleteActivities stringListFlag
+	APIBase            string
+	AzureCLI           string
+	Apply              bool
+	AnswersOnly        bool
+	AllowPartial       bool
+	Overwrite          bool
+	Timeout            time.Duration
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := runCLI(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "compliance: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runCLI(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	options, err := parseFlags(args, stderr)
+	if err != nil {
+		return err
+	}
+	target, err := parsePortalURL(options.PortalURL)
+	if err != nil {
+		return err
+	}
+	if options.Apply && options.AssessmentGroup == "" {
+		return errors.New("-assessment-group is required with -apply; run a dry run first to identify the target group")
+	}
+	if options.APIBase == "" {
+		options.APIBase = "https://entreq.dev.azure.com/" + url.PathEscape(strings.ToLower(target.Organization))
+	} else if parsed, err := url.Parse(options.APIBase); err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return errors.New("-api-base must be an absolute HTTPS URL")
+	}
+	answerOverrides, err := loadAnswerOverrides(options.AnswersFile)
+	if err != nil {
+		return err
+	}
+	completeActivities, err := parseCompleteActivities(options.CompleteActivities)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+	token, err := acquireAzureDevOpsToken(ctx, options.AzureCLI)
+	if err != nil {
+		return err
+	}
+	client, err := newComplianceClient(options.APIBase, token, &http.Client{Timeout: time.Minute})
+	if err != nil {
+		return err
+	}
+
+	s, err := client.getScope(ctx, target.ProductID)
+	if err != nil {
+		return fmt.Errorf("read product %s assessments: %w", target.ProductID, err)
+	}
+	targetGroup, err := selectTargetGroup(s.AssessmentGroups, options.AssessmentGroup)
+	if err != nil {
+		return err
+	}
+	for _, assessment := range targetGroup.Assessments {
+		if assessment.LastSession == nil {
+			continue
+		}
+		session, err := client.getSession(ctx, assessment.LastSession.SessionID)
+		if err != nil {
+			return fmt.Errorf("read existing session for assessment %q: %w", assessment.Name, err)
+		}
+		assessment.LastSession.Session = session
+	}
+	plan, err := buildCompletionPlan(s, options.AssessmentGroup, options.SourceGroup, options.Overwrite)
+	if err != nil {
+		return err
+	}
+	assessmentNames := make(map[string]struct{}, len(plan.Items))
+	for _, item := range plan.Items {
+		assessmentNames[item.Target.Name] = struct{}{}
+	}
+	for name := range answerOverrides {
+		if _, ok := assessmentNames[name]; !ok {
+			return fmt.Errorf("-answers-file contains unknown assessment %q", name)
+		}
+	}
+	for name := range completeActivities {
+		if _, ok := assessmentNames[name]; !ok {
+			return fmt.Errorf("-complete-activity contains unknown assessment %q", name)
+		}
+	}
+	results, runErr := runCompletionPlan(ctx, client, s, plan, completionOptions{
+		Apply:              options.Apply,
+		AnswersOnly:        options.AnswersOnly,
+		AllowPartial:       options.AllowPartial,
+		AnswerOverrides:    answerOverrides,
+		CompleteActivities: completeActivities,
+		PollInterval:       2 * time.Second,
+	})
+	writeCompletionResults(stdout, target, plan, results, options)
+	return runErr
+}
+
+func parseFlags(args []string, stderr io.Writer) (cliOptions, error) {
+	var options cliOptions
+	fs := flag.NewFlagSet("compliance", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&options.PortalURL, "url", "", "Azure DevOps compliance assessments URL (required)")
+	fs.StringVar(&options.AssessmentGroup, "assessment-group", "", "Target assessment group; defaults to the newest group for dry runs")
+	fs.StringVar(&options.SourceGroup, "source-group", "", "Only copy from this prior assessment group")
+	fs.StringVar(&options.AnswersFile, "answers-file", "", "JSON file containing complete per-assessment answer overrides")
+	fs.Var(&options.CompleteActivities, "complete-activity", "Current-only activity to complete, formatted as ASSESSMENT=NODE-ID; may be repeated")
+	fs.StringVar(&options.APIBase, "api-base", "", "Override the Entreq API base URL")
+	fs.StringVar(&options.AzureCLI, "az", "az", "Path to the Azure CLI executable")
+	fs.BoolVar(&options.Apply, "apply", false, "Save answers and generate completion work items")
+	fs.BoolVar(&options.AnswersOnly, "answers-only", false, "Save answers without generating a completion session")
+	fs.BoolVar(&options.AllowPartial, "allow-partial", false, "Apply even when prior answers are incompatible with the current questionnaire")
+	fs.BoolVar(&options.Overwrite, "overwrite", false, "Replace answers in assessments that are already in progress")
+	fs.DurationVar(&options.Timeout, "timeout", 10*time.Minute, "Overall command timeout")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: %s -url URL [-assessment-group NAME] [-apply]\n\n", fs.Name())
+		fmt.Fprintln(fs.Output(), "Copies answers from the latest earlier completed assessment for each policy.")
+		fmt.Fprintln(fs.Output(), "The default is a read-only dry run. -apply can create or update Azure DevOps work items.")
+		fmt.Fprintln(fs.Output(), "\nOptions:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return cliOptions{}, err
+	}
+	if fs.NArg() != 0 {
+		return cliOptions{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if options.PortalURL == "" {
+		return cliOptions{}, errors.New("-url is required")
+	}
+	if options.Timeout <= 0 {
+		return cliOptions{}, errors.New("-timeout must be greater than zero")
+	}
+	if options.AnswersOnly && !options.Apply {
+		return cliOptions{}, errors.New("-answers-only requires -apply")
+	}
+	if options.AllowPartial && !options.Apply {
+		return cliOptions{}, errors.New("-allow-partial requires -apply")
+	}
+	if options.Overwrite && !options.Apply {
+		return cliOptions{}, errors.New("-overwrite requires -apply")
+	}
+	return options, nil
+}
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func parseCompleteActivities(values []string) (map[string]map[string]struct{}, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	result := make(map[string]map[string]struct{})
+	for _, value := range values {
+		assessmentName, nodeID, ok := strings.Cut(value, "=")
+		assessmentName = strings.TrimSpace(assessmentName)
+		nodeID = strings.TrimSpace(nodeID)
+		if !ok || assessmentName == "" || nodeID == "" {
+			return nil, fmt.Errorf("invalid -complete-activity %q; want ASSESSMENT=NODE-ID", value)
+		}
+		if result[assessmentName] == nil {
+			result[assessmentName] = make(map[string]struct{})
+		}
+		result[assessmentName][nodeID] = struct{}{}
+	}
+	return result, nil
+}
+
+func loadAnswerOverrides(path string) (map[string][]json.RawMessage, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read -answers-file: %w", err)
+	}
+	if len(data) > 1<<20 {
+		return nil, errors.New("-answers-file exceeds 1 MiB")
+	}
+	var overrides map[string][]json.RawMessage
+	if err := json.Unmarshal(data, &overrides); err != nil {
+		return nil, fmt.Errorf("decode -answers-file: %w", err)
+	}
+	if len(overrides) == 0 {
+		return nil, errors.New("-answers-file contains no assessments")
+	}
+	for name, answers := range overrides {
+		if strings.TrimSpace(name) == "" {
+			return nil, errors.New("-answers-file contains an empty assessment name")
+		}
+		if len(answers) == 0 {
+			return nil, fmt.Errorf("-answers-file contains no answers for assessment %q", name)
+		}
+	}
+	return overrides, nil
+}
+
+func parsePortalURL(value string) (portalTarget, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return portalTarget{}, fmt.Errorf("parse -url: %w", err)
+	}
+	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), "dev.azure.com") {
+		return portalTarget{}, errors.New("-url must be an https://dev.azure.com compliance URL")
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for index := 2; index+3 < len(segments); index++ {
+		if !strings.EqualFold(segments[index], "_compliance") || !strings.EqualFold(segments[index+1], "product") {
+			continue
+		}
+		if segments[index+2] == "" || !strings.EqualFold(segments[index+3], "assessments") {
+			break
+		}
+		return portalTarget{
+			Organization: segments[0],
+			Project:      segments[1],
+			ProductID:    segments[index+2],
+		}, nil
+	}
+	return portalTarget{}, errors.New("-url must end in /_compliance/product/{product-id}/assessments")
+}
+
+func acquireAzureDevOpsToken(ctx context.Context, azureCLI string) (string, error) {
+	if pat := strings.TrimSpace(os.Getenv("AZURE_DEVOPS_EXT_PAT")); pat != "" {
+		return pat, nil
+	}
+
+	command := exec.CommandContext(ctx, azureCLI,
+		"account", "get-access-token",
+		"--resource", azureDevOpsResource,
+		"--query", "accessToken",
+		"--output", "tsv",
+	)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("acquire Azure DevOps token with %q: %w; run 'az login' or set AZURE_DEVOPS_EXT_PAT", azureCLI, err)
+	}
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", errors.New("access token returned by Azure CLI is empty")
+	}
+	return token, nil
+}
+
+func writeCompletionResults(w io.Writer, target portalTarget, plan *completionPlan, results []completionResult, options cliOptions) {
+	mode := "DRY RUN"
+	if options.Apply {
+		mode = "APPLY"
+	}
+	fmt.Fprintf(w, "%s: %s / %s / %s\n", mode, target.Organization, target.Project, plan.TargetGroup.Name)
+
+	table := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(table, "ASSESSMENT\tSOURCE GROUP\tANSWERS\tQUESTIONS\tWORK\tWORK ITEMS\tSTATUS")
+	for _, result := range results {
+		sourceGroup := result.SourceGroup
+		if sourceGroup == "" {
+			sourceGroup = "-"
+		}
+		answers := "-"
+		if result.SourceGroup != "" {
+			answers = fmt.Sprintf("%d", result.CopiedAnswers)
+			if result.DroppedAnswers > 0 {
+				answers += fmt.Sprintf(" (%d dropped)", result.DroppedAnswers)
+			}
+		}
+		status := result.Status
+		if result.Err != nil {
+			status += ": " + result.Err.Error()
+		}
+		fmt.Fprintf(table, "%s\t%s\t%s\t%d\t%d\t%d\t%s\n",
+			result.AssessmentName,
+			sourceGroup,
+			answers,
+			result.QuestionCount,
+			result.WorkCount,
+			result.WorkItemCount,
+			status,
+		)
+	}
+	_ = table.Flush()
+	if !options.Apply {
+		fmt.Fprintf(w, "\nNo changes made. Review the rows, then rerun with -assessment-group %q -apply.\n", plan.TargetGroup.Name)
+	}
+}

--- a/cmd/compliance/main_test.go
+++ b/cmd/compliance/main_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePortalURL(t *testing.T) {
+	const portalURL = "https://dev.azure.com/example-org/ExampleProject/_compliance/product/00000000-0000-0000-0000-000000000000/assessments"
+	target, err := parsePortalURL(portalURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.Organization != "example-org" || target.Project != "ExampleProject" || target.ProductID != "00000000-0000-0000-0000-000000000000" {
+		t.Fatalf("target = %+v", target)
+	}
+}
+
+func TestParsePortalURLRejectsOtherHostsAndRoutes(t *testing.T) {
+	for _, value := range []string{
+		"https://example.com/example-org/ExampleProject/_compliance/product/id/assessments",
+		"https://dev.azure.com/example-org/ExampleProject/_compliance/product/id",
+		"http://dev.azure.com/example-org/ExampleProject/_compliance/product/id/assessments",
+	} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parsePortalURL(value); err == nil {
+				t.Fatal("parsePortalURL succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestAcquireAzureDevOpsTokenUsesPATEnvironment(t *testing.T) {
+	t.Setenv("AZURE_DEVOPS_EXT_PAT", "test-pat")
+	token, err := acquireAzureDevOpsToken(context.Background(), "does-not-exist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "test-pat" {
+		t.Fatal("token does not match environment value")
+	}
+}
+
+func TestRunCLIRequiresPinnedGroupWhenApplying(t *testing.T) {
+	const portalURL = "https://dev.azure.com/example-org/ExampleProject/_compliance/product/00000000-0000-0000-0000-000000000000/assessments"
+	var stdout, stderr bytes.Buffer
+	err := runCLI(context.Background(), []string{"-url", portalURL, "-apply"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "-assessment-group is required") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestLoadAnswerOverrides(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "answers.json")
+	if err := os.WriteFile(path, []byte(`{"Changed Questionnaire":[{"questionId":"question","answers":["Yes"]}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	overrides, err := loadAnswerOverrides(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(overrides["Changed Questionnaire"]); got != 1 {
+		t.Fatalf("answer count = %d, want 1", got)
+	}
+}
+
+func TestParseCompleteActivities(t *testing.T) {
+	activities, err := parseCompleteActivities([]string{"Changed Questionnaire=policy.activity.new"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := activities["Changed Questionnaire"]["policy.activity.new"]; !ok {
+		t.Fatal("activity was not parsed")
+	}
+	if _, err := parseCompleteActivities([]string{"missing-separator"}); err == nil {
+		t.Fatal("invalid activity succeeded")
+	}
+}

--- a/cmd/compliance/plan.go
+++ b/cmd/compliance/plan.go
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+type scope struct {
+	ID               string             `json:"id"`
+	Name             string             `json:"name"`
+	AssessmentGroups []*assessmentGroup `json:"assessmentGroups"`
+}
+
+type assessmentGroup struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	DueDate     *time.Time    `json:"dueDate"`
+	Assessments []*assessment `json:"assessments"`
+}
+
+type assessment struct {
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	ScopeID           string            `json:"scopeId"`
+	AssessmentGroupID string            `json:"assessmentGroupId"`
+	IsActive          bool              `json:"isActive"`
+	LastModifiedDate  time.Time         `json:"lastModifiedDate"`
+	CreatedDateTime   time.Time         `json:"createdDateTime"`
+	PolicyNodeID      string            `json:"policyNodeId"`
+	PolicyName        string            `json:"policyName"`
+	GraphVersion      *int64            `json:"graphVersion"`
+	GraphID           *string           `json:"graphId"`
+	Answers           []json.RawMessage `json:"answers"`
+	LastSession       *sessionReference `json:"lastSession"`
+	Raw               json.RawMessage   `json:"-"`
+}
+
+func (a *assessment) UnmarshalJSON(data []byte) error {
+	type assessmentFields assessment
+
+	var fields assessmentFields
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	*a = assessment(fields)
+	a.Raw = append(a.Raw[:0], data...)
+	return nil
+}
+
+type sessionReference struct {
+	SessionID string   `json:"sessionId"`
+	Session   *session `json:"-"`
+}
+
+type completionPlan struct {
+	TargetGroup *assessmentGroup
+	Items       []completionPlanItem
+}
+
+type completionPlanItem struct {
+	Target          *assessment
+	Source          *assessment
+	SourceGroup     *assessmentGroup
+	ExistingSession *session
+	SkipReason      string
+}
+
+func buildCompletionPlan(s *scope, targetGroupName, sourceGroupName string, overwrite bool) (*completionPlan, error) {
+	if s == nil {
+		return nil, errors.New("scope is nil")
+	}
+
+	targetGroup, err := selectTargetGroup(s.AssessmentGroups, targetGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	plan := &completionPlan{TargetGroup: targetGroup}
+	for _, target := range targetGroup.Assessments {
+		item := completionPlanItem{Target: target}
+		var targetSession *session
+		if target.LastSession != nil {
+			targetSession = target.LastSession.Session
+		}
+		sessionState := ""
+		if targetSession != nil {
+			sessionState = strings.ToLower(targetSession.State)
+		}
+		failedSession := sessionState == "failed" || sessionState == "archived"
+		switch {
+		case target.LastSession != nil && targetSession == nil:
+			item.SkipReason = "already complete"
+		case sessionState == "complete" && !hasIncompleteChildWorkItems(targetSession):
+			item.SkipReason = "already complete"
+		case sessionState == "complete":
+			item.ExistingSession = targetSession
+			item.SourceGroup, item.Source = findSourceAssessment(s.AssessmentGroups, targetGroup, target, sourceGroupName)
+			if item.Source == nil {
+				item.SkipReason = "no earlier completed assessment for this policy"
+			}
+		case targetSession != nil && !failedSession:
+			item.SkipReason = "completion session is " + sessionState
+		case !failedSession && !overwrite && (target.IsActive || len(target.Answers) > 0):
+			item.SkipReason = "already in progress"
+		default:
+			item.SourceGroup, item.Source = findSourceAssessment(s.AssessmentGroups, targetGroup, target, sourceGroupName)
+			if item.Source == nil {
+				item.SkipReason = "no earlier completed assessment for this policy"
+			}
+		}
+		plan.Items = append(plan.Items, item)
+	}
+
+	slices.SortFunc(plan.Items, func(a, b completionPlanItem) int {
+		return compareStrings(a.Target.Name, b.Target.Name)
+	})
+	return plan, nil
+}
+
+func hasIncompleteChildWorkItems(s *session) bool {
+	for _, item := range s.WorkItems {
+		if item.ItemType == "child" && !item.WorkItemState.IsCompletedCategory {
+			return true
+		}
+	}
+	return false
+}
+
+func selectTargetGroup(groups []*assessmentGroup, name string) (*assessmentGroup, error) {
+	if name != "" {
+		var match *assessmentGroup
+		for _, group := range groups {
+			if group.Name != name {
+				continue
+			}
+			if match != nil {
+				return nil, fmt.Errorf("multiple assessment groups named %q", name)
+			}
+			match = group
+		}
+		if match == nil {
+			return nil, fmt.Errorf("assessment group %q not found", name)
+		}
+		return match, nil
+	}
+
+	var latest *assessmentGroup
+	var latestCreated time.Time
+	for _, group := range groups {
+		for _, candidate := range group.Assessments {
+			if latest == nil || candidate.CreatedDateTime.After(latestCreated) {
+				latest = group
+				latestCreated = candidate.CreatedDateTime
+			}
+		}
+	}
+	if latest == nil {
+		return nil, errors.New("scope has no assessment groups")
+	}
+	return latest, nil
+}
+
+func findSourceAssessment(groups []*assessmentGroup, targetGroup *assessmentGroup, target *assessment, sourceGroupName string) (*assessmentGroup, *assessment) {
+	var sourceGroup *assessmentGroup
+	var source *assessment
+	for _, group := range groups {
+		if group == targetGroup || sourceGroupName != "" && group.Name != sourceGroupName {
+			continue
+		}
+		for _, candidate := range group.Assessments {
+			if candidate.PolicyNodeID != target.PolicyNodeID || candidate.LastSession == nil {
+				continue
+			}
+			if !target.CreatedDateTime.IsZero() && !candidate.CreatedDateTime.Before(target.CreatedDateTime) {
+				continue
+			}
+			if source == nil || candidate.LastModifiedDate.After(source.LastModifiedDate) {
+				sourceGroup = group
+				source = candidate
+			}
+		}
+	}
+	return sourceGroup, source
+}
+
+func compareStrings(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/cmd/compliance/plan_test.go
+++ b/cmd/compliance/plan_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestBuildCompletionPlan(t *testing.T) {
+	old := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	answer := json.RawMessage(`{"questionId":"question-1","answers":["yes"]}`)
+
+	s := &scope{AssessmentGroups: []*assessmentGroup{
+		{
+			Name: "Old",
+			Assessments: []*assessment{
+				{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: old, LastModifiedDate: old, Answers: []json.RawMessage{answer}, LastSession: &sessionReference{SessionID: "old-a"}},
+			},
+		},
+		{
+			Name: "Previous",
+			Assessments: []*assessment{
+				{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: recent, LastModifiedDate: recent, Answers: []json.RawMessage{answer}, LastSession: &sessionReference{SessionID: "recent-a"}},
+				{Name: "Policy B", PolicyNodeID: "b", CreatedDateTime: recent, LastModifiedDate: recent, LastSession: &sessionReference{SessionID: "recent-b"}},
+			},
+		},
+		{
+			Name: "Current",
+			Assessments: []*assessment{
+				{Name: "Policy D", PolicyNodeID: "d", CreatedDateTime: targetDate, LastSession: &sessionReference{SessionID: "current-d"}},
+				{Name: "Policy C", PolicyNodeID: "c", CreatedDateTime: targetDate, IsActive: true},
+				{Name: "Policy B", PolicyNodeID: "b", CreatedDateTime: targetDate},
+				{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: targetDate},
+				{Name: "Policy E", PolicyNodeID: "e", CreatedDateTime: targetDate},
+			},
+		},
+	}}
+
+	plan, err := buildCompletionPlan(s, "Current", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.TargetGroup.Name != "Current" {
+		t.Fatalf("target group = %q, want Current", plan.TargetGroup.Name)
+	}
+
+	items := planItemsByName(plan.Items)
+	if got := items["Policy A"].Source.LastSession.SessionID; got != "recent-a" {
+		t.Errorf("Policy A source session = %q, want recent-a", got)
+	}
+	if got := len(items["Policy B"].Source.Answers); got != 0 {
+		t.Errorf("Policy B copied answer count = %d, want 0", got)
+	}
+	if got := items["Policy C"].SkipReason; got != "already in progress" {
+		t.Errorf("Policy C skip reason = %q", got)
+	}
+	if got := items["Policy D"].SkipReason; got != "already complete" {
+		t.Errorf("Policy D skip reason = %q", got)
+	}
+	if got := items["Policy E"].SkipReason; got != "no earlier completed assessment for this policy" {
+		t.Errorf("Policy E skip reason = %q", got)
+	}
+}
+
+func TestBuildCompletionPlanDefaultsToNewestGroup(t *testing.T) {
+	s := &scope{AssessmentGroups: []*assessmentGroup{
+		{Name: "Earlier", Assessments: []*assessment{{CreatedDateTime: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+		{Name: "Newest", Assessments: []*assessment{{CreatedDateTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}}},
+	}}
+
+	plan, err := buildCompletionPlan(s, "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := plan.TargetGroup.Name; got != "Newest" {
+		t.Fatalf("target group = %q, want Newest", got)
+	}
+}
+
+func TestBuildCompletionPlanRestrictsSourceGroup(t *testing.T) {
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetDate := created.Add(time.Hour)
+	s := &scope{AssessmentGroups: []*assessmentGroup{
+		{Name: "Requested", Assessments: []*assessment{{PolicyNodeID: "a", CreatedDateTime: created, LastModifiedDate: created, LastSession: &sessionReference{SessionID: "requested"}}}},
+		{Name: "Newer", Assessments: []*assessment{{PolicyNodeID: "a", CreatedDateTime: created, LastModifiedDate: created.Add(time.Minute), LastSession: &sessionReference{SessionID: "newer"}}}},
+		{Name: "Current", Assessments: []*assessment{{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: targetDate}}},
+	}}
+
+	plan, err := buildCompletionPlan(s, "Current", "Requested", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := plan.Items[0].Source.LastSession.SessionID; got != "requested" {
+		t.Fatalf("source session = %q, want requested", got)
+	}
+}
+
+func TestBuildCompletionPlanRetriesFailedSession(t *testing.T) {
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetDate := created.Add(time.Hour)
+	s := &scope{AssessmentGroups: []*assessmentGroup{
+		{Name: "Previous", Assessments: []*assessment{{PolicyNodeID: "a", CreatedDateTime: created, LastModifiedDate: created, LastSession: &sessionReference{SessionID: "source"}}}},
+		{Name: "Current", Assessments: []*assessment{{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: targetDate, IsActive: true, LastSession: &sessionReference{SessionID: "failed", Session: &session{ID: "failed", State: "failed"}}}}},
+	}}
+
+	plan, err := buildCompletionPlan(s, "Current", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Items[0].SkipReason != "" {
+		t.Fatalf("skip reason = %q, want retry", plan.Items[0].SkipReason)
+	}
+	if got := plan.Items[0].Source.LastSession.SessionID; got != "source" {
+		t.Fatalf("source session = %q, want source", got)
+	}
+}
+
+func TestBuildCompletionPlanReconcilesOpenExistingSession(t *testing.T) {
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	targetDate := created.Add(time.Hour)
+	existing := &session{ID: "current-session", State: "complete", WorkItems: []sessionWorkItem{{ItemType: "child", NodeID: "activity", WorkItemID: "123"}}}
+	s := &scope{AssessmentGroups: []*assessmentGroup{
+		{Name: "Previous", Assessments: []*assessment{{PolicyNodeID: "a", CreatedDateTime: created, LastModifiedDate: created, LastSession: &sessionReference{SessionID: "source"}}}},
+		{Name: "Current", Assessments: []*assessment{{Name: "Policy A", PolicyNodeID: "a", CreatedDateTime: targetDate, LastSession: &sessionReference{SessionID: existing.ID, Session: existing}}}},
+	}}
+
+	plan, err := buildCompletionPlan(s, "Current", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Items[0].SkipReason != "" {
+		t.Fatalf("skip reason = %q, want reconciliation", plan.Items[0].SkipReason)
+	}
+	if plan.Items[0].ExistingSession != existing {
+		t.Fatal("existing session was not retained")
+	}
+}
+
+func planItemsByName(items []completionPlanItem) map[string]completionPlanItem {
+	result := make(map[string]completionPlanItem, len(items))
+	for _, item := range items {
+		result[item.Target.Name] = item
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- add `cmd/compliance`, a CLI for recurring Azure DevOps compliance assessments
- reuse answers from the latest earlier completed assessment for each policy after validating them against the current questionnaire
- generate compliance work items, resume failed sessions, and complete only child activities that were completed in the selected source assessment
- support explicit, validated overrides when a questionnaire or activity set changes

## Use case

Recurring compliance assessment groups frequently recreate the same policy questionnaires and work-item activities. Completing them manually means finding the prior assessment, copying unchanged answers, recreating its work items, and closing activities that were already satisfied.

This command automates that repeatable work while treating the current assessment as authoritative. It selects prior assessments by policy ID, checks question IDs and definitions against the current graph, and refuses ambiguous changes. After saving answers, it generates a new completion session and reconciles child work items by activity node. Parent work items remain open, matching the portal's existing completion behavior.

## Safety and recovery

- dry-run is the default; `-apply` requires an explicit assessment-group name
- completed assessments are skipped, and in-progress assessments require `-overwrite`
- authentication comes from `az login` or `AZURE_DEVOPS_EXT_PAT`; credentials are not logged
- non-JSON error bodies are not echoed
- changed questionnaires require a complete `-answers-file` that is validated against all current questions and allowed option values
- current-only activities require an explicit `-complete-activity ASSESSMENT=NODE-ID` approval
- failed session generation is resumable and reruns are idempotent
- work items use the current Azure Boards project root instead of historical child paths that may have been deleted
- only node-matched or explicitly approved child work items are completed; parent work items are untouched

## Validation

- `go test ./...`
- `go test -race ./cmd/compliance`
- `golangci-lint run ./cmd/compliance/...`
- `go vet ./cmd/compliance`
- `go mod verify`
- end-to-end dry-run, apply, failure recovery, and idempotent rerun against an internal assessment group
