### PR TITLE
releaseagent: add Azure DevOps work item contract

### DIFF
--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -1,0 +1,386 @@
+// Client operations for release work items.
+package azdoworkitem
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking"
+)
+
+const (
+	AreaPath         = `DevDiv\GoLang`
+	SelectorTag      = "releaseagent"
+	TestTag          = "releaseagent-test"
+	descriptionField = "System.Description"
+	maxQueryResults  = 200
+	sdkTimeout       = 3 * time.Minute
+)
+
+var ErrRevisionConflict = errors.New("release work item revision changed")
+
+type TokenProvider interface {
+	Token(context.Context) (string, error)
+}
+
+type Config struct {
+	BaseURL      string
+	Project      string
+	WorkItemType string
+}
+
+type Client struct {
+	baseURL      string
+	project      string
+	workItemType string
+	tokens       TokenProvider
+	newClient    func(context.Context) (workItemClient, string, error)
+}
+
+type WorkItem struct {
+	ID       int
+	Revision int
+	URL      string
+	Title    string
+	State    string
+	Snapshot *Snapshot
+}
+
+type workItemClient interface {
+	CreateWorkItem(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error)
+	GetWorkItem(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error)
+	GetWorkItems(context.Context, workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error)
+	QueryByWiql(context.Context, workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error)
+	UpdateWorkItem(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error)
+}
+
+func NewClient(config Config, tokens TokenProvider) (*Client, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(config.BaseURL), "/")
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme != "https" && parsed.Scheme != "http" || parsed.Host == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+
+		return nil, fmt.Errorf("invalid Azure DevOps base URL %q", config.BaseURL)
+	}
+	project := strings.TrimSpace(config.Project)
+	if project == "" {
+		return nil, errors.New("azure DevOps project must not be empty")
+	}
+	workItemType := strings.TrimSpace(config.WorkItemType)
+	if workItemType == "" {
+		return nil, errors.New("azure DevOps work item type must not be empty")
+	}
+	if tokens == nil {
+		return nil, errors.New("azure DevOps token provider must not be nil")
+	}
+	client := &Client{
+		baseURL: baseURL, project: project, workItemType: workItemType,
+		tokens: tokens,
+	}
+	client.newClient = client.createClient
+	return client, nil
+}
+
+func (c *Client) Create(ctx context.Context, title string, snapshot *Snapshot) (*WorkItem, error) {
+	if strings.TrimSpace(title) == "" {
+		return nil, errors.New("release work item title must not be empty")
+	}
+	snapshotJSON, err := MarshalSnapshot(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	description, err := RenderDescription(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	document := []webapi.JsonPatchOperation{
+		patch(webapi.OperationValues.Add, "/fields/System.Title", title),
+		patch(webapi.OperationValues.Add, "/fields/System.AreaPath", AreaPath),
+		patch(webapi.OperationValues.Add, "/fields/System.Tags", workItemTags(snapshot)),
+		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
+	}
+	sdk, token, err := c.newClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure DevOps work item client: %w", redactError(err, token))
+	}
+	response, err := sdk.CreateWorkItem(ctx, workitemtracking.CreateWorkItemArgs{
+		Document: &document, Project: &c.project, Type: &c.workItemType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create release work item: %w", redactError(err, token))
+	}
+	return c.parseWrittenWorkItem(response, snapshotJSON, "created")
+}
+
+func (c *Client) Get(ctx context.Context, id int) (*WorkItem, error) {
+	if id <= 0 {
+		return nil, errors.New("release work item ID must be positive")
+	}
+	sdk, token, err := c.newClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure DevOps work item client: %w", redactError(err, token))
+	}
+	fields := c.fields()
+	response, err := sdk.GetWorkItem(ctx, workitemtracking.GetWorkItemArgs{
+		Id: &id, Project: &c.project, Fields: &fields,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get release work item %d: %w", id, redactError(err, token))
+	}
+	workItem, err := c.parseWorkItem(response)
+	if err != nil {
+		return nil, err
+	}
+	if workItem.ID != id {
+		return nil, fmt.Errorf("azure DevOps returned work item %d, expected %d", workItem.ID, id)
+	}
+	return workItem, nil
+}
+
+func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapshot) (*WorkItem, error) {
+	if current == nil || current.ID <= 0 || current.Revision <= 0 {
+		return nil, errors.New("current release work item is invalid")
+	}
+	snapshotJSON, err := MarshalSnapshot(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	description, err := RenderDescription(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	document := []webapi.JsonPatchOperation{
+		patch(webapi.OperationValues.Test, "/rev", current.Revision),
+		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
+	}
+	sdk, token, err := c.newClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure DevOps work item client: %w", redactError(err, token))
+	}
+	response, err := sdk.UpdateWorkItem(ctx, workitemtracking.UpdateWorkItemArgs{
+		Document: &document, Id: &current.ID, Project: &c.project,
+	})
+	if err != nil {
+		if isRevisionConflict(err) {
+			return nil, fmt.Errorf("%w: work item %d revision %d", ErrRevisionConflict, current.ID, current.Revision)
+		}
+		return nil, fmt.Errorf("update release work item %d: %w", current.ID, redactError(err, token))
+	}
+	workItem, err := c.parseWrittenWorkItem(response, snapshotJSON, "updated")
+	if err != nil {
+		return nil, err
+	}
+	if workItem.ID != current.ID || workItem.Revision <= current.Revision {
+		return nil, errors.New("azure DevOps returned an unexpected work item revision")
+	}
+	return workItem, nil
+}
+
+func (c *Client) Query(ctx context.Context, limit int) ([]*WorkItem, error) {
+	if limit <= 0 || limit > maxQueryResults {
+		return nil, fmt.Errorf("release work item query limit must be between 1 and %d", maxQueryResults)
+	}
+	wiql := fmt.Sprintf(
+		"SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = '%s' "+
+			"AND [System.AreaPath] = '%s' AND [System.Tags] CONTAINS '%s' "+
+			"ORDER BY [System.ChangedDate] DESC",
+		escapeWIQL(c.workItemType), escapeWIQL(AreaPath), escapeWIQL(SelectorTag),
+	)
+	sdk, token, err := c.newClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure DevOps work item client: %w", redactError(err, token))
+	}
+	result, err := sdk.QueryByWiql(ctx, workitemtracking.QueryByWiqlArgs{
+		Wiql: &workitemtracking.Wiql{Query: &wiql}, Project: &c.project, Top: &limit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query release work items: %w", redactError(err, token))
+	}
+	if result == nil || result.WorkItems == nil || len(*result.WorkItems) == 0 {
+		return []*WorkItem{}, nil
+	}
+	if len(*result.WorkItems) > limit {
+		return nil, fmt.Errorf("azure DevOps query returned more than %d work items", limit)
+	}
+
+	ids := make([]int, len(*result.WorkItems))
+	positions := make(map[int]int, len(ids))
+	for index, reference := range *result.WorkItems {
+		if reference.Id == nil || *reference.Id <= 0 {
+			return nil, errors.New("azure DevOps query returned an invalid work item ID")
+		}
+		if _, exists := positions[*reference.Id]; exists {
+			return nil, fmt.Errorf("azure DevOps query returned duplicate work item %d", *reference.Id)
+		}
+		ids[index] = *reference.Id
+		positions[*reference.Id] = index
+	}
+	fields := c.fields()
+	responses, err := sdk.GetWorkItems(ctx, workitemtracking.GetWorkItemsArgs{
+		Ids: &ids, Project: &c.project, Fields: &fields,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read release work item query results: %w", redactError(err, token))
+	}
+	if responses == nil {
+		return nil, errors.New("azure DevOps returned no work item query results")
+	}
+	items := make([]*WorkItem, len(ids))
+	for index := range *responses {
+		item, err := c.parseWorkItem(&(*responses)[index])
+		if err != nil {
+			return nil, err
+		}
+		position, ok := positions[item.ID]
+		if !ok {
+			return nil, fmt.Errorf("azure DevOps returned unrequested work item %d", item.ID)
+		}
+		if items[position] != nil {
+			return nil, fmt.Errorf("azure DevOps returned duplicate work item %d", item.ID)
+		}
+		items[position] = item
+	}
+	for _, item := range items {
+		if item == nil {
+			return nil, fmt.Errorf("azure DevOps returned %d of %d requested work items", len(*responses), len(ids))
+		}
+	}
+	return items, nil
+}
+
+func (c *Client) createClient(ctx context.Context) (workItemClient, string, error) {
+	token, err := c.tokens.Token(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("acquire Azure DevOps token: %w", err)
+	}
+	if token == "" {
+		return nil, "", errors.New("azure DevOps token provider returned an empty token")
+	}
+	connection := azuredevops.NewAnonymousConnection(c.baseURL)
+	connection.AuthorizationString = "Bearer " + token
+	timeout := sdkTimeout
+	connection.Timeout = &timeout
+	client, err := workitemtracking.NewClient(ctx, connection)
+	return client, token, err
+}
+
+func (c *Client) parseWrittenWorkItem(response *workitemtracking.WorkItem, want []byte, action string) (*WorkItem, error) {
+	workItem, err := c.parseWorkItem(response)
+	if err != nil {
+		return nil, err
+	}
+	got, err := MarshalSnapshot(workItem.Snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(got, want) {
+		return nil, fmt.Errorf("azure DevOps returned a different %s release snapshot", action)
+	}
+	return workItem, nil
+}
+
+func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, error) {
+	if response == nil || response.Id == nil || *response.Id <= 0 || response.Rev == nil || *response.Rev <= 0 || response.Fields == nil {
+		return nil, errors.New("azure DevOps returned an invalid work item")
+	}
+	fields := *response.Fields
+	workItemType, ok := fields["System.WorkItemType"].(string)
+	if !ok || workItemType != c.workItemType {
+		return nil, fmt.Errorf("work item %d has unexpected type %q", *response.Id, workItemType)
+	}
+	areaPath, ok := fields["System.AreaPath"].(string)
+	if !ok || areaPath != AreaPath {
+		return nil, fmt.Errorf("work item %d has unexpected area path %q", *response.Id, areaPath)
+	}
+	tags, ok := fields["System.Tags"].(string)
+	if !ok || !hasTag(tags, SelectorTag) {
+		return nil, fmt.Errorf("work item %d is missing tag %q", *response.Id, SelectorTag)
+	}
+	title, titleOK := fields["System.Title"].(string)
+	state, stateOK := fields["System.State"].(string)
+	description, snapshotOK := fields[descriptionField].(string)
+	if !titleOK || strings.TrimSpace(title) == "" || !stateOK || strings.TrimSpace(state) == "" || !snapshotOK {
+		return nil, fmt.Errorf("work item %d has incomplete managed fields", *response.Id)
+	}
+	snapshot, err := ParseDescription(description)
+	if err != nil {
+		return nil, fmt.Errorf("parse work item %d release snapshot: %w", *response.Id, err)
+	}
+	if hasTag(tags, TestTag) != snapshot.Test {
+		return nil, fmt.Errorf("work item %d test tag does not match release snapshot", *response.Id)
+	}
+	itemURL := workItemURL(response)
+	if itemURL == "" {
+		return nil, fmt.Errorf("work item %d has no URL", *response.Id)
+	}
+	return &WorkItem{
+		ID: *response.Id, Revision: *response.Rev, URL: itemURL,
+		Title: title, State: state, Snapshot: snapshot,
+	}, nil
+}
+
+func (c *Client) fields() []string {
+	return []string{
+		"System.WorkItemType", "System.Title", "System.State", "System.AreaPath", "System.Tags", descriptionField,
+	}
+}
+
+func patch(operation webapi.Operation, path string, value any) webapi.JsonPatchOperation {
+	return webapi.JsonPatchOperation{Op: &operation, Path: &path, Value: value}
+}
+
+func workItemURL(item *workitemtracking.WorkItem) string {
+	if links, ok := item.Links.(map[string]any); ok {
+		if html, ok := links["html"].(map[string]any); ok {
+			if href, ok := html["href"].(string); ok && href != "" {
+				return href
+			}
+		}
+	}
+	if item.Url != nil {
+		return *item.Url
+	}
+	return ""
+}
+
+func hasTag(tags, want string) bool {
+	for _, tag := range strings.Split(tags, ";") {
+		if strings.TrimSpace(tag) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func escapeWIQL(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func workItemTags(snapshot *Snapshot) string {
+	if snapshot.Test {
+		return SelectorTag + "; " + TestTag
+	}
+	return SelectorTag
+}
+func isRevisionConflict(err error) bool {
+	var value azuredevops.WrappedError
+	if errors.As(err, &value) && value.TypeName != nil && strings.Contains(*value.TypeName, "WorkItemRevisionMismatchException") {
+		return true
+	}
+	var pointer *azuredevops.WrappedError
+	return errors.As(err, &pointer) && pointer.TypeName != nil && strings.Contains(*pointer.TypeName, "WorkItemRevisionMismatchException")
+}
+
+func redactError(err error, token string) error {
+	if err == nil || token == "" {
+		return err
+	}
+	return errors.New(strings.ReplaceAll(err.Error(), token, "[REDACTED]"))
+}

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -369,6 +369,7 @@ func workItemTags(snapshot *Snapshot) string {
 	}
 	return SelectorTag
 }
+
 func isRevisionConflict(err error) bool {
 	var value azuredevops.WrappedError
 	if errors.As(err, &value) && value.TypeName != nil && strings.Contains(*value.TypeName, "WorkItemRevisionMismatchException") {

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -102,6 +102,7 @@ func TestGetRejectsMismatchedTestTag(t *testing.T) {
 		t.Fatalf("error = %v, want mismatched test tag error", err)
 	}
 }
+
 func TestUpdateTestsRevisionFirst(t *testing.T) {
 	snapshot := testSnapshot(StatusRunning)
 	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -1,0 +1,271 @@
+// Tests for the Azure DevOps work item client.
+package azdoworkitem
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking"
+)
+
+type staticToken string
+
+func (t staticToken) Token(context.Context) (string, error) { return string(t), nil }
+
+type fakeClient struct {
+	create func(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error)
+	get    func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error)
+	gets   func(context.Context, workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error)
+	query  func(context.Context, workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error)
+	update func(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error)
+}
+
+func (f *fakeClient) CreateWorkItem(ctx context.Context, args workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+	return f.create(ctx, args)
+}
+
+func (f *fakeClient) GetWorkItem(ctx context.Context, args workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+	return f.get(ctx, args)
+}
+
+func (f *fakeClient) GetWorkItems(ctx context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+	return f.gets(ctx, args)
+}
+
+func (f *fakeClient) QueryByWiql(ctx context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+	return f.query(ctx, args)
+}
+
+func (f *fakeClient) UpdateWorkItem(ctx context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+	return f.update(ctx, args)
+}
+
+func TestCreateUsesFixedMetadata(t *testing.T) {
+	snapshot := testSnapshot(StatusStarting)
+	sdk := &fakeClient{create: func(_ context.Context, args workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		if args.Project == nil || *args.Project != "project" || args.Type == nil || *args.Type != "Task" || args.Document == nil {
+			t.Fatalf("create args = %#v", args)
+		}
+		assertPatch(t, *args.Document, 0, webapi.OperationValues.Add, "/fields/System.Title", "Go images test release")
+		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.AreaPath", AreaPath)
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag)
+		assertPatch(t, *args.Document, 3, webapi.OperationValues.Add, "/fields/System.Description", mustRenderDescription(t, snapshot))
+		return sdkWorkItem(t, 42, 1, snapshot), nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	item, err := client.Create(context.Background(), "Go images test release", snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.ID != 42 || item.Revision != 1 || item.Snapshot.Status != StatusStarting {
+		t.Fatalf("work item = %#v", item)
+	}
+}
+
+func TestCreateAddsTestTag(t *testing.T) {
+	snapshot := testSnapshot(StatusStarting)
+	snapshot.Test = true
+	sdk := &fakeClient{create: func(_ context.Context, args workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		if args.Document == nil {
+			t.Fatal("create document is nil")
+		}
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; "+TestTag)
+		return sdkWorkItem(t, 42, 1, snapshot), nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	item, err := client.Create(context.Background(), "Go images test release", snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !item.Snapshot.Test {
+		t.Fatal("created work item lost test classification")
+	}
+}
+
+func TestGetRejectsMismatchedTestTag(t *testing.T) {
+	snapshot := testSnapshot(StatusStarting)
+	snapshot.Test = true
+	item := sdkWorkItem(t, 42, 1, snapshot)
+	(*item.Fields)["System.Tags"] = SelectorTag
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return item, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Get(context.Background(), 42); err == nil || !strings.Contains(err.Error(), "test tag") {
+		t.Fatalf("error = %v, want mismatched test tag error", err)
+	}
+}
+func TestUpdateTestsRevisionFirst(t *testing.T) {
+	snapshot := testSnapshot(StatusRunning)
+	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 2 {
+			t.Fatalf("update args = %#v", args)
+		}
+		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
+		return sdkWorkItem(t, 42, 8, snapshot), nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	item, err := client.Update(context.Background(), &WorkItem{ID: 42, Revision: 7}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Revision != 8 || item.Snapshot.Status != StatusRunning {
+		t.Fatalf("updated work item = %#v", item)
+	}
+}
+
+func TestUpdateDoesNotRetryRevisionConflict(t *testing.T) {
+	var calls atomic.Int32
+	typeName := "WorkItemRevisionMismatchException"
+	message := "stale secret-token"
+	sdk := &fakeClient{update: func(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		calls.Add(1)
+		return nil, azuredevops.WrappedError{TypeName: &typeName, Message: &message}
+	}}
+	client := newTestClient(t, sdk, "secret-token")
+	_, err := client.Update(context.Background(), &WorkItem{ID: 42, Revision: 7}, testSnapshot(StatusRunning))
+	if !errors.Is(err, ErrRevisionConflict) {
+		t.Fatalf("error = %v, want ErrRevisionConflict", err)
+	}
+	if calls.Load() != 1 || strings.Contains(err.Error(), "secret-token") {
+		t.Fatalf("calls = %d, error = %v", calls.Load(), err)
+	}
+}
+
+func TestCreateRejectsChangedSnapshot(t *testing.T) {
+	sdk := &fakeClient{create: func(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return sdkWorkItem(t, 42, 1, testSnapshot(StatusRunning)), nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Create(context.Background(), "Go images test release", testSnapshot(StatusStarting)); err == nil || !strings.Contains(err.Error(), "different created release snapshot") {
+		t.Fatalf("error = %v, want changed snapshot error", err)
+	}
+}
+
+func TestGetRejectsWrongWorkItem(t *testing.T) {
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return sdkWorkItem(t, 43, 1, testSnapshot(StatusRunning)), nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Get(context.Background(), 42); err == nil || !strings.Contains(err.Error(), "expected 42") {
+		t.Fatalf("error = %v, want mismatched ID error", err)
+	}
+}
+
+func TestQueryReturnsWIQLOrder(t *testing.T) {
+	references := []workitemtracking.WorkItemReference{{Id: pointer(2)}, {Id: pointer(1)}}
+	responses := []workitemtracking.WorkItem{
+		*sdkWorkItem(t, 1, 3, testSnapshot(StatusRunning)),
+		*sdkWorkItem(t, 2, 4, testSnapshot(StatusFailed)),
+	}
+	sdk := &fakeClient{
+		query: func(_ context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+			if args.Top == nil || *args.Top != 20 || args.Wiql == nil || args.Wiql.Query == nil {
+				t.Fatalf("query args = %#v", args)
+			}
+			for _, clause := range []string{"[System.WorkItemType] = 'Task'", "[System.AreaPath] = 'DevDiv\\GoLang'", "[System.Tags] CONTAINS 'releaseagent'"} {
+				if !strings.Contains(*args.Wiql.Query, clause) {
+					t.Fatalf("WIQL %q does not contain %q", *args.Wiql.Query, clause)
+				}
+			}
+			return &workitemtracking.WorkItemQueryResult{WorkItems: &references}, nil
+		},
+		gets: func(_ context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+			if args.Ids == nil || !slices.Equal(*args.Ids, []int{2, 1}) {
+				t.Fatalf("get work items args = %#v", args)
+			}
+			return &responses, nil
+		},
+	}
+	client := newTestClient(t, sdk, "test-token")
+	items, err := client.Query(context.Background(), 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []int{items[0].ID, items[1].ID}; !slices.Equal(got, []int{2, 1}) {
+		t.Fatalf("work item order = %v, want [2 1]", got)
+	}
+}
+
+func TestSDKErrorRedactsToken(t *testing.T) {
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return nil, errors.New("secret-token denied")
+	}}
+	client := newTestClient(t, sdk, "secret-token")
+	_, err := client.Get(context.Background(), 42)
+	if err == nil || strings.Contains(err.Error(), "secret-token") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error = %v, want redacted error", err)
+	}
+}
+
+func newTestClient(t *testing.T, sdk workItemClient, token string) *Client {
+	t.Helper()
+	client, err := NewClient(Config{
+		BaseURL: "https://example.invalid", Project: "project", WorkItemType: "Task",
+	}, staticToken(token))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.newClient = func(context.Context) (workItemClient, string, error) { return sdk, token, nil }
+	return client
+}
+
+func testSnapshot(status Status) *Snapshot {
+	return &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-images",
+		Status:        status,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"buildId":"42"}`),
+	}
+}
+
+func sdkWorkItem(t *testing.T, id, revision int, snapshot *Snapshot) *workitemtracking.WorkItem {
+	t.Helper()
+	fields := map[string]any{
+		"System.WorkItemType": "Task",
+		"System.Title":        "Go images release",
+		"System.State":        "Active",
+		"System.AreaPath":     AreaPath,
+		"System.Tags":         "other; " + workItemTags(snapshot),
+		"System.Description":  mustRenderDescription(t, snapshot),
+	}
+	return &workitemtracking.WorkItem{
+		Id: &id, Rev: &revision, Fields: &fields,
+		Links: map[string]any{"html": map[string]any{"href": "https://example.invalid/workitems/42"}},
+	}
+}
+
+func mustRenderDescription(t *testing.T, snapshot *Snapshot) string {
+	t.Helper()
+	description, err := RenderDescription(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return description
+}
+
+func assertPatch(
+	t *testing.T,
+	document []webapi.JsonPatchOperation,
+	index int,
+	operation webapi.Operation,
+	path string,
+	value any,
+) {
+	t.Helper()
+	if len(document) <= index || document[index].Op == nil || *document[index].Op != operation ||
+		document[index].Path == nil || *document[index].Path != path || document[index].Value != value {
+
+		t.Fatalf("patch %d = %#v, want %s %s %#v", index, document[index], operation, path, value)
+	}
+}
+
+func pointer[T any](value T) *T { return &value }

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot.go
@@ -1,0 +1,155 @@
+// Package azdoworkitem stores release state in Azure DevOps work items.
+package azdoworkitem
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	CurrentSchemaVersion = 1
+	MaxSnapshotSize      = 512 << 10
+	MaxDescriptionSize   = 1_000_000
+	descriptionMarker    = "releaseagent-state-v1:"
+)
+
+var processIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+type Status string
+
+const (
+	StatusStarting  Status = "starting"
+	StatusRunning   Status = "running"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusCanceled  Status = "canceled"
+	StatusUncertain Status = "uncertain"
+)
+
+// Snapshot is the process-neutral envelope stored in a release work item.
+// Process-specific validation remains with the owning release process.
+type Snapshot struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	ProcessID     string          `json:"processId"`
+	Status        Status          `json:"status"`
+	Test          bool            `json:"test,omitempty"`
+	IntentDigest  string          `json:"intentDigest"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+func (s *Snapshot) Validate() error {
+	if s == nil {
+		return errors.New("release snapshot is nil")
+	}
+	if s.SchemaVersion != CurrentSchemaVersion {
+		return fmt.Errorf("unsupported release snapshot schema %d", s.SchemaVersion)
+	}
+	if !processIDPattern.MatchString(s.ProcessID) {
+		return fmt.Errorf("invalid release process ID %q", s.ProcessID)
+	}
+	switch s.Status {
+	case StatusStarting, StatusRunning, StatusSucceeded, StatusFailed, StatusCanceled, StatusUncertain:
+	default:
+		return fmt.Errorf("invalid release status %q", s.Status)
+	}
+	if len(s.IntentDigest) != 64 {
+		return errors.New("release intent digest must be a 64-character SHA-256 digest")
+	}
+	if _, err := hex.DecodeString(s.IntentDigest); err != nil {
+		return errors.New("release intent digest must be hexadecimal")
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(s.Payload, &payload); err != nil || payload == nil {
+		return errors.New("release payload must be a JSON object")
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal release snapshot: %w", err)
+	}
+	if len(data) > MaxSnapshotSize {
+		return fmt.Errorf("release snapshot exceeds %d bytes", MaxSnapshotSize)
+	}
+	return nil
+}
+
+// MarshalSnapshot validates and returns the canonical JSON representation of a snapshot.
+func MarshalSnapshot(snapshot *Snapshot) ([]byte, error) {
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("marshal release snapshot: %w", err)
+	}
+	return data, nil
+}
+
+// ParseSnapshot strictly parses and validates a snapshot.
+func ParseSnapshot(data []byte) (*Snapshot, error) {
+	if len(data) > MaxSnapshotSize {
+		return nil, fmt.Errorf("release snapshot exceeds %d bytes", MaxSnapshotSize)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var snapshot Snapshot
+	if err := decoder.Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("decode release snapshot: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("decode release snapshot: trailing JSON content")
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, err
+	}
+	return &snapshot, nil
+}
+
+// RenderDescription encodes a snapshot for the Azure DevOps HTML Description field.
+func RenderDescription(snapshot *Snapshot) (string, error) {
+	data, err := MarshalSnapshot(snapshot)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	description := "<p>Managed by releaseagent. Add operator notes as comments.</p><pre>" +
+		descriptionMarker + encoded + "</pre>"
+	if len(description) > MaxDescriptionSize {
+		return "", fmt.Errorf("release description exceeds %d characters", MaxDescriptionSize)
+	}
+	return description, nil
+}
+
+// ParseDescription decodes the releaseagent snapshot embedded in an HTML Description field.
+func ParseDescription(description string) (*Snapshot, error) {
+	if len(description) > MaxDescriptionSize {
+		return nil, fmt.Errorf("release description exceeds %d characters", MaxDescriptionSize)
+	}
+	if strings.Count(description, descriptionMarker) != 1 {
+		return nil, errors.New("release description must contain exactly one state marker")
+	}
+	remainder := description[strings.Index(description, descriptionMarker)+len(descriptionMarker):]
+	end := 0
+	for end < len(remainder) && isBase64URL(remainder[end]) {
+		end++
+	}
+	if end == 0 {
+		return nil, errors.New("release description state is empty")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(remainder[:end])
+	if err != nil {
+		return nil, fmt.Errorf("decode release description state: %w", err)
+	}
+	return ParseSnapshot(data)
+}
+
+func isBase64URL(character byte) bool {
+	return character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' ||
+		character >= '0' && character <= '9' || character == '-' || character == '_'
+}

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
@@ -1,0 +1,126 @@
+package azdoworkitem
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testDigest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	want := &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-images",
+		Status:        StatusRunning,
+		Test:          true,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"buildId":"42"}`),
+	}
+	data, err := MarshalSnapshot(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseSnapshot(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != want.SchemaVersion || got.ProcessID != want.ProcessID ||
+		got.Status != want.Status || got.Test != want.Test || got.IntentDigest != want.IntentDigest ||
+		!bytes.Equal(got.Payload, want.Payload) {
+
+		t.Fatalf("snapshot = %#v, want %#v", got, want)
+	}
+}
+
+func TestSnapshotRejectsInvalidEnvelope(t *testing.T) {
+	valid := `{"schemaVersion":1,"processId":"go-images","status":"running",` +
+		`"intentDigest":"` + testDigest + `","payload":{"buildId":"42"}}`
+	for _, test := range []struct {
+		name string
+		data string
+	}{
+		{name: "unknown field", data: strings.TrimSuffix(valid, "}") + `,"extra":true}`},
+		{name: "unknown schema", data: strings.Replace(valid, `"schemaVersion":1`, `"schemaVersion":2`, 1)},
+		{name: "invalid process", data: strings.Replace(valid, `"go-images"`, `"Go Images"`, 1)},
+		{name: "invalid status", data: strings.Replace(valid, `"running"`, `"waiting"`, 1)},
+		{name: "invalid digest", data: strings.Replace(valid, testDigest, strings.Repeat("z", 64), 1)},
+		{name: "non-object payload", data: strings.Replace(valid, `{"buildId":"42"}`, `[]`, 1)},
+		{name: "trailing JSON", data: valid + `{}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := ParseSnapshot([]byte(test.data)); err == nil {
+				t.Fatal("invalid snapshot unexpectedly parsed")
+			}
+		})
+	}
+}
+
+func TestSnapshotRejectsOversizedPayload(t *testing.T) {
+	snapshot := &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-images",
+		Status:        StatusStarting,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"value":"` + strings.Repeat("x", MaxSnapshotSize) + `"}`),
+	}
+	if _, err := MarshalSnapshot(snapshot); err == nil {
+		t.Fatal("oversized snapshot unexpectedly marshaled")
+	}
+}
+
+func TestDescriptionRoundTrip(t *testing.T) {
+	want := &Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-images",
+		Status:        StatusRunning,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"buildId":"42","html":"<unsafe>"}`),
+	}
+	description, err := RenderDescription(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(description, `{"buildId"`) || !strings.Contains(description, descriptionMarker) {
+		t.Fatalf("description does not use encoded transport: %q", description)
+	}
+	got, err := ParseDescription("<div>" + description + "</div>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON, err := MarshalSnapshot(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotJSON, err := MarshalSnapshot(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotJSON, wantJSON) {
+		t.Fatalf("snapshot = %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func TestDescriptionRejectsInvalidTransport(t *testing.T) {
+	valid, err := RenderDescription(&Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-images",
+		Status:        StatusStarting,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"buildId":"42"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, description := range []string{
+		"<p>no state</p>",
+		valid + valid,
+		"<pre>" + descriptionMarker + "!</pre>",
+		"<pre>" + descriptionMarker + "not-valid-json</pre>",
+	} {
+		if _, err := ParseDescription(description); err == nil {
+			t.Fatalf("invalid description unexpectedly parsed: %q", description)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- define a strict, process-neutral release snapshot with schema, status, digest, payload, and size validation
- store canonical snapshot JSON in the existing `System.Description` field using a base64url transport marker
- add a typed Azure DevOps work-item client for fixed metadata, create/get/query operations, and revision-checked updates
- validate returned work items and redact bearer tokens from SDK errors

This layer adds the storage contract and client only. Runtime persistence moves to work items in the following PRs. It does not require a custom process field or board change.

Sample work item created from the stack: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3062490

## Stack

1 of 4. Stacked on #592.

## Testing

- `go test -count=1 ./cmd/releaseagent/...` at this layer
- `go test -count=1 -race ./cmd/releaseagent/...` on the completed stack
- `go vet ./cmd/releaseagent/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.0 run ./cmd/releaseagent/...`