### PR TITLE
relui: improve failure diagnostics

### DIFF
--- a/cmd/releaseagent/internal/azdopipeline/client.go
+++ b/cmd/releaseagent/internal/azdopipeline/client.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +61,12 @@ type Build struct {
 	SourceVersion      string
 	Parameters         map[string]string
 	TemplateParameters map[string]any
+}
+
+// BuildFailure identifies one failed leaf in an Azure Pipelines run.
+type BuildFailure struct {
+	Path    string
+	Message string
 }
 
 // Definition is the allowlist-relevant metadata of an Azure Pipeline definition.
@@ -130,6 +137,21 @@ func (c *Client) Get(ctx context.Context, buildID int) (*Build, error) {
 		return nil, err
 	}
 	return response.build()
+}
+
+// GetFailures returns concise failure details from a completed pipeline run.
+func (c *Client) GetFailures(ctx context.Context, buildID int) ([]BuildFailure, error) {
+	if buildID <= 0 {
+		return nil, errors.New("build ID must be positive")
+	}
+	endpoint := c.buildsURL(nil) + "/" + strconv.Itoa(buildID) + "/timeline?api-version=7.1"
+	var response struct {
+		Records []apiTimelineRecord `json:"records"`
+	}
+	if err := c.getJSON(ctx, endpoint, &response); err != nil {
+		return nil, err
+	}
+	return timelineFailures(response.Records), nil
 }
 
 // GetDefinition returns read-only metadata used to verify an allowlisted pipeline target.
@@ -333,6 +355,91 @@ type apiBuild struct {
 		ID int `json:"id"`
 	} `json:"definition"`
 	Links json.RawMessage `json:"_links"`
+}
+
+type apiTimelineRecord struct {
+	ID       string `json:"id"`
+	ParentID string `json:"parentId"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Result   string `json:"result"`
+	Issues   []struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"issues"`
+}
+
+func timelineFailures(records []apiTimelineRecord) []BuildFailure {
+	byID := make(map[string]apiTimelineRecord, len(records))
+	for _, record := range records {
+		byID[record.ID] = record
+	}
+
+	var failed []apiTimelineRecord
+	for _, typeName := range []string{"task", "job", "stage"} {
+		for _, record := range records {
+			if strings.EqualFold(record.Type, typeName) && strings.EqualFold(record.Result, "failed") {
+				failed = append(failed, record)
+			}
+		}
+		if len(failed) != 0 {
+			break
+		}
+	}
+
+	result := make([]BuildFailure, 0, len(failed))
+	seen := make(map[string]struct{}, len(failed))
+	for _, record := range failed {
+		failure := BuildFailure{Path: timelineFailurePath(record, byID)}
+		for _, issue := range record.Issues {
+			if strings.EqualFold(issue.Type, "error") {
+				failure.Message = strings.Join(strings.Fields(issue.Message), " ")
+				if failure.Message != "" {
+					break
+				}
+			}
+		}
+		key := failure.Path + "\x00" + failure.Message
+		if failure.Path == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, failure)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left].Path < result[right].Path })
+	return result
+}
+
+func timelineFailurePath(record apiTimelineRecord, byID map[string]apiTimelineRecord) string {
+	var reversed []string
+	visited := make(map[string]struct{})
+	for {
+		if record.ID != "" {
+			if _, ok := visited[record.ID]; ok {
+				break
+			}
+			visited[record.ID] = struct{}{}
+		}
+		switch strings.ToLower(record.Type) {
+		case "stage", "job", "task":
+			if record.Name != "" {
+				reversed = append(reversed, record.Name)
+			}
+		}
+		parent, ok := byID[record.ParentID]
+		if !ok {
+			break
+		}
+		record = parent
+	}
+	path := make([]string, len(reversed))
+	for index := range reversed {
+		path[len(reversed)-1-index] = reversed[index]
+	}
+	return strings.Join(path, " > ")
 }
 
 func (b apiBuild) build() (*Build, error) {

--- a/cmd/releaseagent/internal/azdopipeline/client.go
+++ b/cmd/releaseagent/internal/azdopipeline/client.go
@@ -39,15 +39,16 @@ type HTTPDoer interface {
 
 // Client accesses one Azure DevOps project.
 type Client struct {
-	baseURL             string
-	project             string
-	http                HTTPDoer
-	tokens              TokenProvider
-	newDefinitionClient func(context.Context) (definitionClient, string, error)
+	baseURL        string
+	project        string
+	http           HTTPDoer
+	tokens         TokenProvider
+	newBuildClient func(context.Context) (buildClient, string, error)
 }
 
-type definitionClient interface {
+type buildClient interface {
 	GetDefinition(context.Context, azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error)
+	GetBuildTimeline(context.Context, azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error)
 }
 
 // Build is the release UI's stable view of an Azure Pipelines run.
@@ -122,7 +123,7 @@ func NewClient(baseURL, project string, httpClient HTTPDoer, tokens TokenProvide
 		http:    httpClient,
 		tokens:  tokens,
 	}
-	client.newDefinitionClient = client.createDefinitionClient
+	client.newBuildClient = client.createBuildClient
 	return client, nil
 }
 
@@ -144,14 +145,20 @@ func (c *Client) GetFailures(ctx context.Context, buildID int) ([]BuildFailure, 
 	if buildID <= 0 {
 		return nil, errors.New("build ID must be positive")
 	}
-	endpoint := c.buildsURL(nil) + "/" + strconv.Itoa(buildID) + "/timeline?api-version=7.1"
-	var response struct {
-		Records []apiTimelineRecord `json:"records"`
+	client, token, err := c.newBuildClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure DevOps Build client: %w", redactError(err, token))
 	}
-	if err := c.getJSON(ctx, endpoint, &response); err != nil {
-		return nil, err
+	timeline, err := client.GetBuildTimeline(ctx, azdobuild.GetBuildTimelineArgs{
+		Project: &c.project, BuildId: &buildID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get Azure DevOps build %d timeline: %w", buildID, redactError(err, token))
 	}
-	return timelineFailures(response.Records), nil
+	if timeline == nil || timeline.Records == nil {
+		return []BuildFailure{}, nil
+	}
+	return timelineFailures(*timeline.Records), nil
 }
 
 // GetDefinition returns read-only metadata used to verify an allowlisted pipeline target.
@@ -159,7 +166,7 @@ func (c *Client) GetDefinition(ctx context.Context, definitionID int) (*Definiti
 	if definitionID <= 0 {
 		return nil, errors.New("pipeline definition ID must be positive")
 	}
-	client, token, err := c.newDefinitionClient(ctx)
+	client, token, err := c.newBuildClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("create Azure DevOps Build client: %w", redactError(err, token))
 	}
@@ -181,12 +188,7 @@ func (c *Client) GetDefinition(ctx context.Context, definitionID int) (*Definiti
 	}, nil
 }
 
-func (c *Client) createDefinitionClient(ctx context.Context) (definitionClient, string, error) {
-	client, token, err := c.createBuildClient(ctx)
-	return client, token, err
-}
-
-func (c *Client) createBuildClient(ctx context.Context) (azdobuild.Client, string, error) {
+func (c *Client) createBuildClient(ctx context.Context) (buildClient, string, error) {
 	token, err := c.tokens.Token(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("acquire Azure DevOps token: %w", err)
@@ -357,28 +359,20 @@ type apiBuild struct {
 	Links json.RawMessage `json:"_links"`
 }
 
-type apiTimelineRecord struct {
-	ID       string `json:"id"`
-	ParentID string `json:"parentId"`
-	Type     string `json:"type"`
-	Name     string `json:"name"`
-	Result   string `json:"result"`
-	Issues   []struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
-	} `json:"issues"`
-}
-
-func timelineFailures(records []apiTimelineRecord) []BuildFailure {
-	byID := make(map[string]apiTimelineRecord, len(records))
+func timelineFailures(records []azdobuild.TimelineRecord) []BuildFailure {
+	byID := make(map[string]azdobuild.TimelineRecord, len(records))
 	for _, record := range records {
-		byID[record.ID] = record
+		if record.Id != nil {
+			byID[record.Id.String()] = record
+		}
 	}
 
-	var failed []apiTimelineRecord
+	var failed []azdobuild.TimelineRecord
 	for _, typeName := range []string{"task", "job", "stage"} {
 		for _, record := range records {
-			if strings.EqualFold(record.Type, typeName) && strings.EqualFold(record.Result, "failed") {
+			if strings.EqualFold(stringValue(record.Type), typeName) &&
+				strings.EqualFold(enumValue(record.Result), string(azdobuild.TaskResultValues.Failed)) {
+
 				failed = append(failed, record)
 			}
 		}
@@ -391,9 +385,12 @@ func timelineFailures(records []apiTimelineRecord) []BuildFailure {
 	seen := make(map[string]struct{}, len(failed))
 	for _, record := range failed {
 		failure := BuildFailure{Path: timelineFailurePath(record, byID)}
-		for _, issue := range record.Issues {
-			if strings.EqualFold(issue.Type, "error") {
-				failure.Message = strings.Join(strings.Fields(issue.Message), " ")
+		if record.Issues != nil {
+			for _, issue := range *record.Issues {
+				if !strings.EqualFold(enumValue(issue.Type), string(azdobuild.IssueTypeValues.Error)) {
+					continue
+				}
+				failure.Message = strings.Join(strings.Fields(stringValue(issue.Message)), " ")
 				if failure.Message != "" {
 					break
 				}
@@ -413,23 +410,31 @@ func timelineFailures(records []apiTimelineRecord) []BuildFailure {
 	return result
 }
 
-func timelineFailurePath(record apiTimelineRecord, byID map[string]apiTimelineRecord) string {
+func timelineFailurePath(record azdobuild.TimelineRecord, byID map[string]azdobuild.TimelineRecord) string {
 	var reversed []string
 	visited := make(map[string]struct{})
 	for {
-		if record.ID != "" {
-			if _, ok := visited[record.ID]; ok {
+		id := ""
+		if record.Id != nil {
+			id = record.Id.String()
+		}
+		if id != "" {
+			if _, ok := visited[id]; ok {
 				break
 			}
-			visited[record.ID] = struct{}{}
+			visited[id] = struct{}{}
 		}
-		switch strings.ToLower(record.Type) {
+		switch strings.ToLower(stringValue(record.Type)) {
 		case "stage", "job", "task":
-			if record.Name != "" {
-				reversed = append(reversed, record.Name)
+			if name := stringValue(record.Name); name != "" {
+				reversed = append(reversed, name)
 			}
 		}
-		parent, ok := byID[record.ParentID]
+		parentID := ""
+		if record.ParentId != nil {
+			parentID = record.ParentId.String()
+		}
+		parent, ok := byID[parentID]
 		if !ok {
 			break
 		}

--- a/cmd/releaseagent/internal/azdopipeline/client_test.go
+++ b/cmd/releaseagent/internal/azdopipeline/client_test.go
@@ -56,6 +56,35 @@ func TestListRecent(t *testing.T) {
 	}
 }
 
+func TestGetFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/internal/_apis/build/builds/888/timeline" || request.URL.Query().Get("api-version") != "7.1" {
+			t.Fatalf("unexpected timeline request: %s", request.URL.String())
+		}
+		_, _ = response.Write([]byte(`{"records":[` +
+			`{"id":"stage","type":"Stage","name":"Build","result":"failed"},` +
+			`{"id":"job","parentId":"stage","type":"Job","name":"Linux arm32","result":"failed"},` +
+			`{"id":"task","parentId":"job","type":"Task","name":"Build Images","result":"failed",` +
+			`"issues":[{"type":"warning","message":"retrying"},{"type":"error","message":"PowerShell  exited\nwith code 1"}]},` +
+			`{"id":"other","parentId":"job","type":"Task","name":"Cleanup","result":"succeeded"}` +
+			`]}`))
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, "internal", server.Client(), staticToken("test-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failures, err := client.GetFailures(context.Background(), 888)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 1 || failures[0].Path != "Build > Linux arm32 > Build Images" ||
+		failures[0].Message != "PowerShell exited with code 1" {
+
+		t.Fatalf("failures = %#v", failures)
+	}
+}
+
 func TestGetDefinition(t *testing.T) {
 	client, err := NewClient("https://example.invalid", "internal", http.DefaultClient, staticToken("test-token"))
 	if err != nil {

--- a/cmd/releaseagent/internal/azdopipeline/client_test.go
+++ b/cmd/releaseagent/internal/azdopipeline/client_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	azdobuild "github.com/microsoft/azure-devops-go-api/azuredevops/build"
 )
 
@@ -18,10 +19,17 @@ type staticToken string
 
 func (t staticToken) Token(context.Context) (string, error) { return string(t), nil }
 
-type definitionClientFunc func(context.Context, azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error)
+type fakeBuildClient struct {
+	getDefinition func(context.Context, azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error)
+	getTimeline   func(context.Context, azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error)
+}
 
-func (f definitionClientFunc) GetDefinition(ctx context.Context, args azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error) {
-	return f(ctx, args)
+func (f fakeBuildClient) GetDefinition(ctx context.Context, args azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error) {
+	return f.getDefinition(ctx, args)
+}
+
+func (f fakeBuildClient) GetBuildTimeline(ctx context.Context, args azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error) {
+	return f.getTimeline(ctx, args)
 }
 
 func TestListRecent(t *testing.T) {
@@ -57,22 +65,38 @@ func TestListRecent(t *testing.T) {
 }
 
 func TestGetFailures(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/internal/_apis/build/builds/888/timeline" || request.URL.Query().Get("api-version") != "7.1" {
-			t.Fatalf("unexpected timeline request: %s", request.URL.String())
-		}
-		_, _ = response.Write([]byte(`{"records":[` +
-			`{"id":"stage","type":"Stage","name":"Build","result":"failed"},` +
-			`{"id":"job","parentId":"stage","type":"Job","name":"Linux arm32","result":"failed"},` +
-			`{"id":"task","parentId":"job","type":"Task","name":"Build Images","result":"failed",` +
-			`"issues":[{"type":"warning","message":"retrying"},{"type":"error","message":"PowerShell  exited\nwith code 1"}]},` +
-			`{"id":"other","parentId":"job","type":"Task","name":"Cleanup","result":"succeeded"}` +
-			`]}`))
-	}))
-	defer server.Close()
-	client, err := NewClient(server.URL, "internal", server.Client(), staticToken("test-token"))
+	stageID := uuid.New()
+	jobID := uuid.New()
+	taskID := uuid.New()
+	otherID := uuid.New()
+	typeStage, typeJob, typeTask := "Stage", "Job", "Task"
+	nameStage, nameJob, nameTask, nameOther := "Build", "Linux arm32", "Build Images", "Cleanup"
+	failed := azdobuild.TaskResultValues.Failed
+	succeeded := azdobuild.TaskResultValues.Succeeded
+	warning := azdobuild.IssueTypeValues.Warning
+	errorIssue := azdobuild.IssueTypeValues.Error
+	retrying := "retrying"
+	message := "PowerShell  exited\nwith code 1"
+	client, err := NewClient("https://example.invalid", "internal", http.DefaultClient, staticToken("test-token"))
 	if err != nil {
 		t.Fatal(err)
+	}
+	client.newBuildClient = func(context.Context) (buildClient, string, error) {
+		return fakeBuildClient{getTimeline: func(_ context.Context, args azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error) {
+			if args.Project == nil || *args.Project != "internal" || args.BuildId == nil || *args.BuildId != 888 {
+				t.Fatalf("timeline args = %#v", args)
+			}
+			records := []azdobuild.TimelineRecord{
+				{Id: &stageID, Type: &typeStage, Name: &nameStage, Result: &failed},
+				{Id: &jobID, ParentId: &stageID, Type: &typeJob, Name: &nameJob, Result: &failed},
+				{
+					Id: &taskID, ParentId: &jobID, Type: &typeTask, Name: &nameTask, Result: &failed,
+					Issues: &[]azdobuild.Issue{{Type: &warning, Message: &retrying}, {Type: &errorIssue, Message: &message}},
+				},
+				{Id: &otherID, ParentId: &jobID, Type: &typeTask, Name: &nameOther, Result: &succeeded},
+			}
+			return &azdobuild.Timeline{Records: &records}, nil
+		}}, "test-token", nil
 	}
 	failures, err := client.GetFailures(context.Background(), 888)
 	if err != nil {
@@ -85,13 +109,29 @@ func TestGetFailures(t *testing.T) {
 	}
 }
 
+func TestGetFailuresRedactsToken(t *testing.T) {
+	client, err := NewClient("https://example.invalid", "internal", http.DefaultClient, staticToken("secret-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.newBuildClient = func(context.Context) (buildClient, string, error) {
+		return fakeBuildClient{getTimeline: func(context.Context, azdobuild.GetBuildTimelineArgs) (*azdobuild.Timeline, error) {
+			return nil, errors.New("secret-token denied")
+		}}, "secret-token", nil
+	}
+	_, err = client.GetFailures(context.Background(), 888)
+	if err == nil || strings.Contains(err.Error(), "secret-token") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error = %v, want redacted error", err)
+	}
+}
+
 func TestGetDefinition(t *testing.T) {
 	client, err := NewClient("https://example.invalid", "internal", http.DefaultClient, staticToken("test-token"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.newDefinitionClient = func(context.Context) (definitionClient, string, error) {
-		return definitionClientFunc(func(_ context.Context, args azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error) {
+	client.newBuildClient = func(context.Context) (buildClient, string, error) {
+		return fakeBuildClient{getDefinition: func(_ context.Context, args azdobuild.GetDefinitionArgs) (*azdobuild.BuildDefinition, error) {
 			if args.Project == nil || *args.Project != "internal" || args.DefinitionId == nil || *args.DefinitionId != 1023 {
 				t.Fatalf("definition args = %#v", args)
 			}
@@ -105,7 +145,7 @@ func TestGetDefinition(t *testing.T) {
 				Process:    map[string]any{"yamlFilename": "eng/pipeline/go-docker-rolling-internal-pipeline.yml"},
 				Repository: &azdobuild.BuildRepository{DefaultBranch: &defaultBranch, Name: &repositoryName},
 			}, nil
-		}), "test-token", nil
+		}}, "test-token", nil
 	}
 	definition, err := client.GetDefinition(context.Background(), 1023)
 	if err != nil {

--- a/cmd/releaseagent/internal/goimagesexecution/service.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
@@ -34,6 +35,7 @@ var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 // PipelineReader is the read-only Azure DevOps behavior required for reconciliation and polling.
 type PipelineReader interface {
 	Get(context.Context, int) (*azdopipeline.Build, error)
+	GetFailures(context.Context, int) ([]azdopipeline.BuildFailure, error)
 	ListRecent(context.Context, int) ([]*azdopipeline.Build, error)
 }
 
@@ -270,11 +272,24 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 			})
 			return nil
 		case azdopipeline.RunStateFailed, azdopipeline.RunStateCanceled:
+			detail := fmt.Sprintf("Build %d finished with result %s", id, build.Result)
+			failure := fmt.Sprintf("go-images release build %d %s", id, state)
+			if state == azdopipeline.RunStateFailed {
+				if summary := s.failureSummary(ctx, id); summary != "" {
+					detail = summary
+					failure += ": " + summary
+				} else {
+					failure += fmt.Sprintf(" with result %q", build.Result)
+				}
+			}
 			coordinator.ReportProgress(ctx, coordinator.StepProgress{
 				Summary: fmt.Sprintf("Azure pipeline %s", state),
-				Detail:  fmt.Sprintf("Build %d finished with result %s", id, build.Result),
+				Detail:  detail,
 			})
-			return fmt.Errorf("go-images release build %d finished with state %q and result %q: %s", id, state, build.Result, build.WebURL)
+			if build.WebURL != "" {
+				failure += ". Inspect the Azure run: " + build.WebURL
+			}
+			return errors.New(failure)
 		case azdopipeline.RunStateWaiting, azdopipeline.RunStateRunning:
 			s.reportPipelineProgress(ctx, id, state)
 			if err := s.sleep(ctx, s.config.PollInterval); err != nil {
@@ -284,6 +299,36 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 			return fmt.Errorf("go-images release build %d has unsupported state %q", id, state)
 		}
 	}
+}
+
+func (s *Service) failureSummary(ctx context.Context, buildID int) string {
+	failures, err := s.reader.GetFailures(ctx, buildID)
+	if err != nil || len(failures) == 0 {
+		return ""
+	}
+	const maxFailures = 3
+	count := min(len(failures), maxFailures)
+	details := make([]string, 0, count+1)
+	for _, failure := range failures[:count] {
+		detail := failure.Path
+		if failure.Message != "" {
+			detail += ": " + truncateFailureMessage(failure.Message)
+		}
+		details = append(details, detail)
+	}
+	if remaining := len(failures) - count; remaining > 0 {
+		details = append(details, fmt.Sprintf("and %d more failures", remaining))
+	}
+	return strings.Join(details, "; ")
+}
+
+func truncateFailureMessage(message string) string {
+	const maxRunes = 240
+	runes := []rune(message)
+	if len(runes) <= maxRunes {
+		return message
+	}
+	return string(runes[:maxRunes]) + "..."
 }
 
 func (s *Service) reportPipelineProgress(ctx context.Context, buildID int, state azdopipeline.RunState) {

--- a/cmd/releaseagent/internal/goimagesexecution/service_test.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service_test.go
@@ -16,10 +16,13 @@ import (
 )
 
 type fakeReader struct {
-	builds []*azdopipeline.Build
-	recent [][]*azdopipeline.Build
-	gets   int
-	lists  int
+	builds      []*azdopipeline.Build
+	recent      [][]*azdopipeline.Build
+	failures    []azdopipeline.BuildFailure
+	failureErr  error
+	gets        int
+	lists       int
+	failureGets int
 }
 
 func (r *fakeReader) Get(context.Context, int) (*azdopipeline.Build, error) {
@@ -41,6 +44,11 @@ func (r *fakeReader) ListRecent(context.Context, int) ([]*azdopipeline.Build, er
 		index = len(r.recent) - 1
 	}
 	return r.recent[index], nil
+}
+
+func (r *fakeReader) GetFailures(context.Context, int) ([]azdopipeline.BuildFailure, error) {
+	r.failureGets++
+	return r.failures, r.failureErr
 }
 
 type fakeQueueClient struct {
@@ -240,18 +248,35 @@ func TestPollPipeline(t *testing.T) {
 	if err := service.PollPipeline(context.Background(), "888"); err != nil {
 		t.Fatal(err)
 	}
-	if reader.gets != 2 || sleeps != 1 {
-		t.Fatalf("gets = %d, sleeps = %d", reader.gets, sleeps)
+	if reader.gets != 2 || reader.failureGets != 0 || sleeps != 1 {
+		t.Fatalf("gets = %d, failure gets = %d, sleeps = %d", reader.gets, reader.failureGets, sleeps)
 	}
 }
 
 func TestPollPipelineReportsFailure(t *testing.T) {
 	reader := &fakeReader{builds: []*azdopipeline.Build{{
 		ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "failed", WebURL: "https://example/build/888",
+	}}, failures: []azdopipeline.BuildFailure{{
+		Path: "Build > Linux arm32 > Build Images", Message: "PowerShell exited with code 1",
 	}}}
 	service := newTestService(t, reader, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
 	err := service.PollPipeline(context.Background(), strconv.Itoa(888))
-	if err == nil || !strings.Contains(err.Error(), "failed") || !strings.Contains(err.Error(), "https://example/build/888") {
+	if err == nil || !strings.Contains(err.Error(), "Build > Linux arm32 > Build Images: PowerShell exited with code 1") ||
+		!strings.Contains(err.Error(), "https://example/build/888") || reader.failureGets != 1 {
+
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPollPipelineFailureDetailsAreOptional(t *testing.T) {
+	reader := &fakeReader{builds: []*azdopipeline.Build{{
+		ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "failed", WebURL: "https://example/build/888",
+	}}, failureErr: errors.New("timeline unavailable")}
+	service := newTestService(t, reader, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
+	err := service.PollPipeline(context.Background(), "888")
+	if err == nil || !strings.Contains(err.Error(), `failed with result "failed"`) ||
+		!strings.Contains(err.Error(), "https://example/build/888") {
+
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -352,7 +352,7 @@
     executionControls.hidden = !visible;
     const unavailableReason = execution?.unavailableReason ||
       (execution?.enabled && !preflightReady
-        ? "External execution is not ready. Review the preflight checks."
+        ? preflightFailureSummary()
         : "");
     executionUnavailable.hidden = visible || !unavailableReason;
     executionUnavailable.textContent = unavailableReason;
@@ -366,6 +366,12 @@
     executionWarning.textContent = view.executionWarning || "This starts the configured external release workflow.";
     runConfirmationCopy.textContent = view.executionConfirmation || "Confirm this release before starting it.";
     updateExecutionButton();
+  }
+
+  function preflightFailureSummary() {
+    const failures = (preflight?.checks || []).filter((check) => check.status !== "passed");
+    if (!failures.length) return "External execution is unavailable.";
+    return failures.map((check) => `${check.name}: ${check.details}`).join("; ");
   }
 
   function handleExecutionAction() {


### PR DESCRIPTION
Improves the diagnostics shown when release readiness checks or a go-images pipeline run fails.

## Summary

- replace the generic execution-unavailable message with details from non-passing preflight checks
- read the Azure timeline once after a failed go-images run and report up to three failed task paths with their issue messages
- retain the Azure run link and fall back to the run-level result when timeline details are unavailable

This does not restore continuous timeline polling or persist timeline data.

## Validation

- `go test -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.0 run ./cmd/releaseagent/...`
- `git diff --check`