### PR TITLE
releaseagent: persist generic runs in work items

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -5,9 +5,9 @@ The server runs on the release runner's machine and opens in their default brows
 
 `releaseagent serve` starts the local release UI.
 
-The landing page lists work tracked by the current durable session and the two implemented release
-processes. Go images provides local planning, execution, and monitoring. Go infrastructure provides
-reviewed, confirmed actions for the two GitHub-owned patch release paths documented by the team.
+The landing page lists the two implemented release processes. Go images provides local planning,
+execution, and monitoring. Go infrastructure provides reviewed, confirmed actions for the two
+GitHub-owned patch release paths documented by the team.
 
 Each registry entry owns its dashboard metadata, inputs, and workflow callbacks. The server derives
 the process page and API routes from that entry. One HTML page and JavaScript implementation render
@@ -40,7 +40,11 @@ ProcessDefinition{
 }
 ```
 
-Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store holds the server's single current durable external action. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`, and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart behavior, state APIs, and event streaming.
+Supply one `ProcessExecutor` under the same process ID and one shared `ProcessRunStore`. The store
+creates an Azure DevOps work item only after confirmation and updates it by revision at durable
+checkpoints. The executor owns process policy through `Preflight`, `Prepare`, `Execute`, `Resume`,
+and `Validate`. The server owns confirmation, duplicate-start protection, checkpoints, restart
+behavior, state APIs, and event streaming.
 
 Before preparation, the shared lifecycle validates request keys, visible and conditional fields, choice values, positive integer syntax, and defaults. Executors then apply process-specific semantic and fixed-target validation.
 
@@ -84,7 +88,7 @@ and exposes both supported paths:
 * **Manual patch release** dispatches only `create-go-infra-patch-release.yml` on `main`. Dry-run
   mode sets `dry-run` to `true` and only calculates the next version. Publish mode sets it to
   `false` and can create the next patch release. After GitHub accepts the dispatch, the server
-  discovers the new run, journals its ID and URL, and polls it to a terminal conclusion. GitHub's workflow dispatch endpoint does not return a run ID, so the UI supplies a random token as the run title and matches that exact title. If a monitoring interval times out, polling continues from the checkpointed run ID. The dashboard reports the final result.
+  discovers the new run, checkpoints its ID and URL, and polls it to a terminal conclusion. GitHub's workflow dispatch endpoint does not return a run ID, so the UI supplies a random token as the run title and matches that exact title. If a monitoring interval times out, polling continues from the checkpointed run ID. The dashboard reports the final result.
 
 Both paths require an authenticated `gh` CLI, a reviewed plan, and a separate confirmation click.
 The server hardcodes `microsoft/go-infra`, `main`,
@@ -92,7 +96,7 @@ The server hardcodes `microsoft/go-infra`, `main`,
 
 ## Running locally
 
-Start the fully configured release UI without arguments:
+Start the release UI without additional storage configuration:
 
 ```console
 go run ./cmd/releaseagent serve
@@ -102,17 +106,22 @@ Authenticate `az` before using Azure-backed go-images actions and `gh` before us
 go-infra actions. Missing authentication is reported by process preflight; it does not require a
 different server startup mode.
 
-By default, the UI stores its durable session under the operating system's user configuration directory.
-Use `-session-file` only to override that location:
+Go-images still stores its durable session under the operating system's user configuration
+directory. Use `-session-file` only to override that location:
 
 ```console
 go run ./cmd/releaseagent serve \
   -session-file /path/to/release-session.json
 ```
 
-The configured session path also derives an adjacent durable process-run journal. Starting the
-server does not perform an external action. Opening the go-infra page performs read-only preflight
-checks; a mutation still requires preparing the exact request and confirming it.
+Generic actions do not use the session file. Each confirmed action creates a tagged DEVDIV `Issue`
+under `DevDiv\GoLang`. To restore one explicitly, add `-release-work-item <id>`. Starting the server
+does not perform an external action. Opening the go-infra page performs read-only preflight checks;
+a mutation still requires preparing the exact request and confirming it.
+
+Releaseagent owns `System.Description` on generic-action work items. It stores a visible managed-state
+notice followed by base64url-encoded canonical JSON so Azure DevOps HTML normalization cannot alter
+the release state. Add operator notes as work-item comments rather than editing Description.
 
 Every new real run uses a two-step **Run** then **Confirm run** interaction.
 The second request must include explicit confirmation and the exact current plan digest, so a stale or changed plan is rejected.
@@ -147,14 +156,11 @@ older full-release-shaped prototype documents rather than retaining a second dom
 migration path. Workflow revision 8 uses unique step names as graph identity. Start with a new
 session file when either version is unsupported.
 
-The current session and process-run stores together own one active durable release at a time. The
-dashboard lists that release as ongoing or recently completed work.
-
-Durable external actions use an adjacent, schema-versioned atomic process-run journal derived from
-`-session-file`. The shared executor checkpoints `started` before calling the target service and
-resumes monitoring a known external run after restart. If a run cannot be correlated, the next
-startup marks the action `uncertain` and refuses a replacement. The local file protects one
-machine; it is not a shared handoff mechanism for an unexpected outage.
+The current server runs one selected release at a time. Go-images state remains in its session file.
+Generic action state lives only in the selected Azure DevOps work item. The shared executor creates
+the work item before calling the target service, updates it with an Azure DevOps revision check, and
+resumes monitoring a known external run after explicit restore. If a run cannot be correlated, the
+restored action becomes `uncertain` and refuses a replacement.
 
 If a process terminates without cleaning up its lease, verify no release UI process is using the
 session and remove the adjacent `.lock` file manually.

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -43,7 +43,7 @@ type Client struct {
 	workItemType string
 	tokens       TokenProvider
 	newClient    func(context.Context) (workItemClient, string, error)
-	newLocation   func(context.Context) (locationClient, string, error)
+	newLocation  func(context.Context) (locationClient, string, error)
 }
 
 type WorkItem struct {
@@ -426,6 +426,7 @@ func workItemState(status Status) string {
 	}
 	return "Active"
 }
+
 func isRevisionConflict(err error) bool {
 	var value azuredevops.WrappedError
 	if errors.As(err, &value) && value.TypeName != nil && strings.Contains(*value.TypeName, "WorkItemRevisionMismatchException") {

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/location"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking"
 )
@@ -42,6 +43,7 @@ type Client struct {
 	workItemType string
 	tokens       TokenProvider
 	newClient    func(context.Context) (workItemClient, string, error)
+	newLocation   func(context.Context) (locationClient, string, error)
 }
 
 type WorkItem struct {
@@ -59,6 +61,10 @@ type workItemClient interface {
 	GetWorkItems(context.Context, workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error)
 	QueryByWiql(context.Context, workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error)
 	UpdateWorkItem(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error)
+}
+
+type locationClient interface {
+	GetConnectionData(context.Context, location.GetConnectionDataArgs) (*location.ConnectionData, error)
 }
 
 func NewClient(config Config, tokens TokenProvider) (*Client, error) {
@@ -85,12 +91,34 @@ func NewClient(config Config, tokens TokenProvider) (*Client, error) {
 		tokens: tokens,
 	}
 	client.newClient = client.createClient
+	client.newLocation = client.createLocationClient
 	return client, nil
 }
 
-func (c *Client) Create(ctx context.Context, title string, snapshot *Snapshot) (*WorkItem, error) {
+// CurrentUser returns the identity used to assign a release work item.
+func (c *Client) CurrentUser(ctx context.Context) (string, error) {
+	sdk, token, err := c.newLocation(ctx)
+	if err != nil {
+		return "", fmt.Errorf("create Azure DevOps location client: %w", redactError(err, token))
+	}
+	data, err := sdk.GetConnectionData(ctx, location.GetConnectionDataArgs{})
+	if err != nil {
+		return "", fmt.Errorf("get authenticated Azure DevOps user: %w", redactError(err, token))
+	}
+	if data == nil || data.AuthenticatedUser == nil || data.AuthenticatedUser.ProviderDisplayName == nil ||
+		strings.TrimSpace(*data.AuthenticatedUser.ProviderDisplayName) == "" {
+
+		return "", errors.New("azure DevOps returned no authenticated user name")
+	}
+	return *data.AuthenticatedUser.ProviderDisplayName, nil
+}
+
+func (c *Client) Create(ctx context.Context, title, assignedTo string, snapshot *Snapshot) (*WorkItem, error) {
 	if strings.TrimSpace(title) == "" {
 		return nil, errors.New("release work item title must not be empty")
+	}
+	if strings.TrimSpace(assignedTo) == "" {
+		return nil, errors.New("release work item assignee must not be empty")
 	}
 	snapshotJSON, err := MarshalSnapshot(snapshot)
 	if err != nil {
@@ -104,6 +132,8 @@ func (c *Client) Create(ctx context.Context, title string, snapshot *Snapshot) (
 		patch(webapi.OperationValues.Add, "/fields/System.Title", title),
 		patch(webapi.OperationValues.Add, "/fields/System.AreaPath", AreaPath),
 		patch(webapi.OperationValues.Add, "/fields/System.Tags", workItemTags(snapshot)),
+		patch(webapi.OperationValues.Add, "/fields/System.AssignedTo", assignedTo),
+		patch(webapi.OperationValues.Add, "/fields/System.State", workItemState(snapshot.Status)),
 		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
 	}
 	sdk, token, err := c.newClient(ctx)
@@ -158,6 +188,7 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	}
 	document := []webapi.JsonPatchOperation{
 		patch(webapi.OperationValues.Test, "/rev", current.Revision),
+		patch(webapi.OperationValues.Add, "/fields/System.State", workItemState(snapshot.Status)),
 		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
 	}
 	sdk, token, err := c.newClient(ctx)
@@ -256,6 +287,23 @@ func (c *Client) Query(ctx context.Context, limit int) ([]*WorkItem, error) {
 }
 
 func (c *Client) createClient(ctx context.Context) (workItemClient, string, error) {
+	connection, token, err := c.createConnection(ctx)
+	if err != nil {
+		return nil, token, err
+	}
+	client, err := workitemtracking.NewClient(ctx, connection)
+	return client, token, err
+}
+
+func (c *Client) createLocationClient(ctx context.Context) (locationClient, string, error) {
+	connection, token, err := c.createConnection(ctx)
+	if err != nil {
+		return nil, token, err
+	}
+	return location.NewClient(ctx, connection), token, nil
+}
+
+func (c *Client) createConnection(ctx context.Context) (*azuredevops.Connection, string, error) {
 	token, err := c.tokens.Token(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("acquire Azure DevOps token: %w", err)
@@ -267,8 +315,7 @@ func (c *Client) createClient(ctx context.Context) (workItemClient, string, erro
 	connection.AuthorizationString = "Bearer " + token
 	timeout := sdkTimeout
 	connection.Timeout = &timeout
-	client, err := workitemtracking.NewClient(ctx, connection)
-	return client, token, err
+	return connection, token, nil
 }
 
 func (c *Client) parseWrittenWorkItem(response *workitemtracking.WorkItem, want []byte, action string) (*WorkItem, error) {
@@ -315,6 +362,9 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	}
 	if hasTag(tags, TestTag) != snapshot.Test {
 		return nil, fmt.Errorf("work item %d test tag does not match release snapshot", *response.Id)
+	}
+	if state != workItemState(snapshot.Status) {
+		return nil, fmt.Errorf("work item %d state %q does not match release status %q", *response.Id, state, snapshot.Status)
 	}
 	itemURL := workItemURL(response)
 	if itemURL == "" {
@@ -368,6 +418,13 @@ func workItemTags(snapshot *Snapshot) string {
 		return SelectorTag + "; " + TestTag
 	}
 	return SelectorTag
+}
+
+func workItemState(status Status) string {
+	if status == StatusSucceeded {
+		return "Closed"
+	}
+	return "Active"
 }
 func isRevisionConflict(err error) bool {
 	var value azuredevops.WrappedError

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/identity"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/location"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/webapi"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/workitemtracking"
 )
@@ -18,6 +20,14 @@ import (
 type staticToken string
 
 func (t staticToken) Token(context.Context) (string, error) { return string(t), nil }
+
+type fakeLocationClient struct {
+	get func(context.Context, location.GetConnectionDataArgs) (*location.ConnectionData, error)
+}
+
+func (f fakeLocationClient) GetConnectionData(ctx context.Context, args location.GetConnectionDataArgs) (*location.ConnectionData, error) {
+	return f.get(ctx, args)
+}
 
 type fakeClient struct {
 	create func(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error)
@@ -50,17 +60,19 @@ func (f *fakeClient) UpdateWorkItem(ctx context.Context, args workitemtracking.U
 func TestCreateUsesFixedMetadata(t *testing.T) {
 	snapshot := testSnapshot(StatusStarting)
 	sdk := &fakeClient{create: func(_ context.Context, args workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
-		if args.Project == nil || *args.Project != "project" || args.Type == nil || *args.Type != "Task" || args.Document == nil {
+		if args.Project == nil || *args.Project != "project" || args.Type == nil || *args.Type != "Issue" || args.Document == nil {
 			t.Fatalf("create args = %#v", args)
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Add, "/fields/System.Title", "Go images test release")
 		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.AreaPath", AreaPath)
 		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag)
-		assertPatch(t, *args.Document, 3, webapi.OperationValues.Add, "/fields/System.Description", mustRenderDescription(t, snapshot))
+		assertPatch(t, *args.Document, 3, webapi.OperationValues.Add, "/fields/System.AssignedTo", "Release Operator")
+		assertPatch(t, *args.Document, 4, webapi.OperationValues.Add, "/fields/System.State", "Active")
+		assertPatch(t, *args.Document, 5, webapi.OperationValues.Add, "/fields/System.Description", mustRenderDescription(t, snapshot))
 		return sdkWorkItem(t, 42, 1, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
-	item, err := client.Create(context.Background(), "Go images test release", snapshot)
+	item, err := client.Create(context.Background(), "Go images test release", "Release Operator", snapshot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +92,7 @@ func TestCreateAddsTestTag(t *testing.T) {
 		return sdkWorkItem(t, 42, 1, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
-	item, err := client.Create(context.Background(), "Go images test release", snapshot)
+	item, err := client.Create(context.Background(), "Go images test release", "Release Operator", snapshot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,13 +114,32 @@ func TestGetRejectsMismatchedTestTag(t *testing.T) {
 		t.Fatalf("error = %v, want mismatched test tag error", err)
 	}
 }
+
+func TestCurrentUser(t *testing.T) {
+	name := "Release Operator"
+	client := newTestClient(t, &fakeClient{}, "test-token")
+	client.newLocation = func(context.Context) (locationClient, string, error) {
+		return fakeLocationClient{get: func(context.Context, location.GetConnectionDataArgs) (*location.ConnectionData, error) {
+			return &location.ConnectionData{AuthenticatedUser: &identity.Identity{ProviderDisplayName: &name}}, nil
+		}}, "test-token", nil
+	}
+	got, err := client.CurrentUser(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != name {
+		t.Fatalf("CurrentUser = %q, want %q", got, name)
+	}
+}
+
 func TestUpdateTestsRevisionFirst(t *testing.T) {
 	snapshot := testSnapshot(StatusRunning)
 	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
-		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 2 {
+		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 3 {
 			t.Fatalf("update args = %#v", args)
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
+		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.State", "Active")
 		return sdkWorkItem(t, 42, 8, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
@@ -144,7 +175,7 @@ func TestCreateRejectsChangedSnapshot(t *testing.T) {
 		return sdkWorkItem(t, 42, 1, testSnapshot(StatusRunning)), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
-	if _, err := client.Create(context.Background(), "Go images test release", testSnapshot(StatusStarting)); err == nil || !strings.Contains(err.Error(), "different created release snapshot") {
+	if _, err := client.Create(context.Background(), "Go images test release", "Release Operator", testSnapshot(StatusStarting)); err == nil || !strings.Contains(err.Error(), "different created release snapshot") {
 		t.Fatalf("error = %v, want changed snapshot error", err)
 	}
 }
@@ -170,7 +201,7 @@ func TestQueryReturnsWIQLOrder(t *testing.T) {
 			if args.Top == nil || *args.Top != 20 || args.Wiql == nil || args.Wiql.Query == nil {
 				t.Fatalf("query args = %#v", args)
 			}
-			for _, clause := range []string{"[System.WorkItemType] = 'Task'", "[System.AreaPath] = 'DevDiv\\GoLang'", "[System.Tags] CONTAINS 'releaseagent'"} {
+			for _, clause := range []string{"[System.WorkItemType] = 'Issue'", "[System.AreaPath] = 'DevDiv\\GoLang'", "[System.Tags] CONTAINS 'releaseagent'"} {
 				if !strings.Contains(*args.Wiql.Query, clause) {
 					t.Fatalf("WIQL %q does not contain %q", *args.Wiql.Query, clause)
 				}
@@ -208,7 +239,7 @@ func TestSDKErrorRedactsToken(t *testing.T) {
 func newTestClient(t *testing.T, sdk workItemClient, token string) *Client {
 	t.Helper()
 	client, err := NewClient(Config{
-		BaseURL: "https://example.invalid", Project: "project", WorkItemType: "Task",
+		BaseURL: "https://example.invalid", Project: "project", WorkItemType: "Issue",
 	}, staticToken(token))
 	if err != nil {
 		t.Fatal(err)
@@ -230,9 +261,9 @@ func testSnapshot(status Status) *Snapshot {
 func sdkWorkItem(t *testing.T, id, revision int, snapshot *Snapshot) *workitemtracking.WorkItem {
 	t.Helper()
 	fields := map[string]any{
-		"System.WorkItemType": "Task",
+		"System.WorkItemType": "Issue",
 		"System.Title":        "Go images release",
-		"System.State":        "Active",
+		"System.State":        workItemState(snapshot.Status),
 		"System.AreaPath":     AreaPath,
 		"System.Tags":         "other; " + workItemTags(snapshot),
 		"System.Description":  mustRenderDescription(t, snapshot),

--- a/cmd/releaseagent/internal/releaseui/go_infra_process.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_process.go
@@ -73,7 +73,7 @@ func prepareGoInfraProcess(
 		return ProcessPreparedRun{}, fmt.Errorf("encode go-infra process plan: %w", err)
 	}
 	return ProcessPreparedRun{
-		Input: normalizedJSON, Payload: payloadJSON,
+		Test: goInfraProcessIsTest(normalized), Input: normalizedJSON, Payload: payloadJSON,
 		Step: goInfraProcessStep(payload), View: goInfraProcessView(payload), Target: goInfraProcessTarget(payload),
 	}, nil
 }
@@ -170,6 +170,9 @@ func validateGoInfraProcessRun(run *ProcessRun) error {
 	if err != nil || normalized != payload.Input || input != payload.Input {
 		return errors.New("go-infra process input is invalid")
 	}
+	if run.Test != goInfraProcessIsTest(payload.Input) {
+		return errors.New("go-infra process test classification is invalid")
+	}
 	switch payload.Input.Action {
 	case goInfraActionReleaseOnMerge:
 		if payload.PullRequest == nil {
@@ -209,6 +212,10 @@ func validateGoInfraProcessRun(run *ProcessRun) error {
 		}
 	}
 	return nil
+}
+
+func goInfraProcessIsTest(input goInfraPlanInput) bool {
+	return input.Action == goInfraActionManualDispatch && input.DispatchMode == goInfraDispatchModeDryRun
 }
 
 func goInfraProcessStep(payload goInfraProcessPayload) ProcessRunStep {

--- a/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
@@ -24,17 +24,12 @@ func TestGoInfraDispatchSuccessWithoutExternalRunFailsPolicyValidation(t *testin
 }
 
 func TestInterruptedGoInfraRunRestoresUncertain(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	store := newMemoryProcessRunStore()
 	run := testStoredGoInfraRun(t, goInfraPlanInput{Action: goInfraActionManualDispatch, DispatchMode: goInfraDispatchModePublish}, nil)
 	run.Started = true
-	if err := store.Save(context.Background(), run); err != nil {
-		t.Fatal(err)
-	}
+	workItemID := store.seed(run)
 	github := &fakeGoInfraGitHub{pullRequest: testGoInfraPullRequest()}
-	ui := newTestUI(t, WithProcessRunStore(store), WithGoInfraGitHubIntegration(github.integration()))
+	ui := newTestUI(t, WithProcessRunStore(store), WithProcessRunWorkItem(workItemID), WithGoInfraGitHubIntegration(github.integration()))
 	response, err := ui.client.Get(ui.http.URL + "/api/processes/go-infra/plan")
 	if err != nil {
 		t.Fatal(err)
@@ -54,20 +49,14 @@ func TestInterruptedGoInfraRunRestoresUncertain(t *testing.T) {
 	if len(github.dispatches) != 0 || github.labelCalls != 0 {
 		t.Fatalf("dispatches = %v, label calls = %d", github.dispatches, github.labelCalls)
 	}
-	persisted, err := store.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	persisted := store.latest(t)
 	if !persisted.Complete || persisted.Result != "uncertain" {
 		t.Fatalf("persisted = %#v", persisted)
 	}
 }
 
 func TestDiscoveredGoInfraRunResumesMonitoring(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	store := newMemoryProcessRunStore()
 	run := testStoredGoInfraRun(t, goInfraPlanInput{Action: goInfraActionManualDispatch, DispatchMode: goInfraDispatchModeDryRun}, nil)
 	queued := testGoInfraWorkflowRun("queued", "")
 	state, err := json.Marshal(queued)
@@ -78,9 +67,7 @@ func TestDiscoveredGoInfraRunResumesMonitoring(t *testing.T) {
 	run.Checkpoint = state
 	external := goInfraExternalRun(queued)
 	run.External = &external
-	if err := store.Save(context.Background(), run); err != nil {
-		t.Fatal(err)
-	}
+	workItemID := store.seed(run)
 	github := &fakeGoInfraGitHub{
 		pullRequest: testGoInfraPullRequest(), workflowRun: queued,
 		workflowUpdates: []GoInfraWorkflowRun{
@@ -88,15 +75,12 @@ func TestDiscoveredGoInfraRunResumesMonitoring(t *testing.T) {
 			testGoInfraWorkflowRun("completed", "success"),
 		},
 	}
-	ui := newTestUI(t, WithProcessRunStore(store), WithGoInfraGitHubIntegration(github.integration()))
+	ui := newTestUI(t, WithProcessRunStore(store), WithProcessRunWorkItem(workItemID), WithGoInfraGitHubIntegration(github.integration()))
 	waitForGoInfraAction(t, ui)
 	if github.pollCalls != 1 || len(github.dispatches) != 0 {
 		t.Fatalf("poll calls = %d, dispatches = %v", github.pollCalls, github.dispatches)
 	}
-	persisted, err := store.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	persisted := store.latest(t)
 	if !persisted.Complete || persisted.Result != "succeeded" || persisted.External == nil ||
 		persisted.External.Status != "completed" || !persisted.External.Succeeded {
 
@@ -109,10 +93,7 @@ func TestGoInfraExecutorRequiresProcessRunStore(t *testing.T) {
 	if _, err := New(context.Background(), WithGoInfraGitHubIntegration(github.integration())); err == nil {
 		t.Fatal("go-infra executor was enabled without a process run store")
 	}
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	store := newMemoryProcessRunStore()
 	if _, err := New(context.Background(), WithProcessRunStore(store)); err == nil {
 		t.Fatal("process run store was enabled without an executor")
 	}
@@ -125,15 +106,10 @@ func TestGoInfraExecutorRequiresProcessRunStore(t *testing.T) {
 }
 
 func TestUncertainGoInfraRunDoesNotHideBehindGoImagesSession(t *testing.T) {
-	runStore, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	runStore := newMemoryProcessRunStore()
 	run := testStoredGoInfraRun(t, goInfraPlanInput{Action: goInfraActionManualDispatch, DispatchMode: goInfraDispatchModePublish}, nil)
 	run.Started = true
-	if err := runStore.Save(context.Background(), run); err != nil {
-		t.Fatal(err)
-	}
+	workItemID := runStore.seed(run)
 	sessionStore, err := goimagessession.NewFileStore(filepath.Join(t.TempDir(), "go-images-session.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +119,7 @@ func TestUncertainGoInfraRunDoesNotHideBehindGoImagesSession(t *testing.T) {
 	createTestPlan(t, first, `{"mode":"normal"}`)
 	github := &fakeGoInfraGitHub{pullRequest: testGoInfraPullRequest()}
 	_, err = New(
-		context.Background(), WithSessionStore(sessionStore), WithProcessRunStore(runStore),
+		context.Background(), WithSessionStore(sessionStore), WithProcessRunStore(runStore), WithProcessRunWorkItem(workItemID),
 		WithGoInfraGitHubIntegration(github.integration()),
 	)
 	if err == nil {
@@ -163,7 +139,7 @@ func testStoredGoInfraRun(t *testing.T, input goInfraPlanInput, pullRequest *GoI
 		t.Fatal(err)
 	}
 	run, err := newProcessRun(goInfraProcessID, ProcessPreparedRun{
-		Input: inputJSON, Payload: payloadJSON,
+		Test: goInfraProcessIsTest(input), Input: inputJSON, Payload: payloadJSON,
 		Step: goInfraProcessStep(payload), View: goInfraProcessView(payload), Target: goInfraProcessTarget(payload),
 	})
 	if err != nil {

--- a/cmd/releaseagent/internal/releaseui/go_infra_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_test.go
@@ -121,10 +121,7 @@ func testGoInfraPullRequest() GoInfraPullRequest {
 
 func testGoInfraOptions(t *testing.T, github *fakeGoInfraGitHub) []Option {
 	t.Helper()
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "process-run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	store := newMemoryProcessRunStore()
 	return []Option{WithProcessRunStore(store), WithGoInfraGitHubIntegration(github.integration())}
 }
 
@@ -266,6 +263,34 @@ func TestGoInfraWorkflowDispatchModes(t *testing.T) {
 				plan.Execution.Run.URL != "https://github.com/microsoft/go-infra/actions/runs/123" {
 
 				t.Fatalf("completed plan = %#v", plan)
+			}
+		})
+	}
+}
+
+func TestGoInfraTestClassification(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "dry-run", input: `{"action":"manual-dispatch","dispatchMode":"dry-run"}`, want: true},
+		{name: "publish", input: `{"action":"manual-dispatch","dispatchMode":"publish"}`},
+		{name: "release-on-merge", input: `{"action":"release-on-merge","pullRequest":"42"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			github := &fakeGoInfraGitHub{pullRequest: testGoInfraPullRequest()}
+			ui := newTestUI(t, testGoInfraOptions(t, github)...)
+			response := postJSON(t, ui, "/api/processes/go-infra/plan", test.input)
+			response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("plan status = %d", response.StatusCode)
+			}
+			ui.server.mu.Lock()
+			got := ui.server.processRun.Test
+			ui.server.mu.Unlock()
+			if got != test.want {
+				t.Fatalf("processRun.Test = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/cmd/releaseagent/internal/releaseui/process_execution.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution.go
@@ -82,6 +82,13 @@ func WithProcessRunStore(store ProcessRunStore) Option {
 	}
 }
 
+// WithProcessRunWorkItem selects one work item to restore when the server starts.
+func WithProcessRunWorkItem(workItemID int) Option {
+	return func(server *Server) {
+		server.processRunItemID = workItemID
+	}
+}
+
 func (s *Server) validateProcessExecutionConfiguration() error {
 	for processID, executor := range s.processExecutors {
 		definition, ok := s.processes.byID[processID]
@@ -99,6 +106,12 @@ func (s *Server) validateProcessExecutionConfiguration() error {
 	}
 	if s.processRunStore != nil && len(s.processExecutors) == 0 {
 		return errors.New("process run store requires at least one executor")
+	}
+	if s.processRunItemID < 0 {
+		return errors.New("process run work item ID must not be negative")
+	}
+	if s.processRunItemID > 0 && s.processRunStore == nil {
+		return errors.New("process run work item selection requires a durable run store")
 	}
 	return nil
 }
@@ -184,7 +197,7 @@ func (s *Server) handlePrepareProcessRun(processID string, response http.Respons
 	}
 	if s.processRun != nil && s.processRun.Result == "uncertain" {
 		s.mu.Unlock()
-		writeError(response, http.StatusConflict, "a previous external action has uncertain status; inspect the target service and remove the process run journal before retrying")
+		writeError(response, http.StatusConflict, "a previous external action has uncertain status; inspect the target service and repair its release work item before retrying")
 		return
 	}
 	s.mu.Unlock()
@@ -223,15 +236,11 @@ func (s *Server) handlePrepareProcessRun(processID string, response http.Respons
 	}
 	if s.processRun != nil && s.processRun.Result == "uncertain" {
 		s.mu.Unlock()
-		writeError(response, http.StatusConflict, "a previous external action has uncertain status; inspect the target service and remove the process run journal before retrying")
-		return
-	}
-	if err := s.processRunStore.Save(request.Context(), run); err != nil {
-		s.mu.Unlock()
-		writeError(response, http.StatusInternalServerError, fmt.Sprintf("persist reviewed process run: %v", err))
+		writeError(response, http.StatusConflict, "a previous external action has uncertain status; inspect the target service and repair its release work item before retrying")
 		return
 	}
 	s.processRun = run
+	s.processRunRecord = nil
 	s.steps = []*coordinator.Step{step}
 	s.runner = &coordinator.StepRunner{}
 	result := s.processRunResponseLocked()
@@ -293,12 +302,15 @@ func (s *Server) handleStartProcessRun(processID string, response http.ResponseW
 		writeError(response, http.StatusInternalServerError, fmt.Sprintf("validate started process run: %v", err))
 		return
 	}
-	if err := s.processRunStore.Save(request.Context(), run); err != nil {
+	record, err := s.processRunStore.Create(request.Context(), run)
+	if err != nil {
 		s.mu.Unlock()
-		writeError(response, http.StatusInternalServerError, fmt.Sprintf("checkpoint process run before mutation: %v", err))
+		writeError(response, http.StatusInternalServerError, fmt.Sprintf("create release work item before mutation: %v", err))
 		return
 	}
+	run = record.Run
 	s.processRun = run
+	s.processRunRecord = record
 	s.processRunning = true
 	s.mu.Unlock()
 
@@ -324,11 +336,17 @@ func (s *Server) processCheckpoint(digest string, executor ProcessExecutor) Proc
 			s.mu.Unlock()
 			return err
 		}
-		if err := s.processRunStore.Save(ctx, run); err != nil {
+		if s.processRunRecord == nil {
+			s.mu.Unlock()
+			return errors.New("external run has no release work item")
+		}
+		record, err := s.processRunStore.Update(ctx, s.processRunRecord, run)
+		if err != nil {
 			s.mu.Unlock()
 			return fmt.Errorf("persist external run checkpoint: %w", err)
 		}
-		s.processRun = run
+		s.processRunRecord = record
+		s.processRun = record.Run
 		s.mu.Unlock()
 		coordinator.ReportProgress(ctx, coordinator.StepProgress{
 			Summary: checkpoint.Progress.Summary, Detail: checkpoint.Progress.Detail,
@@ -368,10 +386,14 @@ func (s *Server) executeProcessRun(digest string, runner *coordinator.StepRunner
 			run.Result = "uncertain"
 			valid = false
 		}
-		if saveErr := s.processRunStore.Save(context.Background(), run); saveErr != nil {
+		record, saveErr := s.processRunStore.Update(context.Background(), s.processRunRecord, run)
+		if saveErr != nil {
 			run.Complete = true
 			run.Result = "uncertain"
 			valid = false
+		} else {
+			s.processRunRecord = record
+			run = record.Run
 		}
 		s.processRun = run
 		if valid && resumable && errors.Is(err, context.DeadlineExceeded) && s.ctx.Err() == nil {
@@ -395,16 +417,14 @@ func (s *Server) executeProcessRun(digest string, runner *coordinator.StepRunner
 }
 
 func (s *Server) restoreProcessRun() error {
-	if s.processRunStore == nil {
+	if s.processRunStore == nil || s.processRunItemID == 0 {
 		return nil
 	}
-	run, err := s.processRunStore.Load(s.ctx)
-	if errors.Is(err, ErrProcessRunNotFound) {
-		return nil
-	}
+	record, err := s.processRunStore.Get(s.ctx, s.processRunItemID)
 	if err != nil {
-		return fmt.Errorf("load process run journal: %w", err)
+		return fmt.Errorf("load release work item %d: %w", s.processRunItemID, err)
 	}
+	run := record.Run
 	executor, ok := s.processExecutors[run.ProcessID]
 	if !ok {
 		return fmt.Errorf("stored process %q has no configured executor", run.ProcessID)
@@ -415,14 +435,17 @@ func (s *Server) restoreProcessRun() error {
 	if run.Started && !run.Complete && len(run.Checkpoint) == 0 {
 		run.Complete = true
 		run.Result = "uncertain"
-		if err := s.processRunStore.Save(s.ctx, run); err != nil {
+		record, err = s.processRunStore.Update(s.ctx, record, run)
+		if err != nil {
 			return fmt.Errorf("mark interrupted process run uncertain: %w", err)
 		}
+		run = record.Run
 	}
 	s.processRun = run
+	s.processRunRecord = record
 	if s.goImages.document != nil {
 		if run.Result == "uncertain" || run.Started && !run.Complete {
-			return errors.New("both a go-images session and an active or uncertain process run exist; inspect the process run journal before restarting")
+			return errors.New("both a go-images session and an active or uncertain process work item exist; inspect the work item before restarting")
 		}
 		return nil
 	}

--- a/cmd/releaseagent/internal/releaseui/process_execution_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution_test.go
@@ -6,9 +6,9 @@ package releaseui
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -17,11 +17,9 @@ import (
 )
 
 func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	store := newMemoryProcessRunStore()
 	var executed bool
+	var workItemCreatedBeforeExecution bool
 	executor := ProcessExecutor{
 		Preflight: func(context.Context) (string, error) { return "verified example", nil },
 		Prepare: func(_ context.Context, input json.RawMessage) (ProcessPreparedRun, error) {
@@ -37,6 +35,7 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 		},
 		Execute: func(ctx context.Context, payload json.RawMessage, checkpoint ProcessCheckpointFunc) error {
 			executed = true
+			workItemCreatedBeforeExecution = store.count() == 1
 			return checkpoint(ctx, ProcessRunCheckpoint{
 				State: json.RawMessage(`{"run":7}`),
 				External: ProcessRunReference{
@@ -79,6 +78,9 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 	if prepared.Code != http.StatusOK {
 		t.Fatalf("prepare status = %d, body = %s", prepared.Code, prepared.Body.String())
 	}
+	if count := store.count(); count != 0 {
+		t.Fatalf("work item count after preparation = %d, want 0", count)
+	}
 	var plan processRunResponse
 	if err := json.Unmarshal(prepared.Body.Bytes(), &plan); err != nil {
 		t.Fatal(err)
@@ -109,20 +111,53 @@ func TestDurableProcessUsesSharedLifecycle(t *testing.T) {
 	if !executed {
 		t.Fatal("example process was not executed")
 	}
-	persisted, err := store.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
+	if !workItemCreatedBeforeExecution {
+		t.Fatal("process executed before its release work item was created")
 	}
+	persisted := store.latest(t)
 	if !persisted.Complete || persisted.Result != "succeeded" || persisted.External == nil || persisted.External.ID != "7" {
 		t.Fatalf("persisted = %#v", persisted)
 	}
 }
 
-func TestProcessRunTimeoutAutomaticallyResumesKnownRun(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
+func TestProcessRunCreationFailurePreventsExecution(t *testing.T) {
+	store := newMemoryProcessRunStore()
+	store.createErr = errors.New("tracking unavailable")
+	run := testProcessRun(t)
+	preflightCalled := false
+	executed := false
+	executor := ProcessExecutor{
+		Preflight: func(context.Context) (string, error) {
+			preflightCalled = true
+			return "verified", nil
+		},
+		Execute: func(context.Context, json.RawMessage, ProcessCheckpointFunc) error {
+			executed = true
+			return nil
+		},
+		Validate: func(*ProcessRun) error { return nil },
 	}
+	server := &Server{
+		ctx: context.Background(), processExecutors: map[string]ProcessExecutor{"example": executor},
+		processRunStore: store, processRun: run, runner: &coordinator.StepRunner{},
+	}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost, "http://localhost/api/processes/example/start",
+		strings.NewReader(`{"planDigest":"`+run.Digest+`","confirmed":true}`),
+	)
+	request.Header.Set("Origin", "http://localhost")
+	server.handleStartProcessRun("example", response, request)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("start status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if preflightCalled || executed || server.processRun.Started || store.count() != 0 {
+		t.Fatalf("preflight = %v, executed = %v, run = %#v, records = %d", preflightCalled, executed, server.processRun, store.count())
+	}
+}
+
+func TestProcessRunTimeoutAutomaticallyResumesKnownRun(t *testing.T) {
+	store := newMemoryProcessRunStore()
 	run, err := newProcessRun("example", ProcessPreparedRun{
 		Input: json.RawMessage(`{"mode":"test"}`), Payload: json.RawMessage(`{"value":"fixed"}`),
 		Step: ProcessRunStep{Name: "Run example", Timeout: 5 * time.Millisecond},
@@ -136,7 +171,9 @@ func TestProcessRunTimeoutAutomaticallyResumesKnownRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	run.Started = true
-	if err := store.Save(context.Background(), run); err != nil {
+	workItemID := store.seed(run)
+	record, err := store.Get(context.Background(), workItemID)
+	if err != nil {
 		t.Fatal(err)
 	}
 	resumeCalls := 0
@@ -154,7 +191,7 @@ func TestProcessRunTimeoutAutomaticallyResumesKnownRun(t *testing.T) {
 		Validate: func(*ProcessRun) error { return nil },
 	}
 	server := &Server{
-		ctx: context.Background(), processRunStore: store, processRun: run,
+		ctx: context.Background(), processRunStore: store, processRun: run, processRunRecord: record,
 		runner: &coordinator.StepRunner{}, processRunning: true,
 	}
 	step := processExecutionStep(run, func(ctx context.Context) error {
@@ -188,10 +225,7 @@ func TestProcessRunTimeoutAutomaticallyResumesKnownRun(t *testing.T) {
 	if resumeCalls != 1 {
 		t.Fatalf("resume calls = %d, want 1", resumeCalls)
 	}
-	persisted, err := store.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	persisted := store.latest(t)
 	if !persisted.Complete || persisted.Result != "succeeded" || persisted.External == nil || !persisted.External.Succeeded {
 		t.Fatalf("persisted = %#v", persisted)
 	}

--- a/cmd/releaseagent/internal/releaseui/process_run_store.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store.go
@@ -4,36 +4,39 @@
 package releaseui
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
-	"path/filepath"
+	"io"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/microsoft/go-infra/cmd/releaseagent/internal/atomicfile"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
 )
 
-const (
-	processRunSchemaVersion = 1
-	maxProcessRunSize       = 64 << 10
-)
-
-var ErrProcessRunNotFound = errors.New("process run not found")
-
-// ProcessRunStore persists the server's single current reviewed process intent without credentials.
+// ProcessRunStore persists confirmed process runs as explicitly identified work items.
 type ProcessRunStore interface {
-	Load(context.Context) (*ProcessRun, error)
-	Save(context.Context, *ProcessRun) error
+	Create(context.Context, *ProcessRun) (*ProcessRunRecord, error)
+	Get(context.Context, int) (*ProcessRunRecord, error)
+	Update(context.Context, *ProcessRunRecord, *ProcessRun) (*ProcessRunRecord, error)
+}
+
+// ProcessRunRecord binds one process run to its Azure DevOps work item revision.
+type ProcessRunRecord struct {
+	WorkItemID int
+	Revision   int
+	URL        string
+	Run        *ProcessRun
+	workItem   *azdoworkitem.WorkItem
 }
 
 // ProcessRun is the durable, process-neutral state of one reviewed external action.
 type ProcessRun struct {
 	ProcessID  string               `json:"processId"`
+	Test       bool                 `json:"test,omitempty"`
 	Input      json.RawMessage      `json:"input"`
 	Payload    json.RawMessage      `json:"payload"`
 	Digest     string               `json:"digest"`
@@ -66,6 +69,7 @@ type ProcessRunReference struct {
 
 // ProcessPreparedRun is the immutable plan returned by a process-specific executor.
 type ProcessPreparedRun struct {
+	Test    bool
 	Input   json.RawMessage
 	Payload json.RawMessage
 	Step    ProcessRunStep
@@ -73,79 +77,155 @@ type ProcessPreparedRun struct {
 	Target  ProcessRunReference
 }
 
-type processRunDocument struct {
-	SchemaVersion int        `json:"schemaVersion"`
-	Run           ProcessRun `json:"run"`
-	UpdatedAt     time.Time  `json:"updatedAt"`
+type releaseWorkItemClient interface {
+	Create(context.Context, string, string, *azdoworkitem.Snapshot) (*azdoworkitem.WorkItem, error)
+	Get(context.Context, int) (*azdoworkitem.WorkItem, error)
+	Update(context.Context, *azdoworkitem.WorkItem, *azdoworkitem.Snapshot) (*azdoworkitem.WorkItem, error)
 }
 
-// ProcessRunFileStore atomically persists one process run.
-type ProcessRunFileStore struct {
-	path string
-	mu   sync.Mutex
+type processRunWorkItemStore struct {
+	client     releaseWorkItemClient
+	assignedTo string
 }
 
-// NewProcessRunFileStore creates a file-backed process run store.
-func NewProcessRunFileStore(path string) (*ProcessRunFileStore, error) {
-	if path == "" {
-		return nil, errors.New("process run file path is empty")
+// NewProcessRunWorkItemStore creates a generic process-run store backed by Azure DevOps.
+func NewProcessRunWorkItemStore(client releaseWorkItemClient, assignedTo string) (ProcessRunStore, error) {
+	if client == nil {
+		return nil, errors.New("release work item client is nil")
 	}
-	absolute, err := filepath.Abs(path)
+	if strings.TrimSpace(assignedTo) == "" {
+		return nil, errors.New("release work item assignee is empty")
+	}
+	return &processRunWorkItemStore{client: client, assignedTo: assignedTo}, nil
+}
+
+func (s *processRunWorkItemStore) Create(ctx context.Context, run *ProcessRun) (*ProcessRunRecord, error) {
+	snapshot, err := processRunSnapshot(run)
 	if err != nil {
-		return nil, fmt.Errorf("make process run path absolute: %w", err)
-	}
-	return &ProcessRunFileStore{path: filepath.Clean(absolute)}, nil
-}
-
-func (s *ProcessRunFileStore) Load(ctx context.Context) (*ProcessRun, error) {
-	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	var document processRunDocument
-	if err := atomicfile.ReadJSON(s.path, maxProcessRunSize, &document); errors.Is(err, fs.ErrNotExist) {
-		return nil, ErrProcessRunNotFound
-	} else if err != nil {
-		return nil, fmt.Errorf("read process run: %w", err)
+	workItem, err := s.client.Create(ctx, "[releaseagent] "+run.View.IntentTitle, s.assignedTo, snapshot)
+	if err != nil {
+		return nil, err
 	}
-	if document.SchemaVersion != processRunSchemaVersion {
-		return nil, fmt.Errorf("unsupported process run schema %d", document.SchemaVersion)
-	}
-	if err := validateProcessRun(&document.Run); err != nil {
-		return nil, fmt.Errorf("validate process run: %w", err)
-	}
-	result := cloneProcessRun(&document.Run)
-	result.UpdatedAt = document.UpdatedAt
-	return result, nil
+	return processRunRecord(workItem)
 }
 
-func (s *ProcessRunFileStore) Save(ctx context.Context, run *ProcessRun) error {
-	if err := ctx.Err(); err != nil {
-		return err
+func (s *processRunWorkItemStore) Get(ctx context.Context, workItemID int) (*ProcessRunRecord, error) {
+	workItem, err := s.client.Get(ctx, workItemID)
+	if err != nil {
+		return nil, err
 	}
-	if err := validateProcessRun(run); err != nil {
-		return fmt.Errorf("refuse to save invalid process run: %w", err)
-	}
-	now := time.Now().UTC()
-	run.UpdatedAt = now
-	document := processRunDocument{
-		SchemaVersion: processRunSchemaVersion,
-		Run:           *cloneProcessRun(run),
-		UpdatedAt:     now,
-	}
+	return processRunRecord(workItem)
+}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if err := atomicfile.WriteJSON(s.path, ".process-run-*.tmp", maxProcessRunSize, document); err != nil {
-		return fmt.Errorf("write process run: %w", err)
+func (s *processRunWorkItemStore) Update(
+	ctx context.Context,
+	current *ProcessRunRecord,
+	run *ProcessRun,
+) (*ProcessRunRecord, error) {
+	if current == nil || current.workItem == nil || current.WorkItemID != current.workItem.ID ||
+		current.Revision != current.workItem.Revision {
+
+		return nil, errors.New("current process run record is invalid")
 	}
-	return nil
+	snapshot, err := processRunSnapshot(run)
+	if err != nil {
+		return nil, err
+	}
+	workItem, err := s.client.Update(ctx, current.workItem, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	return processRunRecord(workItem)
+}
+
+func processRunSnapshot(run *ProcessRun) (*azdoworkitem.Snapshot, error) {
+	if err := validateProcessRun(run); err != nil {
+		return nil, fmt.Errorf("refuse to persist invalid process run: %w", err)
+	}
+	status, err := processRunStatus(run)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(run)
+	if err != nil {
+		return nil, fmt.Errorf("marshal process run: %w", err)
+	}
+	return &azdoworkitem.Snapshot{
+		SchemaVersion: azdoworkitem.CurrentSchemaVersion,
+		ProcessID:     run.ProcessID,
+		Status:        status,
+		Test:          run.Test,
+		IntentDigest:  run.Digest,
+		Payload:       payload,
+	}, nil
+}
+
+func processRunRecord(workItem *azdoworkitem.WorkItem) (*ProcessRunRecord, error) {
+	if workItem == nil || workItem.Snapshot == nil {
+		return nil, errors.New("release work item is empty")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(workItem.Snapshot.Payload))
+	decoder.DisallowUnknownFields()
+	var run ProcessRun
+	if err := decoder.Decode(&run); err != nil {
+		return nil, fmt.Errorf("decode process run: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("decode process run: trailing JSON content")
+	}
+	if err := validateProcessRun(&run); err != nil {
+		return nil, fmt.Errorf("validate process run: %w", err)
+	}
+	if workItem.Snapshot.ProcessID != run.ProcessID || workItem.Snapshot.IntentDigest != run.Digest {
+		return nil, errors.New("release work item identity does not match process run")
+	}
+	if workItem.Snapshot.Test != run.Test {
+		return nil, errors.New("release work item test classification does not match process run")
+	}
+	status, err := processRunStatus(&run)
+	if err != nil {
+		return nil, err
+	}
+	if workItem.Snapshot.Status != status {
+		return nil, errors.New("release work item status does not match process run")
+	}
+	return &ProcessRunRecord{
+		WorkItemID: workItem.ID,
+		Revision:   workItem.Revision,
+		URL:        workItem.URL,
+		Run:        cloneProcessRun(&run),
+		workItem:   workItem,
+	}, nil
+}
+
+func processRunStatus(run *ProcessRun) (azdoworkitem.Status, error) {
+	if !run.Started {
+		return "", errors.New("process run has not started")
+	}
+	if !run.Complete {
+		if run.External != nil {
+			return azdoworkitem.StatusRunning, nil
+		}
+		return azdoworkitem.StatusStarting, nil
+	}
+	switch run.Result {
+	case "succeeded":
+		return azdoworkitem.StatusSucceeded, nil
+	case "failed":
+		return azdoworkitem.StatusFailed, nil
+	case "uncertain":
+		return azdoworkitem.StatusUncertain, nil
+	default:
+		return "", fmt.Errorf("process run has invalid terminal result %q", run.Result)
+	}
 }
 
 func newProcessRun(processID string, prepared ProcessPreparedRun) (*ProcessRun, error) {
 	run := &ProcessRun{
 		ProcessID: processID,
+		Test:      prepared.Test,
 		Input:     append(json.RawMessage(nil), prepared.Input...),
 		Payload:   append(json.RawMessage(nil), prepared.Payload...),
 		Step:      prepared.Step,
@@ -167,6 +247,7 @@ func newProcessRun(processID string, prepared ProcessPreparedRun) (*ProcessRun, 
 func processRunDigest(run *ProcessRun) (string, error) {
 	payload := struct {
 		ProcessID string
+		Test      bool
 		Input     json.RawMessage
 		Payload   json.RawMessage
 		Step      ProcessRunStep
@@ -174,6 +255,7 @@ func processRunDigest(run *ProcessRun) (string, error) {
 		Target    ProcessRunReference
 	}{
 		ProcessID: run.ProcessID,
+		Test:      run.Test,
 		Input:     run.Input,
 		Payload:   run.Payload,
 		Step:      run.Step,

--- a/cmd/releaseagent/internal/releaseui/process_run_store_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store_test.go
@@ -1,63 +1,106 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
+// Tests for generic process-run persistence.
 package releaseui
 
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
 )
 
-func TestProcessRunStoreRoundTrip(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	run := testProcessRun(t)
-	if err := store.Save(context.Background(), run); err != nil {
-		t.Fatal(err)
-	}
-	loaded, err := store.Load(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if loaded.Digest != run.Digest || loaded.ProcessID != "example" || loaded.Started || loaded.Complete ||
-		loaded.UpdatedAt.IsZero() {
-
-		t.Fatalf("loaded run = %#v", loaded)
-	}
-	loaded.Digest = "tampered"
-	if err := store.Save(context.Background(), loaded); err == nil {
-		t.Fatal("tampered process run was persisted")
-	}
+type fakeReleaseWorkItemClient struct {
+	item *azdoworkitem.WorkItem
 }
 
-func TestProcessRunStoreRequiresPairedCheckpoint(t *testing.T) {
-	store, err := NewProcessRunFileStore(filepath.Join(t.TempDir(), "run.json"))
+func (f *fakeReleaseWorkItemClient) Create(
+	_ context.Context,
+	title, assignedTo string,
+	snapshot *azdoworkitem.Snapshot,
+) (*azdoworkitem.WorkItem, error) {
+	if title != "[releaseagent] Run example" || assignedTo != "Release Operator" {
+		return nil, fmt.Errorf("unexpected title %q or assignee %q", title, assignedTo)
+	}
+	f.item = &azdoworkitem.WorkItem{
+		ID: 42, Revision: 1, URL: "https://example.invalid/workitems/42", Snapshot: snapshot,
+	}
+	return f.item, nil
+}
+
+func (f *fakeReleaseWorkItemClient) Get(context.Context, int) (*azdoworkitem.WorkItem, error) {
+	return f.item, nil
+}
+
+func (f *fakeReleaseWorkItemClient) Update(
+	_ context.Context,
+	current *azdoworkitem.WorkItem,
+	snapshot *azdoworkitem.Snapshot,
+) (*azdoworkitem.WorkItem, error) {
+	if current != f.item {
+		return nil, errors.New("unexpected current work item")
+	}
+	f.item = &azdoworkitem.WorkItem{
+		ID: current.ID, Revision: current.Revision + 1, URL: current.URL, Snapshot: snapshot,
+	}
+	return f.item, nil
+}
+
+func TestProcessRunWorkItemStoreRoundTrip(t *testing.T) {
+	client := &fakeReleaseWorkItemClient{}
+	store, err := NewProcessRunWorkItemStore(client, "Release Operator")
 	if err != nil {
 		t.Fatal(err)
 	}
 	run := testProcessRun(t)
 	run.Started = true
-	run.Checkpoint = json.RawMessage(`{"run":7}`)
-	if err := store.Save(context.Background(), run); err == nil {
-		t.Fatal("checkpoint without an external run was persisted")
+	record, err := store.Create(context.Background(), run)
+	if err != nil {
+		t.Fatal(err)
 	}
-	run.Checkpoint = nil
-	run.External = &ProcessRunReference{
-		ID: "7", URL: "https://example.com/runs/7", LinkLabel: "Open example run 7",
+	if record.WorkItemID != 42 || record.Revision != 1 || record.Run.Digest != run.Digest ||
+		client.item.Snapshot.Status != azdoworkitem.StatusStarting || !client.item.Snapshot.Test {
+
+		t.Fatalf("record = %#v, snapshot = %#v", record, client.item.Snapshot)
 	}
-	if err := store.Save(context.Background(), run); err == nil {
-		t.Fatal("external run without a checkpoint was persisted")
+	loaded, err := store.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Run.Digest != run.Digest {
+		t.Fatalf("loaded run = %#v", loaded.Run)
+	}
+
+	run.Complete = true
+	run.Result = "succeeded"
+	updated, err := store.Update(context.Background(), record, run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Revision != 2 || updated.Run.Result != "succeeded" ||
+		client.item.Snapshot.Status != azdoworkitem.StatusSucceeded {
+
+		t.Fatalf("updated = %#v, snapshot = %#v", updated, client.item.Snapshot)
+	}
+}
+
+func TestProcessRunWorkItemStoreRejectsUnstartedRun(t *testing.T) {
+	store, err := NewProcessRunWorkItemStore(&fakeReleaseWorkItemClient{}, "Release Operator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(context.Background(), testProcessRun(t)); err == nil {
+		t.Fatal("unstarted process run was persisted")
 	}
 }
 
 func testProcessRun(t *testing.T) *ProcessRun {
 	t.Helper()
 	run, err := newProcessRun("example", ProcessPreparedRun{
+		Test:  true,
 		Input: json.RawMessage(`{"mode":"test"}`), Payload: json.RawMessage(`{"value":"fixed"}`),
 		Step: ProcessRunStep{Name: "Run example", Timeout: time.Minute},
 		View: ProcessPlanView{
@@ -72,4 +115,93 @@ func testProcessRun(t *testing.T) *ProcessRun {
 	return run
 }
 
-var _ ProcessRunStore = (*ProcessRunFileStore)(nil)
+type memoryProcessRunStore struct {
+	mu        sync.Mutex
+	nextID    int
+	records   map[int]*ProcessRunRecord
+	createErr error
+}
+
+func newMemoryProcessRunStore() *memoryProcessRunStore {
+	return &memoryProcessRunStore{nextID: 1, records: make(map[int]*ProcessRunRecord)}
+}
+
+func (s *memoryProcessRunStore) Create(_ context.Context, run *ProcessRun) (*ProcessRunRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	record := &ProcessRunRecord{
+		WorkItemID: s.nextID, Revision: 1,
+		URL: fmt.Sprintf("https://example.invalid/workitems/%d", s.nextID),
+		Run: cloneProcessRun(run),
+	}
+	s.records[record.WorkItemID] = record
+	s.nextID++
+	return cloneProcessRunRecord(record), nil
+}
+
+func (s *memoryProcessRunStore) Get(_ context.Context, id int) (*ProcessRunRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[id]
+	if !ok {
+		return nil, errors.New("process run record not found")
+	}
+	return cloneProcessRunRecord(record), nil
+}
+
+func (s *memoryProcessRunStore) Update(
+	_ context.Context,
+	current *ProcessRunRecord,
+	run *ProcessRun,
+) (*ProcessRunRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[current.WorkItemID]
+	if !ok || record.Revision != current.Revision {
+		return nil, azdoworkitem.ErrRevisionConflict
+	}
+	record = &ProcessRunRecord{
+		WorkItemID: record.WorkItemID, Revision: record.Revision + 1,
+		URL: record.URL, Run: cloneProcessRun(run),
+	}
+	s.records[record.WorkItemID] = record
+	return cloneProcessRunRecord(record), nil
+}
+
+func (s *memoryProcessRunStore) seed(run *ProcessRun) int {
+	record, err := s.Create(context.Background(), run)
+	if err != nil {
+		panic(err)
+	}
+	return record.WorkItemID
+}
+
+func (s *memoryProcessRunStore) latest(t *testing.T) *ProcessRun {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.records) != 1 {
+		t.Fatalf("record count = %d, want 1", len(s.records))
+	}
+	for _, record := range s.records {
+		return cloneProcessRun(record.Run)
+	}
+	panic("unreachable")
+}
+
+func (s *memoryProcessRunStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.records)
+}
+
+func cloneProcessRunRecord(record *ProcessRunRecord) *ProcessRunRecord {
+	clone := *record
+	clone.Run = cloneProcessRun(record.Run)
+	return &clone
+}
+
+var _ ProcessRunStore = (*memoryProcessRunStore)(nil)

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	activeProcessID  string
 	processExecutors map[string]ProcessExecutor
 	processRunStore  ProcessRunStore
+	processRunItemID int
 
 	sessionStore goimagessession.Store
 	readOnly     *GoImagesReadOnlyIntegration
@@ -71,6 +72,7 @@ type Server struct {
 	simulationRunning bool
 	releaseRunning    bool
 	processRun        *ProcessRun
+	processRunRecord  *ProcessRunRecord
 	processRunning    bool
 }
 

--- a/cmd/releaseagent/serve.go
+++ b/cmd/releaseagent/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/go-infra/buildmodel/dockerversions"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdopipeline"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdorepo"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesexecution"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesrelease"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagessession"
@@ -50,8 +51,20 @@ func handleServe(parse subcmd.ParseFunc) error {
 		filepath.Join(configDir, "microsoft-go", "release-session.json"),
 		"JSON file used to persist and restore the non-secret release plan",
 	)
+	releaseWorkItem := flag.Int(
+		"release-work-item", 0,
+		"Azure DevOps work item ID to restore; 0 starts without a selected release",
+	)
 	if err := parse(); err != nil {
 		return err
+	}
+	if *releaseWorkItem < 0 {
+		return errors.New("release work item ID must not be negative")
+	}
+
+	tokenProvider := &azdopipeline.CachingTokenProvider{
+		Provider: azdopipeline.AzureCLITokenProvider{Runner: azdopipeline.ExecCommandRunner{}},
+		TTL:      5 * time.Minute,
 	}
 
 	var options []releaseui.Option
@@ -75,7 +88,19 @@ func handleServe(parse subcmd.ParseFunc) error {
 	if err != nil {
 		return err
 	}
-	processRunStore, err := releaseui.NewProcessRunFileStore(sessionPath + ".process-run.json")
+	workItems, err := azdoworkitem.NewClient(azdoworkitem.Config{
+		BaseURL:      "https://dev.azure.com/devdiv",
+		Project:      "DEVDIV",
+		WorkItemType: "Issue",
+	}, tokenProvider)
+	if err != nil {
+		return err
+	}
+	assignedTo, err := workItems.CurrentUser(context.Background())
+	if err != nil {
+		return err
+	}
+	processRunStore, err := releaseui.NewProcessRunWorkItemStore(workItems, assignedTo)
 	if err != nil {
 		return err
 	}
@@ -87,12 +112,11 @@ func handleServe(parse subcmd.ParseFunc) error {
 			DispatchPatchRelease:   service.DispatchPatchRelease, PollWorkflowRun: service.PollWorkflowRun,
 		}),
 	)
+	if *releaseWorkItem > 0 {
+		options = append(options, releaseui.WithProcessRunWorkItem(*releaseWorkItem))
+	}
 
 	azureHTTPClient := &http.Client{Timeout: 3 * time.Minute}
-	tokenProvider := &azdopipeline.CachingTokenProvider{
-		Provider: azdopipeline.AzureCLITokenProvider{Runner: azdopipeline.ExecCommandRunner{}},
-		TTL:      5 * time.Minute,
-	}
 	azureClient, err := azdopipeline.NewClient(
 		"https://dev.azure.com/dnceng",
 		"internal",


### PR DESCRIPTION
## Summary

- replace generic `ProcessRun` file persistence with explicit Azure DevOps work-item identity and revision handling
- create the work item only after confirmation and before the external GitHub action can mutate anything
- checkpoint and restore generic runs through revision-checked work-item updates
- assign new work items to the authenticated operator and classify confirmed go-infra dry runs as tests

This keeps unconfirmed plans in memory and preserves the existing preflight, confirmation, and target-reconciliation behavior.

## Stack

2 of 4. Stacked on #598.

## Testing

- `go test -count=1 ./cmd/releaseagent/...` at this layer
- `go test -count=1 -race ./cmd/releaseagent/...` on the completed stack
- `go vet ./cmd/releaseagent/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.0 run ./cmd/releaseagent/...`