### PR TITLE
pipelineymlgen: preserve inline YAML map order

### DIFF
--- a/internal/pipelineymlgen/eval.go
+++ b/internal/pipelineymlgen/eval.go
@@ -33,6 +33,10 @@ type EvalState struct {
 	// inlinerange iterates without variable names, it may be any value
 	// (e.g. a scalar), allowing ${ . } to give the element directly.
 	Data any
+
+	// preservedYAML retains the original YAML nodes for maps and slices decoded
+	// into Data so yml can emit them without losing mapping order.
+	preservedYAML map[dataIdentity]preservedYAMLValue
 }
 
 // EvalFile is a helper to run EvalFileConfig and evalFileWithConfig in one.
@@ -219,6 +223,10 @@ func (e *EvalState) eval(orig *yaml.Node) (any, error) {
 
 				if err := valueNode.Decode(&evalKey.data); err != nil {
 					return fail(fmt.Errorf("decoding template data for mapping key: %w", err))
+				}
+				evalKey.preservedYAML, err = preserveYAMLValueNodes(evalKey.data, valueNode)
+				if err != nil {
+					return fail(fmt.Errorf("preserving template data YAML nodes: %w", err))
 				}
 				m.content = append(m.content, evalKey)
 			// If the key is an evalRange, keep the value as the unevaluated body.
@@ -603,6 +611,7 @@ func (e *EvalState) evalTemplateResult(t *evalTemplate) (*yaml.Node, error) {
 	ee := *e
 	ee.File = filepath.Join(filepath.Dir(e.File), t.path)
 	ee.MergeData(t.data)
+	ee.mergePreservedYAML(t.preservedYAML)
 	v, err := ee.EvalFile()
 	if err != nil {
 		return nil, err
@@ -828,8 +837,9 @@ func (e *evalElse) satisfied() (bool, error) {
 }
 
 type evalTemplate struct {
-	path string
-	data map[string]any
+	path          string
+	data          map[string]any
+	preservedYAML map[dataIdentity]preservedYAMLValue
 }
 
 type evalRange struct {

--- a/internal/pipelineymlgen/expr.go
+++ b/internal/pipelineymlgen/expr.go
@@ -73,9 +73,13 @@ func executeExpression(e *EvalState, expr string) (any, error) {
 			return "", nil
 		},
 		"yml": func(v any) (string, error) {
-			n, err := marshalToNode(v)
-			if err != nil {
-				return "", fmt.Errorf("failed to convert inline value: %w", err)
+			n := e.preservedYAMLNode(v)
+			if n == nil {
+				var err error
+				n, err = marshalToNode(v)
+				if err != nil {
+					return "", fmt.Errorf("failed to convert inline value: %w", err)
+				}
 			}
 			result = n
 			return "", nil

--- a/internal/pipelineymlgen/testdata/TestIndividualFiles/inline-template-map-order.gen.yml
+++ b/internal/pipelineymlgen/testdata/TestIndividualFiles/inline-template-map-order.gen.yml
@@ -1,0 +1,8 @@
+- ${ inlinetemplate "inline-x-template.yml" }:
+    x:
+      - stage: PrepareRelease
+        jobs:
+          - job: PrepareRelease
+      - template: release.yml
+        parameters:
+          publish: true

--- a/internal/pipelineymlgen/testdata/TestIndividualFiles/inline-template-map-order.golden.yml
+++ b/internal/pipelineymlgen/testdata/TestIndividualFiles/inline-template-map-order.golden.yml
@@ -1,0 +1,6 @@
+- stage: PrepareRelease
+  jobs:
+    - job: PrepareRelease
+- template: release.yml
+  parameters:
+    publish: true

--- a/internal/pipelineymlgen/yamldata.go
+++ b/internal/pipelineymlgen/yamldata.go
@@ -112,7 +112,15 @@ func preserveYAMLValueNode(preserved map[dataIdentity]preservedYAMLValue, value 
 
 func identityOf(value reflect.Value) (dataIdentity, bool) {
 	switch value.Kind() {
-	case reflect.Map, reflect.Slice:
+	case reflect.Map:
+		if value.IsNil() {
+			return dataIdentity{}, false
+		}
+		return dataIdentity{
+			typ:     value.Type(),
+			pointer: uintptr(value.UnsafePointer()),
+		}, true
+	case reflect.Slice:
 		if value.IsNil() {
 			return dataIdentity{}, false
 		}
@@ -144,6 +152,11 @@ func (e *EvalState) preservedYAMLNode(value any) *yaml.Node {
 	}
 	preserved, ok := e.preservedYAML[identity]
 	if !ok {
+		return nil
+	}
+	decoded := reflect.New(reflect.TypeOf(value))
+	if err := preserved.node.Decode(decoded.Interface()); err != nil ||
+		!reflect.DeepEqual(value, decoded.Elem().Interface()) {
 		return nil
 	}
 	return cloneNodeTree(preserved.node)

--- a/internal/pipelineymlgen/yamldata.go
+++ b/internal/pipelineymlgen/yamldata.go
@@ -4,10 +4,24 @@
 package pipelineymlgen
 
 import (
+	"fmt"
+	"maps"
+	"reflect"
 	"slices"
 
 	"go.yaml.in/yaml/v4"
 )
+
+type dataIdentity struct {
+	typ     reflect.Type
+	pointer uintptr
+}
+
+type preservedYAMLValue struct {
+	// Keep the source value alive so its identity cannot be reused.
+	value any
+	node  *yaml.Node
+}
 
 // sortedMapKeys returns the keys of m in sorted order for deterministic output.
 func sortedMapKeys(m map[string]any) []string {
@@ -33,4 +47,116 @@ func marshalToNode(v any) (*yaml.Node, error) {
 		return n.Content[0], nil
 	}
 	return &n, nil
+}
+
+func preserveYAMLValueNodes(value any, node *yaml.Node) (map[dataIdentity]preservedYAMLValue, error) {
+	preserved := make(map[dataIdentity]preservedYAMLValue)
+	if err := preserveYAMLValueNode(preserved, value, node); err != nil {
+		return nil, err
+	}
+	return preserved, nil
+}
+
+func preserveYAMLValueNode(preserved map[dataIdentity]preservedYAMLValue, value any, node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 1 {
+			return preserveYAMLValueNode(preserved, value, node.Content[0])
+		}
+		return nil
+	}
+
+	rv := reflect.ValueOf(value)
+	identity, ok := identityOf(rv)
+	if ok {
+		preserved[identity] = preservedYAMLValue{
+			value: value,
+			node:  node,
+		}
+	}
+
+	switch node.Kind {
+	case yaml.MappingNode:
+		if rv.Kind() != reflect.Map {
+			return nil
+		}
+		for i := 0; i < len(node.Content); i += 2 {
+			key := reflect.New(rv.Type().Key())
+			if err := node.Content[i].Decode(key.Interface()); err != nil {
+				return fmt.Errorf("decoding mapping key at index %d: %w", i/2, err)
+			}
+			mapValue := rv.MapIndex(key.Elem())
+			if mapValue.IsValid() {
+				if err := preserveYAMLValueNode(preserved, mapValue.Interface(), node.Content[i+1]); err != nil {
+					return err
+				}
+			}
+		}
+	case yaml.SequenceNode:
+		if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+			return nil
+		}
+		for i, child := range node.Content {
+			if i >= rv.Len() {
+				break
+			}
+			if err := preserveYAMLValueNode(preserved, rv.Index(i).Interface(), child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func identityOf(value reflect.Value) (dataIdentity, bool) {
+	switch value.Kind() {
+	case reflect.Map, reflect.Slice:
+		if value.IsNil() {
+			return dataIdentity{}, false
+		}
+		return dataIdentity{
+			typ:     value.Type(),
+			pointer: value.Pointer(),
+		}, true
+	default:
+		return dataIdentity{}, false
+	}
+}
+
+func (e *EvalState) mergePreservedYAML(preserved map[dataIdentity]preservedYAMLValue) {
+	if len(preserved) == 0 {
+		return
+	}
+	cloned := maps.Clone(e.preservedYAML)
+	if cloned == nil {
+		cloned = make(map[dataIdentity]preservedYAMLValue)
+	}
+	maps.Copy(cloned, preserved)
+	e.preservedYAML = cloned
+}
+
+func (e *EvalState) preservedYAMLNode(value any) *yaml.Node {
+	identity, ok := identityOf(reflect.ValueOf(value))
+	if !ok {
+		return nil
+	}
+	preserved, ok := e.preservedYAML[identity]
+	if !ok {
+		return nil
+	}
+	return cloneNodeTree(preserved.node)
+}
+
+func cloneNodeTree(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	cloned := *node
+	cloned.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		cloned.Content[i] = cloneNodeTree(child)
+	}
+	return &cloned
 }

--- a/internal/pipelineymlgen/yamldata_test.go
+++ b/internal/pipelineymlgen/yamldata_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package pipelineymlgen
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v4"
+)
+
+func TestPreservedYAMLNode(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		mutate func(any) any
+	}{
+		{
+			name:   "mutated map",
+			source: "first: 1\nsecond: 2\n",
+			mutate: func(value any) any {
+				value.(map[string]any)["third"] = 3
+				return value
+			},
+		},
+		{
+			name:   "shortened slice",
+			source: "- first\n- second\n",
+			mutate: func(value any) any {
+				return value.([]any)[:1]
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var node yaml.Node
+			if err := yaml.Unmarshal([]byte(test.source), &node); err != nil {
+				t.Fatal(err)
+			}
+			var value any
+			if err := node.Decode(&value); err != nil {
+				t.Fatal(err)
+			}
+			preserved, err := preserveYAMLValueNodes(value, &node)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state := EvalState{preservedYAML: preserved}
+
+			if state.preservedYAMLNode(value) == nil {
+				t.Fatal("expected unchanged value to use its preserved YAML node")
+			}
+			if state.preservedYAMLNode(test.mutate(value)) != nil {
+				t.Fatal("expected mutated value not to use its preserved YAML node")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Retain source YAML nodes for structured inline-template data so yml insertion does not reorder AzDO Pipeline keys.

For example, currently, alphanumeric ordering changes this:

```yml
      - stage: PrepareRelease
        jobs:
          - job: PrepareRelease
```

to:

```yml
      - jobs:
          - job: PrepareRelease
        stage: PrepareRelease
```

which AzDO doesn't accept.

Fixing this allows jobs to pass through `data`, improving the flexibility of `pipelineymlgen` templates.

---

Yes, AzDO pipeline yaml is not compliant with the YAML spec:
https://yaml.org/spec/1.2.2/#3221-mapping-key-order

> To serialize a mapping, it is necessary to impose an ordering on its keys. This order is a serialization detail and should not be used when composing the representation graph (and hence for the preservation of application data). **In every case where node order is significant, a sequence must be used.**