### PR TITLE
releaseagent: add work item dashboard and recovery

### DIFF
--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -64,7 +64,8 @@ It offers three explicit modes:
   It then uses that ID as `sourceBuildPipelineRunId` and publishes to `public/`.
   The build ID is the only editable pipeline input.
 * **Test** resolves the current `microsoft/main` tip, builds fresh images, and fixes `publishRepoPrefix` to `dev/`.
-  It still queues a real official build, creates a `releaseagent-test` work item when confirmed, and
+  It still queues a real official build, creates a work item tagged `releaseagent`, `test`, and
+  `go-images` when confirmed, and
   may consume signing and agent resources, but it does not publish under `public/`.
 
 The pipeline declares `publishRepoPrefix` as an unrestricted string whose official default is `public/`.
@@ -87,8 +88,9 @@ and exposes both supported paths:
 
 * **Release on merge** accepts one pull request number. The server verifies that the PR is open, targets `main`, and is not from a fork, then prepares a request to add the `release-on-merge` label. Starting the action rechecks the exact PR head SHA. The UI never merges the PR; the existing workflow creates the release only after the labeled PR is merged.
 * **Manual patch release** dispatches only `create-go-infra-patch-release.yml` on `main`. Dry-run
-  mode sets `dry-run` to `true`, calculates the next version, and creates a `releaseagent-test` work
-  item when confirmed. Publish mode sets it to `false` and can create the next patch release. After
+  mode sets `dry-run` to `true`, calculates the next version, and creates a work item tagged
+  `releaseagent`, `test`, and `go-infra` when confirmed. Publish mode sets it to `false` and can
+  create the next patch release. After
   GitHub accepts the dispatch, the server
   discovers the new run, checkpoints its ID and URL, and polls it to a terminal conclusion. GitHub's workflow dispatch endpoint does not return a run ID, so the UI supplies a random token as the run title and matches that exact title. If a monitoring interval times out, polling continues from the checkpointed run ID. The dashboard reports the final result.
 
@@ -106,7 +108,8 @@ go run ./cmd/releaseagent serve
 
 Authenticate `az` before starting the UI and `gh` before using GitHub-backed go-infra actions. Each
 confirmed execution creates a tagged DEVDIV `Issue` under `DevDiv\GoLang`; this includes go-images
-test mode and go-infra dry-run mode. Those two modes also receive the `releaseagent-test` tag.
+test mode and go-infra dry-run mode. Every item receives its process ID as a tag. Test and dry-run
+items also receive `test`; all release UI queries combine these tags with `releaseagent`.
 Simulations and unconfirmed plans remain in memory and create no work item. To restore one
 explicitly, add `-release-work-item <id>`. Starting the server does not perform an external action.
 Opening the go-infra page performs read-only preflight checks; a mutation still requires preparing

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -112,9 +112,15 @@ explicitly, add `-release-work-item <id>`. Starting the server does not perform 
 Opening the go-infra page performs read-only preflight checks; a mutation still requires preparing
 the exact request and confirming it.
 
-Releaseagent owns `System.Description` on generic-action work items. It stores a visible managed-state
+Releaseagent owns `System.Description` on these work items. It stores a visible managed-state
 notice followed by base64url-encoded canonical JSON so Azure DevOps HTML normalization cannot alter
 the release state. Add operator notes as work-item comments rather than editing Description.
+
+The dashboard queries active tagged work items and the ten most recently closed items. **Resume**
+selects one work item for this server. **View JSON** exports its snapshot for manual repair and
+imports edited JSON only when the exported Azure DevOps revision is still current. Import validates
+the process payload and cannot change its process ID or immutable intent digest. Restart without a
+selected release before repairing that release's state.
 
 Every new real run uses a two-step **Run** then **Confirm run** interaction.
 The second request must include explicit confirmation and the exact current plan digest, so a stale or changed plan is rejected.

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -117,7 +117,9 @@ release-type summary, then keeps the base64url-encoded canonical JSON in a colla
 section so Azure DevOps HTML normalization cannot alter the release state. Add operator notes as
 work-item comments rather than editing Description.
 
-The dashboard queries active tagged work items and the ten most recently closed items. Clicking a
+The dashboard queries active tagged work items and the ten most recently closed items. Starting and
+running work appears under **Ongoing releases**. Failed, canceled, and uncertain work appears under
+**Needs attention**, while successful closed work appears under **Recently completed**. Clicking a
 card or **Open** selects one work item for this server. Its Azure DevOps browser link appears on the
 dashboard and selected release page. **View JSON** exports its snapshot for manual repair and imports
 edited JSON only when the exported Azure DevOps revision is still current. Import validates the

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -131,7 +131,8 @@ card or **Open** selects one work item for this server. Its Azure DevOps browser
 dashboard and selected release page. **View JSON** exports its snapshot for manual repair and imports
 edited JSON only when the exported Azure DevOps revision is still current. Import validates the
 process payload and cannot change its process ID or immutable intent digest. Restart without a
-selected release before repairing that release's state.
+selected release before repairing that release's state. Reopening the currently selected work item
+is idempotent; selecting a different work item still requires restarting the server.
 
 Every new real run uses a two-step **Run** then **Confirm run** interaction.
 The second request must include explicit confirmation and the exact current plan digest, so a stale or changed plan is rejected.

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -125,14 +125,15 @@ Azure DevOps HTML normalization cannot alter release state. Add operator notes a
 rather than editing Description.
 
 The dashboard queries active tagged work items and the ten most recently closed items. Starting and
-running work appears under **Ongoing releases**. Failed, canceled, and uncertain work appears under
-**Needs attention**, while successful closed work appears under **Recently completed**. Clicking a
-card or **Open** selects one work item for this server. Its Azure DevOps browser link appears on the
-dashboard and selected release page. **View JSON** exports its snapshot for manual repair and imports
-edited JSON only when the exported Azure DevOps revision is still current. Import validates the
-process payload and cannot change its process ID or immutable intent digest. Restart without a
-selected release before repairing that release's state. Reopening the currently selected work item
-is idempotent; selecting a different work item still requires restarting the server.
+running work appears under **Ongoing releases**. Active failed, canceled, and uncertain work appears
+under **Needs attention**. Successful work and manually closed terminal outcomes appear under
+**Recently completed** without rewriting the execution result. Clicking a card or **Open** selects
+one work item for this server. Its Azure DevOps browser link appears on the dashboard and selected
+release page. **View JSON** exports its snapshot for manual repair and imports edited JSON only when
+the exported Azure DevOps revision is still current. Import validates the process payload and cannot
+change its process ID or immutable intent digest. Restart without a selected release before
+repairing that release's state. Reopening the currently selected work item is idempotent; selecting a
+different work item still requires restarting the server.
 
 Every new real run uses a two-step **Run** then **Confirm run** interaction.
 The second request must include explicit confirmation and the exact current plan digest, so a stale or changed plan is rejected.

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -112,14 +112,16 @@ explicitly, add `-release-work-item <id>`. Starting the server does not perform 
 Opening the go-infra page performs read-only preflight checks; a mutation still requires preparing
 the exact request and confirming it.
 
-Releaseagent owns `System.Description` on these work items. It stores a visible managed-state
-notice followed by base64url-encoded canonical JSON so Azure DevOps HTML normalization cannot alter
-the release state. Add operator notes as work-item comments rather than editing Description.
+Releaseagent owns `System.Description` on these work items. It shows a compact process, status, and
+release-type summary, then keeps the base64url-encoded canonical JSON in a collapsed managed-state
+section so Azure DevOps HTML normalization cannot alter the release state. Add operator notes as
+work-item comments rather than editing Description.
 
-The dashboard queries active tagged work items and the ten most recently closed items. **Resume**
-selects one work item for this server. **View JSON** exports its snapshot for manual repair and
-imports edited JSON only when the exported Azure DevOps revision is still current. Import validates
-the process payload and cannot change its process ID or immutable intent digest. Restart without a
+The dashboard queries active tagged work items and the ten most recently closed items. Clicking a
+card or **Open** selects one work item for this server. Its Azure DevOps browser link appears on the
+dashboard and selected release page. **View JSON** exports its snapshot for manual repair and imports
+edited JSON only when the exported Azure DevOps revision is still current. Import validates the
+process payload and cannot change its process ID or immutable intent digest. Restart without a
 selected release before repairing that release's state.
 
 Every new real run uses a two-step **Run** then **Confirm run** interaction.

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -112,10 +112,13 @@ explicitly, add `-release-work-item <id>`. Starting the server does not perform 
 Opening the go-infra page performs read-only preflight checks; a mutation still requires preparing
 the exact request and confirming it.
 
-Releaseagent owns `System.Description` on these work items. It shows a compact process, status, and
-release-type summary, then keeps the base64url-encoded canonical JSON in a collapsed managed-state
-section so Azure DevOps HTML normalization cannot alter the release state. Add operator notes as
-work-item comments rather than editing Description.
+Releaseagent owns `System.Description` on these work items. It shows status and release type plus
+useful process details. Go-images work items include mode, versions, publication prefix, source
+commit, Azure build, and checkpoint timestamps. Generic actions include their intent, action,
+reviewed facts, target, and external run. Links open the underlying commit, build, pull request, or
+workflow run. The base64url-encoded canonical JSON remains in a collapsed managed-state section so
+Azure DevOps HTML normalization cannot alter release state. Add operator notes as work-item comments
+rather than editing Description.
 
 The dashboard queries active tagged work items and the ten most recently closed items. Starting and
 running work appears under **Ongoing releases**. Failed, canceled, and uncertain work appears under

--- a/cmd/releaseagent/README.md
+++ b/cmd/releaseagent/README.md
@@ -109,7 +109,8 @@ go run ./cmd/releaseagent serve
 Authenticate `az` before starting the UI and `gh` before using GitHub-backed go-infra actions. Each
 confirmed execution creates a tagged DEVDIV `Issue` under `DevDiv\GoLang`; this includes go-images
 test mode and go-infra dry-run mode. Every item receives its process ID as a tag. Test and dry-run
-items also receive `test`; all release UI queries combine these tags with `releaseagent`.
+items also receive `test`; all release UI queries combine these tags with `releaseagent`. Azure
+DevOps treats tags as case-insensitive and may display the project-canonical casing, such as `Test`.
 Simulations and unconfirmed plans remain in memory and create no work item. To restore one
 explicitly, add `-release-work-item <id>`. Starting the server does not perform an external action.
 Opening the go-infra page performs read-only preflight checks; a mutation still requires preparing

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -193,7 +193,7 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	document := []webapi.JsonPatchOperation{
 		patch(webapi.OperationValues.Test, "/rev", current.Revision),
 		patch(webapi.OperationValues.Add, "/fields/System.State", workItemState(snapshot.Status)),
-		patch(webapi.OperationValues.Add, "/fields/System.Tags", workItemTags(snapshot)),
+		patch(webapi.OperationValues.Replace, "/fields/System.Tags", workItemTags(snapshot)),
 		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
 	}
 	sdk, token, err := c.newClient(ctx)
@@ -414,7 +414,7 @@ func (c *Client) workItemURL(id int) string {
 
 func hasTag(tags, want string) bool {
 	for _, tag := range strings.Split(tags, ";") {
-		if strings.TrimSpace(tag) == want {
+		if strings.EqualFold(strings.TrimSpace(tag), want) {
 			return true
 		}
 	}

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -20,7 +20,8 @@ import (
 const (
 	AreaPath         = `DevDiv\GoLang`
 	SelectorTag      = "releaseagent"
-	TestTag          = "releaseagent-test"
+	TestTag          = "test"
+	legacyTestTag    = "releaseagent-test"
 	browserProject   = "DevDiv"
 	descriptionField = "System.Description"
 	maxQueryResults  = 200
@@ -192,6 +193,7 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	document := []webapi.JsonPatchOperation{
 		patch(webapi.OperationValues.Test, "/rev", current.Revision),
 		patch(webapi.OperationValues.Add, "/fields/System.State", workItemState(snapshot.Status)),
+		patch(webapi.OperationValues.Add, "/fields/System.Tags", workItemTags(snapshot)),
 		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
 	}
 	sdk, token, err := c.newClient(ctx)
@@ -372,7 +374,8 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	if err != nil {
 		return nil, fmt.Errorf("parse work item %d release snapshot: %w", *response.Id, err)
 	}
-	if hasTag(tags, TestTag) != snapshot.Test {
+	testTagged := hasTag(tags, TestTag) || hasTag(tags, legacyTestTag)
+	if testTagged != snapshot.Test {
 		return nil, fmt.Errorf("work item %d test tag does not match release snapshot", *response.Id)
 	}
 	if state != workItemState(snapshot.Status) {
@@ -423,10 +426,12 @@ func escapeWIQL(value string) string {
 }
 
 func workItemTags(snapshot *Snapshot) string {
+	tags := []string{SelectorTag}
 	if snapshot.Test {
-		return SelectorTag + "; " + TestTag
+		tags = append(tags, TestTag)
 	}
-	return SelectorTag
+	tags = append(tags, snapshot.ProcessID)
+	return strings.Join(tags, "; ")
 }
 
 func workItemState(status Status) string {

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -47,12 +47,13 @@ type Client struct {
 }
 
 type WorkItem struct {
-	ID       int
-	Revision int
-	URL      string
-	Title    string
-	State    string
-	Snapshot *Snapshot
+	ID        int
+	Revision  int
+	URL       string
+	Title     string
+	State     string
+	ChangedAt time.Time
+	Snapshot  *Snapshot
 }
 
 type workItemClient interface {
@@ -214,15 +215,19 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	return workItem, nil
 }
 
-func (c *Client) Query(ctx context.Context, limit int) ([]*WorkItem, error) {
+func (c *Client) Query(ctx context.Context, closed bool, limit int) ([]*WorkItem, error) {
 	if limit <= 0 || limit > maxQueryResults {
 		return nil, fmt.Errorf("release work item query limit must be between 1 and %d", maxQueryResults)
 	}
+	stateOperator := "<>"
+	if closed {
+		stateOperator = "="
+	}
 	wiql := fmt.Sprintf(
 		"SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = '%s' "+
-			"AND [System.AreaPath] = '%s' AND [System.Tags] CONTAINS '%s' "+
+			"AND [System.AreaPath] = '%s' AND [System.Tags] CONTAINS '%s' AND [System.State] %s 'Closed' "+
 			"ORDER BY [System.ChangedDate] DESC",
-		escapeWIQL(c.workItemType), escapeWIQL(AreaPath), escapeWIQL(SelectorTag),
+		escapeWIQL(c.workItemType), escapeWIQL(AreaPath), escapeWIQL(SelectorTag), stateOperator,
 	)
 	sdk, token, err := c.newClient(ctx)
 	if err != nil {
@@ -352,9 +357,14 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	}
 	title, titleOK := fields["System.Title"].(string)
 	state, stateOK := fields["System.State"].(string)
+	changedText, changedOK := fields["System.ChangedDate"].(string)
 	description, snapshotOK := fields[descriptionField].(string)
-	if !titleOK || strings.TrimSpace(title) == "" || !stateOK || strings.TrimSpace(state) == "" || !snapshotOK {
+	if !titleOK || strings.TrimSpace(title) == "" || !stateOK || strings.TrimSpace(state) == "" || !changedOK || !snapshotOK {
 		return nil, fmt.Errorf("work item %d has incomplete managed fields", *response.Id)
+	}
+	changedAt, err := time.Parse(time.RFC3339Nano, changedText)
+	if err != nil {
+		return nil, fmt.Errorf("work item %d has invalid changed date %q", *response.Id, changedText)
 	}
 	snapshot, err := ParseDescription(description)
 	if err != nil {
@@ -372,13 +382,13 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	}
 	return &WorkItem{
 		ID: *response.Id, Revision: *response.Rev, URL: itemURL,
-		Title: title, State: state, Snapshot: snapshot,
+		Title: title, State: state, ChangedAt: changedAt, Snapshot: snapshot,
 	}, nil
 }
 
 func (c *Client) fields() []string {
 	return []string{
-		"System.WorkItemType", "System.Title", "System.State", "System.AreaPath", "System.Tags", descriptionField,
+		"System.WorkItemType", "System.Title", "System.State", "System.AreaPath", "System.Tags", "System.ChangedDate", descriptionField,
 	}
 }
 

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +21,6 @@ const (
 	SelectorTag      = "releaseagent"
 	TestTag          = "test"
 	legacyTestTag    = "releaseagent-test"
-	browserProject   = "DevDiv"
 	descriptionField = "System.Description"
 	maxQueryResults  = 200
 	sdkTimeout       = 3 * time.Minute
@@ -62,7 +60,7 @@ type WorkItem struct {
 type workItemClient interface {
 	CreateWorkItem(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error)
 	GetWorkItem(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error)
-	GetWorkItems(context.Context, workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error)
+	GetWorkItemsBatch(context.Context, workitemtracking.GetWorkItemsBatchArgs) (*[]workitemtracking.WorkItem, error)
 	QueryByWiql(context.Context, workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error)
 	UpdateWorkItem(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error)
 }
@@ -146,6 +144,7 @@ func (c *Client) Create(ctx context.Context, title, assignedTo string, snapshot 
 	}
 	response, err := sdk.CreateWorkItem(ctx, workitemtracking.CreateWorkItemArgs{
 		Document: &document, Project: &c.project, Type: &c.workItemType,
+		Expand: &workitemtracking.WorkItemExpandValues.Links,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create release work item: %w", redactError(err, token))
@@ -164,6 +163,7 @@ func (c *Client) Get(ctx context.Context, id int) (*WorkItem, error) {
 	fields := c.fields()
 	response, err := sdk.GetWorkItem(ctx, workitemtracking.GetWorkItemArgs{
 		Id: &id, Project: &c.project, Fields: &fields,
+		Expand: &workitemtracking.WorkItemExpandValues.Links,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get release work item %d: %w", id, redactError(err, token))
@@ -202,6 +202,7 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	}
 	response, err := sdk.UpdateWorkItem(ctx, workitemtracking.UpdateWorkItemArgs{
 		Document: &document, Id: &current.ID, Project: &c.project,
+		Expand: &workitemtracking.WorkItemExpandValues.Links,
 	})
 	if err != nil {
 		if isRevisionConflict(err) {
@@ -263,8 +264,12 @@ func (c *Client) Query(ctx context.Context, closed bool, limit int) ([]*WorkItem
 		positions[*reference.Id] = index
 	}
 	fields := c.fields()
-	responses, err := sdk.GetWorkItems(ctx, workitemtracking.GetWorkItemsArgs{
-		Ids: &ids, Project: &c.project, Fields: &fields,
+	expand := workitemtracking.WorkItemExpandValues.Links
+	responses, err := sdk.GetWorkItemsBatch(ctx, workitemtracking.GetWorkItemsBatchArgs{
+		Project: &c.project,
+		WorkItemGetRequest: &workitemtracking.WorkItemBatchGetRequest{
+			Ids: &ids, Fields: &fields, Expand: &expand,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("read release work item query results: %w", redactError(err, token))
@@ -381,8 +386,12 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	if !workItemStateMatches(state, snapshot.Status) {
 		return nil, fmt.Errorf("work item %d state %q is incompatible with release status %q", *response.Id, state, snapshot.Status)
 	}
+	itemURL := workItemURL(response)
+	if itemURL == "" {
+		return nil, fmt.Errorf("work item %d has no browser URL", *response.Id)
+	}
 	return &WorkItem{
-		ID: *response.Id, Revision: *response.Rev, URL: c.workItemURL(*response.Id),
+		ID: *response.Id, Revision: *response.Rev, URL: itemURL,
 		Title: title, State: state, ChangedAt: changedAt, Snapshot: snapshot,
 	}, nil
 }
@@ -397,19 +406,17 @@ func patch(operation webapi.Operation, path string, value any) webapi.JsonPatchO
 	return webapi.JsonPatchOperation{Op: &operation, Path: &path, Value: value}
 }
 
-func (c *Client) workItemURL(id int) string {
-	baseURL := c.baseURL
-	project := c.project
-	if strings.EqualFold(project, browserProject) {
-		project = browserProject
+func workItemURL(item *workitemtracking.WorkItem) string {
+	links, ok := item.Links.(map[string]any)
+	if !ok {
+		return ""
 	}
-	parsed, _ := url.Parse(baseURL)
-	organization := strings.Trim(parsed.Path, "/")
-	if parsed.Hostname() == "dev.azure.com" && organization != "" && !strings.Contains(organization, "/") {
-		baseURL = parsed.Scheme + "://" + organization + ".visualstudio.com"
+	htmlLink, ok := links["html"].(map[string]any)
+	if !ok {
+		return ""
 	}
-	result, _ := url.JoinPath(baseURL, project, "_workitems", "edit", strconv.Itoa(id))
-	return result
+	href, _ := htmlLink["href"].(string)
+	return href
 }
 
 func hasTag(tags, want string) bool {

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -192,7 +192,7 @@ func (c *Client) Update(ctx context.Context, current *WorkItem, snapshot *Snapsh
 	}
 	document := []webapi.JsonPatchOperation{
 		patch(webapi.OperationValues.Test, "/rev", current.Revision),
-		patch(webapi.OperationValues.Add, "/fields/System.State", workItemState(snapshot.Status)),
+		patch(webapi.OperationValues.Add, "/fields/System.State", workItemStateForUpdate(current.State, snapshot.Status)),
 		patch(webapi.OperationValues.Replace, "/fields/System.Tags", workItemTags(snapshot)),
 		patch(webapi.OperationValues.Add, "/fields/"+descriptionField, description),
 	}
@@ -378,8 +378,8 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	if testTagged != snapshot.Test {
 		return nil, fmt.Errorf("work item %d test tag does not match release snapshot", *response.Id)
 	}
-	if state != workItemState(snapshot.Status) {
-		return nil, fmt.Errorf("work item %d state %q does not match release status %q", *response.Id, state, snapshot.Status)
+	if !workItemStateMatches(state, snapshot.Status) {
+		return nil, fmt.Errorf("work item %d state %q is incompatible with release status %q", *response.Id, state, snapshot.Status)
 	}
 	return &WorkItem{
 		ID: *response.Id, Revision: *response.Rev, URL: c.workItemURL(*response.Id),
@@ -439,6 +439,24 @@ func workItemState(status Status) string {
 		return "Closed"
 	}
 	return "Active"
+}
+
+func workItemStateForUpdate(current string, status Status) string {
+	if current == "Closed" && isAttentionStatus(status) {
+		return "Closed"
+	}
+	return workItemState(status)
+}
+
+func workItemStateMatches(state string, status Status) bool {
+	if state == workItemState(status) {
+		return true
+	}
+	return state == "Closed" && isAttentionStatus(status)
+}
+
+func isAttentionStatus(status Status) bool {
+	return status == StatusFailed || status == StatusCanceled || status == StatusUncertain
 }
 
 func isRevisionConflict(err error) bool {

--- a/cmd/releaseagent/internal/azdoworkitem/client.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ const (
 	AreaPath         = `DevDiv\GoLang`
 	SelectorTag      = "releaseagent"
 	TestTag          = "releaseagent-test"
+	browserProject   = "DevDiv"
 	descriptionField = "System.Description"
 	maxQueryResults  = 200
 	sdkTimeout       = 3 * time.Minute
@@ -376,12 +378,8 @@ func (c *Client) parseWorkItem(response *workitemtracking.WorkItem) (*WorkItem, 
 	if state != workItemState(snapshot.Status) {
 		return nil, fmt.Errorf("work item %d state %q does not match release status %q", *response.Id, state, snapshot.Status)
 	}
-	itemURL := workItemURL(response)
-	if itemURL == "" {
-		return nil, fmt.Errorf("work item %d has no URL", *response.Id)
-	}
 	return &WorkItem{
-		ID: *response.Id, Revision: *response.Rev, URL: itemURL,
+		ID: *response.Id, Revision: *response.Rev, URL: c.workItemURL(*response.Id),
 		Title: title, State: state, ChangedAt: changedAt, Snapshot: snapshot,
 	}, nil
 }
@@ -396,18 +394,19 @@ func patch(operation webapi.Operation, path string, value any) webapi.JsonPatchO
 	return webapi.JsonPatchOperation{Op: &operation, Path: &path, Value: value}
 }
 
-func workItemURL(item *workitemtracking.WorkItem) string {
-	if links, ok := item.Links.(map[string]any); ok {
-		if html, ok := links["html"].(map[string]any); ok {
-			if href, ok := html["href"].(string); ok && href != "" {
-				return href
-			}
-		}
+func (c *Client) workItemURL(id int) string {
+	baseURL := c.baseURL
+	project := c.project
+	if strings.EqualFold(project, browserProject) {
+		project = browserProject
 	}
-	if item.Url != nil {
-		return *item.Url
+	parsed, _ := url.Parse(baseURL)
+	organization := strings.Trim(parsed.Path, "/")
+	if parsed.Hostname() == "dev.azure.com" && organization != "" && !strings.Contains(organization, "/") {
+		baseURL = parsed.Scheme + "://" + organization + ".visualstudio.com"
 	}
-	return ""
+	result, _ := url.JoinPath(baseURL, project, "_workitems", "edit", strconv.Itoa(id))
+	return result
 }
 
 func hasTag(tags, want string) bool {

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -143,6 +143,50 @@ func TestGetAcceptsAzureTagCasing(t *testing.T) {
 	}
 }
 
+func TestGetAcceptsClosedAttentionStatus(t *testing.T) {
+	for _, status := range []Status{StatusFailed, StatusCanceled, StatusUncertain} {
+		t.Run(string(status), func(t *testing.T) {
+			snapshot := testSnapshot(status)
+			item := sdkWorkItem(t, 42, 1, snapshot)
+			(*item.Fields)["System.State"] = "Closed"
+			sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+				return item, nil
+			}}
+			client := newTestClient(t, sdk, "test-token")
+			got, err := client.Get(context.Background(), 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.State != "Closed" || got.Snapshot.Status != status {
+				t.Fatalf("work item = %#v", got)
+			}
+		})
+	}
+}
+
+func TestGetRejectsIncompatibleWorkflowState(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status Status
+		state  string
+	}{
+		{name: "closed running", status: StatusRunning, state: "Closed"},
+		{name: "active succeeded", status: StatusSucceeded, state: "Active"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			item := sdkWorkItem(t, 42, 1, testSnapshot(test.status))
+			(*item.Fields)["System.State"] = test.state
+			sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+				return item, nil
+			}}
+			client := newTestClient(t, sdk, "test-token")
+			if _, err := client.Get(context.Background(), 42); err == nil || !strings.Contains(err.Error(), "incompatible") {
+				t.Fatalf("error = %v, want incompatible state error", err)
+			}
+		})
+	}
+}
+
 func TestWorkItemURLUsesBrowserView(t *testing.T) {
 	item := sdkWorkItem(t, 3062459, 1, testSnapshot(StatusRunning))
 	apiURL := "https://devdiv.visualstudio.com/_apis/wit/workItems/3062459"
@@ -205,6 +249,28 @@ func TestUpdateTestsRevisionFirst(t *testing.T) {
 		t.Fatal(err)
 	}
 	if item.Revision != 8 || item.Snapshot.Status != StatusSucceeded {
+		t.Fatalf("updated work item = %#v", item)
+	}
+}
+
+func TestUpdatePreservesClosedAttentionStatus(t *testing.T) {
+	snapshot := testSnapshot(StatusCanceled)
+	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		if args.Document == nil {
+			t.Fatal("update document is nil")
+		}
+		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
+		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.State", "Closed")
+		item := sdkWorkItem(t, 42, 8, snapshot)
+		(*item.Fields)["System.State"] = "Closed"
+		return item, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	item, err := client.Update(context.Background(), &WorkItem{ID: 42, Revision: 7, State: "Closed"}, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.State != "Closed" || item.Snapshot.Status != StatusCanceled {
 		t.Fatalf("updated work item = %#v", item)
 	}
 }

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -115,6 +115,33 @@ func TestGetRejectsMismatchedTestTag(t *testing.T) {
 	}
 }
 
+func TestWorkItemURLUsesBrowserView(t *testing.T) {
+	item := sdkWorkItem(t, 3062459, 1, testSnapshot(StatusRunning))
+	apiURL := "https://devdiv.visualstudio.com/_apis/wit/workItems/3062459"
+	item.Url = &apiURL
+	item.Links = nil
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return item, nil
+	}}
+	client, err := NewClient(Config{
+		BaseURL: "https://dev.azure.com/devdiv", Project: "DEVDIV", WorkItemType: "Issue",
+	}, staticToken("test-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.newClient = func(context.Context) (workItemClient, string, error) {
+		return sdk, "test-token", nil
+	}
+	got, err := client.Get(context.Background(), 3062459)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3062459"
+	if got.URL != want {
+		t.Fatalf("work item URL = %q, want %q", got.URL, want)
+	}
+}
+
 func TestCurrentUser(t *testing.T) {
 	name := "Release Operator"
 	client := newTestClient(t, &fakeClient{}, "test-token")

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -129,6 +129,20 @@ func TestGetAcceptsLegacyTestTag(t *testing.T) {
 	}
 }
 
+func TestGetAcceptsAzureTagCasing(t *testing.T) {
+	snapshot := testSnapshot(StatusStarting)
+	snapshot.Test = true
+	item := sdkWorkItem(t, 42, 1, snapshot)
+	(*item.Fields)["System.Tags"] = "ReleaseAgent; Test; go-images"
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return item, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Get(context.Background(), 42); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWorkItemURLUsesBrowserView(t *testing.T) {
 	item := sdkWorkItem(t, 3062459, 1, testSnapshot(StatusRunning))
 	apiURL := "https://devdiv.visualstudio.com/_apis/wit/workItems/3062459"
@@ -182,7 +196,7 @@ func TestUpdateTestsRevisionFirst(t *testing.T) {
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
 		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.State", "Closed")
-		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; "+TestTag+"; go-images")
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Replace, "/fields/System.Tags", SelectorTag+"; "+TestTag+"; go-images")
 		return sdkWorkItem(t, 42, 8, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -201,7 +201,7 @@ func TestQueryReturnsWIQLOrder(t *testing.T) {
 			if args.Top == nil || *args.Top != 20 || args.Wiql == nil || args.Wiql.Query == nil {
 				t.Fatalf("query args = %#v", args)
 			}
-			for _, clause := range []string{"[System.WorkItemType] = 'Issue'", "[System.AreaPath] = 'DevDiv\\GoLang'", "[System.Tags] CONTAINS 'releaseagent'"} {
+			for _, clause := range []string{"[System.WorkItemType] = 'Issue'", "[System.AreaPath] = 'DevDiv\\GoLang'", "[System.Tags] CONTAINS 'releaseagent'", "[System.State] <> 'Closed'"} {
 				if !strings.Contains(*args.Wiql.Query, clause) {
 					t.Fatalf("WIQL %q does not contain %q", *args.Wiql.Query, clause)
 				}
@@ -216,12 +216,30 @@ func TestQueryReturnsWIQLOrder(t *testing.T) {
 		},
 	}
 	client := newTestClient(t, sdk, "test-token")
-	items, err := client.Query(context.Background(), 20)
+	items, err := client.Query(context.Background(), false, 20)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got := []int{items[0].ID, items[1].ID}; !slices.Equal(got, []int{2, 1}) {
 		t.Fatalf("work item order = %v, want [2 1]", got)
+	}
+}
+
+func TestQueryClosedWorkItems(t *testing.T) {
+	references := []workitemtracking.WorkItemReference{}
+	sdk := &fakeClient{query: func(_ context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+		if args.Wiql == nil || args.Wiql.Query == nil || !strings.Contains(*args.Wiql.Query, "[System.State] = 'Closed'") {
+			t.Fatalf("query args = %#v", args)
+		}
+		return &workitemtracking.WorkItemQueryResult{WorkItems: &references}, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	items, err := client.Query(context.Background(), true, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("items = %#v, want none", items)
 	}
 }
 
@@ -266,6 +284,7 @@ func sdkWorkItem(t *testing.T, id, revision int, snapshot *Snapshot) *workitemtr
 		"System.State":        workItemState(snapshot.Status),
 		"System.AreaPath":     AreaPath,
 		"System.Tags":         "other; " + workItemTags(snapshot),
+		"System.ChangedDate":  "2026-09-09T12:00:00Z",
 		"System.Description":  mustRenderDescription(t, snapshot),
 	}
 	return &workitemtracking.WorkItem{

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -32,7 +33,7 @@ func (f fakeLocationClient) GetConnectionData(ctx context.Context, args location
 type fakeClient struct {
 	create func(context.Context, workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error)
 	get    func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error)
-	gets   func(context.Context, workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error)
+	gets   func(context.Context, workitemtracking.GetWorkItemsBatchArgs) (*[]workitemtracking.WorkItem, error)
 	query  func(context.Context, workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error)
 	update func(context.Context, workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error)
 }
@@ -45,7 +46,7 @@ func (f *fakeClient) GetWorkItem(ctx context.Context, args workitemtracking.GetW
 	return f.get(ctx, args)
 }
 
-func (f *fakeClient) GetWorkItems(ctx context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+func (f *fakeClient) GetWorkItemsBatch(ctx context.Context, args workitemtracking.GetWorkItemsBatchArgs) (*[]workitemtracking.WorkItem, error) {
 	return f.gets(ctx, args)
 }
 
@@ -60,7 +61,9 @@ func (f *fakeClient) UpdateWorkItem(ctx context.Context, args workitemtracking.U
 func TestCreateUsesFixedMetadata(t *testing.T) {
 	snapshot := testSnapshot(StatusStarting)
 	sdk := &fakeClient{create: func(_ context.Context, args workitemtracking.CreateWorkItemArgs) (*workitemtracking.WorkItem, error) {
-		if args.Project == nil || *args.Project != "project" || args.Type == nil || *args.Type != "Issue" || args.Document == nil {
+		if args.Project == nil || *args.Project != "project" || args.Type == nil || *args.Type != "Issue" || args.Document == nil ||
+			args.Expand == nil || *args.Expand != workitemtracking.WorkItemExpandValues.Links {
+
 			t.Fatalf("create args = %#v", args)
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Add, "/fields/System.Title", "Go images test release")
@@ -187,12 +190,16 @@ func TestGetRejectsIncompatibleWorkflowState(t *testing.T) {
 	}
 }
 
-func TestWorkItemURLUsesBrowserView(t *testing.T) {
+func TestWorkItemURLUsesSDKBrowserLink(t *testing.T) {
 	item := sdkWorkItem(t, 3062459, 1, testSnapshot(StatusRunning))
 	apiURL := "https://devdiv.visualstudio.com/_apis/wit/workItems/3062459"
 	item.Url = &apiURL
-	item.Links = nil
-	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+	const want = "https://dev.azure.com/devdiv/project/_workitems/edit/3062459"
+	item.Links = map[string]any{"html": map[string]any{"href": want}}
+	sdk := &fakeClient{get: func(_ context.Context, args workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		if args.Expand == nil || *args.Expand != workitemtracking.WorkItemExpandValues.Links {
+			t.Fatalf("expand = %v, want Links", args.Expand)
+		}
 		return item, nil
 	}}
 	client, err := NewClient(Config{
@@ -208,9 +215,22 @@ func TestWorkItemURLUsesBrowserView(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const want = "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3062459"
 	if got.URL != want {
 		t.Fatalf("work item URL = %q, want %q", got.URL, want)
+	}
+}
+
+func TestGetRejectsMissingBrowserLink(t *testing.T) {
+	item := sdkWorkItem(t, 42, 1, testSnapshot(StatusRunning))
+	item.Links = nil
+	apiURL := "https://devdiv.visualstudio.com/_apis/wit/workItems/42"
+	item.Url = &apiURL
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return item, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Get(context.Background(), 42); err == nil || !strings.Contains(err.Error(), "browser URL") {
+		t.Fatalf("error = %v, want missing browser URL error", err)
 	}
 }
 
@@ -235,7 +255,9 @@ func TestUpdateTestsRevisionFirst(t *testing.T) {
 	snapshot := testSnapshot(StatusSucceeded)
 	snapshot.Test = true
 	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
-		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 4 {
+		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 4 ||
+			args.Expand == nil || *args.Expand != workitemtracking.WorkItemExpandValues.Links {
+
 			t.Fatalf("update args = %#v", args)
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
@@ -353,8 +375,11 @@ func TestQueryReturnsWIQLOrder(t *testing.T) {
 			}
 			return &workitemtracking.WorkItemQueryResult{WorkItems: &references}, nil
 		},
-		gets: func(_ context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
-			if args.Ids == nil || !slices.Equal(*args.Ids, []int{2, 1}) {
+		gets: func(_ context.Context, args workitemtracking.GetWorkItemsBatchArgs) (*[]workitemtracking.WorkItem, error) {
+			request := args.WorkItemGetRequest
+			if request == nil || request.Ids == nil || !slices.Equal(*request.Ids, []int{2, 1}) ||
+				request.Expand == nil || *request.Expand != workitemtracking.WorkItemExpandValues.Links {
+
 				t.Fatalf("get work items args = %#v", args)
 			}
 			return &responses, nil
@@ -434,7 +459,7 @@ func sdkWorkItem(t *testing.T, id, revision int, snapshot *Snapshot) *workitemtr
 	}
 	return &workitemtracking.WorkItem{
 		Id: &id, Rev: &revision, Fields: &fields,
-		Links: map[string]any{"html": map[string]any{"href": "https://example.invalid/workitems/42"}},
+		Links: map[string]any{"html": map[string]any{"href": fmt.Sprintf("https://example.invalid/workitems/%d", id)}},
 	}
 }
 

--- a/cmd/releaseagent/internal/azdoworkitem/client_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/client_test.go
@@ -65,7 +65,7 @@ func TestCreateUsesFixedMetadata(t *testing.T) {
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Add, "/fields/System.Title", "Go images test release")
 		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.AreaPath", AreaPath)
-		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag)
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; go-images")
 		assertPatch(t, *args.Document, 3, webapi.OperationValues.Add, "/fields/System.AssignedTo", "Release Operator")
 		assertPatch(t, *args.Document, 4, webapi.OperationValues.Add, "/fields/System.State", "Active")
 		assertPatch(t, *args.Document, 5, webapi.OperationValues.Add, "/fields/System.Description", mustRenderDescription(t, snapshot))
@@ -88,7 +88,7 @@ func TestCreateAddsTestTag(t *testing.T) {
 		if args.Document == nil {
 			t.Fatal("create document is nil")
 		}
-		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; "+TestTag)
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; "+TestTag+"; go-images")
 		return sdkWorkItem(t, 42, 1, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
@@ -112,6 +112,20 @@ func TestGetRejectsMismatchedTestTag(t *testing.T) {
 	client := newTestClient(t, sdk, "test-token")
 	if _, err := client.Get(context.Background(), 42); err == nil || !strings.Contains(err.Error(), "test tag") {
 		t.Fatalf("error = %v, want mismatched test tag error", err)
+	}
+}
+
+func TestGetAcceptsLegacyTestTag(t *testing.T) {
+	snapshot := testSnapshot(StatusStarting)
+	snapshot.Test = true
+	item := sdkWorkItem(t, 42, 1, snapshot)
+	(*item.Fields)["System.Tags"] = SelectorTag + "; " + legacyTestTag
+	sdk := &fakeClient{get: func(context.Context, workitemtracking.GetWorkItemArgs) (*workitemtracking.WorkItem, error) {
+		return item, nil
+	}}
+	client := newTestClient(t, sdk, "test-token")
+	if _, err := client.Get(context.Background(), 42); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -161,12 +175,14 @@ func TestCurrentUser(t *testing.T) {
 
 func TestUpdateTestsRevisionFirst(t *testing.T) {
 	snapshot := testSnapshot(StatusSucceeded)
+	snapshot.Test = true
 	sdk := &fakeClient{update: func(_ context.Context, args workitemtracking.UpdateWorkItemArgs) (*workitemtracking.WorkItem, error) {
-		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 3 {
+		if args.Id == nil || *args.Id != 42 || args.Document == nil || len(*args.Document) != 4 {
 			t.Fatalf("update args = %#v", args)
 		}
 		assertPatch(t, *args.Document, 0, webapi.OperationValues.Test, "/rev", 7)
 		assertPatch(t, *args.Document, 1, webapi.OperationValues.Add, "/fields/System.State", "Closed")
+		assertPatch(t, *args.Document, 2, webapi.OperationValues.Add, "/fields/System.Tags", SelectorTag+"; "+TestTag+"; go-images")
 		return sdkWorkItem(t, 42, 8, snapshot), nil
 	}}
 	client := newTestClient(t, sdk, "test-token")
@@ -176,6 +192,28 @@ func TestUpdateTestsRevisionFirst(t *testing.T) {
 	}
 	if item.Revision != 8 || item.Snapshot.Status != StatusSucceeded {
 		t.Fatalf("updated work item = %#v", item)
+	}
+}
+
+func TestWorkItemTagsIncludeProcess(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		processID string
+		test      bool
+		want      string
+	}{
+		{name: "release", processID: "go-images", want: "releaseagent; go-images"},
+		{name: "test", processID: "go-images", test: true, want: "releaseagent; test; go-images"},
+		{name: "dry run", processID: "go-infra", test: true, want: "releaseagent; test; go-infra"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := testSnapshot(StatusStarting)
+			snapshot.ProcessID = test.processID
+			snapshot.Test = test.test
+			if got := workItemTags(snapshot); got != test.want {
+				t.Fatalf("work item tags = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot.go
@@ -118,12 +118,41 @@ func RenderDescription(snapshot *Snapshot) (string, error) {
 		return "", err
 	}
 	encoded := base64.RawURLEncoding.EncodeToString(data)
-	description := "<p>Managed by releaseagent. Add operator notes as comments.</p><pre>" +
-		descriptionMarker + encoded + "</pre>"
+	releaseType := "Release"
+	if snapshot.Test {
+		releaseType = "Test / dry run"
+	}
+	description := "<h3>Release status</h3><table><tbody>" +
+		"<tr><td><strong>Process</strong></td><td><code>" + snapshot.ProcessID + "</code></td></tr>" +
+		"<tr><td><strong>Execution</strong></td><td>" + statusLabel(snapshot.Status) + "</td></tr>" +
+		"<tr><td><strong>Type</strong></td><td>" + releaseType + "</td></tr>" +
+		"</tbody></table>" +
+		"<p>Releaseagent manages this state. Add operator notes as comments.</p>" +
+		"<details><summary>Managed state</summary><p>Do not edit this value directly.</p><pre>" +
+		descriptionMarker + encoded + "</pre></details>"
 	if len(description) > MaxDescriptionSize {
 		return "", fmt.Errorf("release description exceeds %d characters", MaxDescriptionSize)
 	}
 	return description, nil
+}
+
+func statusLabel(status Status) string {
+	switch status {
+	case StatusStarting:
+		return "Starting"
+	case StatusRunning:
+		return "In progress"
+	case StatusSucceeded:
+		return "Succeeded"
+	case StatusFailed:
+		return "Failed"
+	case StatusCanceled:
+		return "Canceled"
+	case StatusUncertain:
+		return "Needs attention"
+	default:
+		return string(status)
+	}
 }
 
 // ParseDescription decodes the releaseagent snapshot embedded in an HTML Description field.

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -18,6 +20,7 @@ const (
 	MaxSnapshotSize      = 512 << 10
 	MaxDescriptionSize   = 1_000_000
 	descriptionMarker    = "releaseagent-state-v1:"
+	maxDescriptionFields = 16
 )
 
 var processIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
@@ -36,12 +39,27 @@ const (
 // Snapshot is the process-neutral envelope stored in a release work item.
 // Process-specific validation remains with the owning release process.
 type Snapshot struct {
-	SchemaVersion int             `json:"schemaVersion"`
-	ProcessID     string          `json:"processId"`
-	Status        Status          `json:"status"`
-	Test          bool            `json:"test,omitempty"`
-	IntentDigest  string          `json:"intentDigest"`
-	Payload       json.RawMessage `json:"payload"`
+	SchemaVersion int                 `json:"schemaVersion"`
+	ProcessID     string              `json:"processId"`
+	Status        Status              `json:"status"`
+	Test          bool                `json:"test,omitempty"`
+	IntentDigest  string              `json:"intentDigest"`
+	Payload       json.RawMessage     `json:"payload"`
+	Description   *DescriptionSummary `json:"-"`
+}
+
+// DescriptionSummary contains derived display data for the work item Description field.
+// It is validated but deliberately excluded from the authoritative snapshot JSON.
+type DescriptionSummary struct {
+	ProcessName string
+	Fields      []DescriptionField
+}
+
+// DescriptionField is one human-readable value, optionally linked to its source.
+type DescriptionField struct {
+	Label string
+	Value string
+	URL   string
 }
 
 func (s *Snapshot) Validate() error {
@@ -65,6 +83,9 @@ func (s *Snapshot) Validate() error {
 	if _, err := hex.DecodeString(s.IntentDigest); err != nil {
 		return errors.New("release intent digest must be hexadecimal")
 	}
+	if err := s.Description.validate(); err != nil {
+		return err
+	}
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(s.Payload, &payload); err != nil || payload == nil {
 		return errors.New("release payload must be a JSON object")
@@ -75,6 +96,33 @@ func (s *Snapshot) Validate() error {
 	}
 	if len(data) > MaxSnapshotSize {
 		return fmt.Errorf("release snapshot exceeds %d bytes", MaxSnapshotSize)
+	}
+	return nil
+}
+
+func (summary *DescriptionSummary) validate() error {
+	if summary == nil {
+		return nil
+	}
+	if name := strings.TrimSpace(summary.ProcessName); name == "" || len(name) > 100 {
+		return errors.New("release description process name is invalid")
+	}
+	if len(summary.Fields) > maxDescriptionFields {
+		return fmt.Errorf("release description has more than %d fields", maxDescriptionFields)
+	}
+	for _, field := range summary.Fields {
+		label := strings.TrimSpace(field.Label)
+		value := strings.TrimSpace(field.Value)
+		if label == "" || len(label) > 100 || value == "" || len(value) > 2048 {
+			return errors.New("release description field is invalid")
+		}
+		if field.URL == "" {
+			continue
+		}
+		parsed, err := url.Parse(field.URL)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || len(field.URL) > 2048 {
+			return fmt.Errorf("release description field %q has an invalid URL", label)
+		}
 	}
 	return nil
 }
@@ -122,18 +170,48 @@ func RenderDescription(snapshot *Snapshot) (string, error) {
 	if snapshot.Test {
 		releaseType = "Test / dry run"
 	}
-	description := "<h3>Release status</h3><table><tbody>" +
-		"<tr><td><strong>Process</strong></td><td><code>" + snapshot.ProcessID + "</code></td></tr>" +
-		"<tr><td><strong>Execution</strong></td><td>" + statusLabel(snapshot.Status) + "</td></tr>" +
-		"<tr><td><strong>Type</strong></td><td>" + releaseType + "</td></tr>" +
-		"</tbody></table>" +
-		"<p>Releaseagent manages this state. Add operator notes as comments.</p>" +
-		"<details><summary>Managed state</summary><p>Do not edit this value directly.</p><pre>" +
-		descriptionMarker + encoded + "</pre></details>"
-	if len(description) > MaxDescriptionSize {
+	processName := snapshot.ProcessID
+	if snapshot.Description != nil {
+		processName = snapshot.Description.ProcessName
+	}
+	var description strings.Builder
+	description.WriteString("<h2>Release status</h2><table><tbody>")
+	writeDescriptionField(&description, DescriptionField{Label: "Process", Value: processName})
+	writeDescriptionField(&description, DescriptionField{Label: "Status", Value: statusLabel(snapshot.Status)})
+	writeDescriptionField(&description, DescriptionField{Label: "Type", Value: releaseType})
+	if snapshot.Description != nil {
+		for _, field := range snapshot.Description.Fields {
+			writeDescriptionField(&description, field)
+		}
+	}
+	description.WriteString("</tbody></table>")
+	description.WriteString("<p>Releaseagent manages this state. Add operator notes as comments.</p>")
+	description.WriteString("<details><summary>Managed state</summary><p>Do not edit this value directly.</p><pre>")
+	description.WriteString(descriptionMarker)
+	description.WriteString(encoded)
+	description.WriteString("</pre></details>")
+	result := description.String()
+	if len(result) > MaxDescriptionSize {
 		return "", fmt.Errorf("release description exceeds %d characters", MaxDescriptionSize)
 	}
-	return description, nil
+	return result, nil
+}
+
+func writeDescriptionField(description *strings.Builder, field DescriptionField) {
+	description.WriteString("<tr><td><strong>")
+	description.WriteString(html.EscapeString(strings.TrimSpace(field.Label)))
+	description.WriteString("</strong></td><td>")
+	value := html.EscapeString(strings.TrimSpace(field.Value))
+	if field.URL != "" {
+		description.WriteString(`<a href="`)
+		description.WriteString(html.EscapeString(field.URL))
+		description.WriteString(`">`)
+		description.WriteString(value)
+		description.WriteString("</a>")
+	} else {
+		description.WriteString(value)
+	}
+	description.WriteString("</td></tr>")
 }
 
 func statusLabel(status Status) string {

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot.go
@@ -63,6 +63,11 @@ type DescriptionField struct {
 }
 
 func (s *Snapshot) Validate() error {
+	_, err := MarshalSnapshot(s)
+	return err
+}
+
+func (s *Snapshot) validateStructure() error {
 	if s == nil {
 		return errors.New("release snapshot is nil")
 	}
@@ -89,13 +94,6 @@ func (s *Snapshot) Validate() error {
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(s.Payload, &payload); err != nil || payload == nil {
 		return errors.New("release payload must be a JSON object")
-	}
-	data, err := json.Marshal(s)
-	if err != nil {
-		return fmt.Errorf("marshal release snapshot: %w", err)
-	}
-	if len(data) > MaxSnapshotSize {
-		return fmt.Errorf("release snapshot exceeds %d bytes", MaxSnapshotSize)
 	}
 	return nil
 }
@@ -129,12 +127,15 @@ func (summary *DescriptionSummary) validate() error {
 
 // MarshalSnapshot validates and returns the canonical JSON representation of a snapshot.
 func MarshalSnapshot(snapshot *Snapshot) ([]byte, error) {
-	if err := snapshot.Validate(); err != nil {
+	if err := snapshot.validateStructure(); err != nil {
 		return nil, err
 	}
 	data, err := json.Marshal(snapshot)
 	if err != nil {
 		return nil, fmt.Errorf("marshal release snapshot: %w", err)
+	}
+	if len(data) > MaxSnapshotSize {
+		return nil, fmt.Errorf("release snapshot exceeds %d bytes", MaxSnapshotSize)
 	}
 	return data, nil
 }

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
@@ -82,6 +82,15 @@ func TestDescriptionRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	for _, text := range []string{
+		"<strong>Process</strong>", "<code>go-images</code>",
+		"<strong>Execution</strong>", "In progress",
+		"<strong>Type</strong>", "Release", "<summary>Managed state</summary>",
+	} {
+		if !strings.Contains(description, text) {
+			t.Fatalf("description does not contain %q: %q", text, description)
+		}
+	}
 	if strings.Contains(description, `{"buildId"`) || !strings.Contains(description, descriptionMarker) {
 		t.Fatalf("description does not use encoded transport: %q", description)
 	}
@@ -99,6 +108,23 @@ func TestDescriptionRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(gotJSON, wantJSON) {
 		t.Fatalf("snapshot = %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func TestDescriptionLabelsTestRun(t *testing.T) {
+	description, err := RenderDescription(&Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		ProcessID:     "go-infra",
+		Status:        StatusUncertain,
+		Test:          true,
+		IntentDigest:  testDigest,
+		Payload:       json.RawMessage(`{"action":"manual-dispatch"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(description, "Test / dry run") || !strings.Contains(description, "Needs attention") {
+		t.Fatalf("description = %q", description)
 	}
 }
 

--- a/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
+++ b/cmd/releaseagent/internal/azdoworkitem/snapshot_test.go
@@ -77,15 +77,24 @@ func TestDescriptionRoundTrip(t *testing.T) {
 		Status:        StatusRunning,
 		IntentDigest:  testDigest,
 		Payload:       json.RawMessage(`{"buildId":"42","html":"<unsafe>"}`),
+		Description: &DescriptionSummary{
+			ProcessName: "Go images <release>",
+			Fields: []DescriptionField{
+				{Label: "Versions", Value: "1.26.8-1, 1.27.1-2"},
+				{Label: "Azure build", Value: "3072236 & details", URL: "https://example.invalid/build?id=3072236&view=results"},
+			},
+		},
 	}
 	description, err := RenderDescription(want)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, text := range []string{
-		"<strong>Process</strong>", "<code>go-images</code>",
-		"<strong>Execution</strong>", "In progress",
+		"<strong>Process</strong>", "Go images &lt;release&gt;",
+		"<strong>Status</strong>", "In progress",
 		"<strong>Type</strong>", "Release", "<summary>Managed state</summary>",
+		"1.26.8-1, 1.27.1-2", `href="https://example.invalid/build?id=3072236&amp;view=results"`,
+		"3072236 &amp; details",
 	} {
 		if !strings.Contains(description, text) {
 			t.Fatalf("description does not contain %q: %q", text, description)
@@ -108,6 +117,29 @@ func TestDescriptionRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(gotJSON, wantJSON) {
 		t.Fatalf("snapshot = %s, want %s", gotJSON, wantJSON)
+	}
+	if got.Description != nil {
+		t.Fatalf("parsed snapshot retained non-authoritative description: %#v", got.Description)
+	}
+}
+
+func TestDescriptionRejectsInvalidSummary(t *testing.T) {
+	for _, field := range []DescriptionField{
+		{Label: "", Value: "value"},
+		{Label: "Target", Value: "value", URL: "http://example.invalid"},
+		{Label: "Target", Value: "value", URL: "https://user@example.invalid"},
+	} {
+		snapshot := &Snapshot{
+			SchemaVersion: CurrentSchemaVersion,
+			ProcessID:     "go-images",
+			Status:        StatusRunning,
+			IntentDigest:  testDigest,
+			Payload:       json.RawMessage(`{"buildId":"42"}`),
+			Description:   &DescriptionSummary{ProcessName: "Go images", Fields: []DescriptionField{field}},
+		}
+		if _, err := RenderDescription(snapshot); err == nil {
+			t.Fatalf("invalid description field unexpectedly rendered: %#v", field)
+		}
 	}
 }
 

--- a/cmd/releaseagent/internal/goimagesexecution/service.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service.go
@@ -289,7 +289,7 @@ func (s *Service) PollPipeline(ctx context.Context, buildID string) error {
 			if build.WebURL != "" {
 				failure += ". Inspect the Azure run: " + build.WebURL
 			}
-			return errors.New(failure)
+			return &goimagesworkflow.PipelineResultError{Result: string(state), Err: errors.New(failure)}
 		case azdopipeline.RunStateWaiting, azdopipeline.RunStateRunning:
 			s.reportPipelineProgress(ctx, id, state)
 			if err := s.sleep(ctx, s.config.PollInterval); err != nil {

--- a/cmd/releaseagent/internal/goimagesexecution/service_test.go
+++ b/cmd/releaseagent/internal/goimagesexecution/service_test.go
@@ -261,10 +261,26 @@ func TestPollPipelineReportsFailure(t *testing.T) {
 	}}}
 	service := newTestService(t, reader, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeNormal})
 	err := service.PollPipeline(context.Background(), strconv.Itoa(888))
+	var resultError *goimagesworkflow.PipelineResultError
 	if err == nil || !strings.Contains(err.Error(), "Build > Linux arm32 > Build Images: PowerShell exited with code 1") ||
-		!strings.Contains(err.Error(), "https://example/build/888") || reader.failureGets != 1 {
+		!strings.Contains(err.Error(), "https://example/build/888") || reader.failureGets != 1 ||
+		!errors.As(err, &resultError) || resultError.Result != "failed" {
 
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPollPipelineReportsCancellation(t *testing.T) {
+	reader := &fakeReader{builds: []*azdopipeline.Build{{
+		ID: 888, DefinitionID: goimagesworkflow.DefinitionID, Status: "completed", Result: "canceled", WebURL: "https://example/build/888",
+	}}}
+	service := newTestService(t, reader, &fakeQueueClient{}, Config{Mode: goimagesworkflow.ModeTest})
+	err := service.PollPipeline(context.Background(), "888")
+	var resultError *goimagesworkflow.PipelineResultError
+	if err == nil || !errors.As(err, &resultError) || resultError.Result != "canceled" ||
+		!strings.Contains(err.Error(), "go-images release build 888 canceled") || reader.failureGets != 0 {
+
+		t.Fatalf("error = %v, result error = %#v", err, resultError)
 	}
 }
 

--- a/cmd/releaseagent/internal/goimagesworkflow/workflow.go
+++ b/cmd/releaseagent/internal/goimagesworkflow/workflow.go
@@ -7,6 +7,7 @@ package goimagesworkflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"regexp"
@@ -65,6 +66,20 @@ type Service interface {
 	PollMirror(context.Context, string) error
 	QueuePipeline(context.Context, map[string]string) (string, error)
 	PollPipeline(context.Context, string) error
+}
+
+// PipelineResultError reports a known terminal pipeline outcome.
+type PipelineResultError struct {
+	Result string
+	Err    error
+}
+
+func (e *PipelineResultError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PipelineResultError) Unwrap() error {
+	return e.Err
 }
 
 // CheckpointFunc durably records State. The state pointer is valid only during the call.
@@ -212,6 +227,19 @@ func NewGraphWithCheckpoint(
 			}
 			buildID := stateValue(access, func(state *State) string { return state.BuildID })
 			if err := service.PollPipeline(ctx, buildID); err != nil {
+				var resultError *PipelineResultError
+				if !errors.As(err, &resultError) {
+					return err
+				}
+				if resultError.Result != "failed" && resultError.Result != "canceled" {
+					return fmt.Errorf("invalid terminal pipeline result %q: %w", resultError.Result, err)
+				}
+				if checkpointErr := access.update(ctx, func(state *State) {
+					state.Complete = true
+					state.Result = resultError.Result
+				}); checkpointErr != nil {
+					return errors.Join(err, fmt.Errorf("checkpoint terminal pipeline result: %w", checkpointErr))
+				}
 				return err
 			}
 			return access.update(ctx, func(state *State) {

--- a/cmd/releaseagent/internal/goimagesworkflow/workflow_test.go
+++ b/cmd/releaseagent/internal/goimagesworkflow/workflow_test.go
@@ -21,6 +21,7 @@ var testInput = &Input{
 
 type fakeService struct {
 	mirrorErr error
+	pollErr   error
 	mirrors   int
 	queues    int
 	polls     int
@@ -47,7 +48,7 @@ func (service *fakeService) PollPipeline(_ context.Context, buildID string) erro
 	if buildID != "888" {
 		return errors.New("unexpected build ID")
 	}
-	return nil
+	return service.pollErr
 }
 
 func TestPipelineParameters(t *testing.T) {
@@ -113,6 +114,48 @@ func TestGraphCheckpointsQueueAndCompletion(t *testing.T) {
 		checkpoints[1].BuildID != "888" || checkpoints[1].Complete {
 
 		t.Fatalf("checkpoints = %#v", checkpoints)
+	}
+}
+
+func TestGraphCheckpointsTerminalPipelineResult(t *testing.T) {
+	for _, result := range []string{"failed", "canceled"} {
+		t.Run(result, func(t *testing.T) {
+			terminalErr := errors.New("pipeline " + result)
+			service := &fakeService{pollErr: &PipelineResultError{Result: result, Err: terminalErr}}
+			var checkpoint State
+			steps, state, err := NewGraphWithCheckpoint(testInput, nil, service, func(_ context.Context, state *State) error {
+				checkpoint = *state
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var runner coordinator.StepRunner
+			if err := runner.Execute(context.Background(), steps); !errors.Is(err, terminalErr) {
+				t.Fatalf("error = %v, want %v", err, terminalErr)
+			}
+			if !state.Complete || state.Result != result || !checkpoint.Complete || checkpoint.Result != result {
+				t.Fatalf("state = %#v, checkpoint = %#v", state, checkpoint)
+			}
+		})
+	}
+}
+
+func TestGraphLeavesTransientPollFailureIncomplete(t *testing.T) {
+	pollErr := errors.New("pipeline read unavailable")
+	service := &fakeService{pollErr: pollErr}
+	steps, state, err := NewGraphWithCheckpoint(testInput, nil, service, func(context.Context, *State) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var runner coordinator.StepRunner
+	if err := runner.Execute(context.Background(), steps); !errors.Is(err, pollErr) {
+		t.Fatalf("error = %v, want %v", err, pollErr)
+	}
+	if state.Complete || state.Result != "" {
+		t.Fatalf("state = %#v, want resumable incomplete state", state)
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/go_images_execution.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_execution.go
@@ -22,6 +22,9 @@ import (
 
 func (s *Server) goImagesExecutionResponseLocked() executionResponse {
 	result := executionResponse{Enabled: s.execution != nil}
+	if s.goImages.record != nil {
+		result.WorkItem = &workItemReference{ID: s.goImages.record.WorkItemID, URL: s.goImages.record.URL}
+	}
 	if s.goImages.document == nil || s.goImages.workflowInput == nil || len(s.steps) == 0 {
 		return result
 	}

--- a/cmd/releaseagent/internal/releaseui/go_images_execution.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_execution.go
@@ -86,6 +86,10 @@ func (s *Server) restoreSession() error {
 	if err != nil {
 		return fmt.Errorf("load release work item %d: %w", s.goImagesWorkItemID, err)
 	}
+	return s.restoreGoImagesSession(record)
+}
+
+func (s *Server) restoreGoImagesSession(record *GoImagesSessionRecord) error {
 	document := record.Document
 	input := document.Input
 	state := document.State

--- a/cmd/releaseagent/internal/releaseui/go_images_execution.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_execution.go
@@ -33,7 +33,7 @@ func (s *Server) goImagesExecutionResponseLocked() executionResponse {
 		BuildID: state.BuildID, Result: state.Result, Complete: state.Complete,
 	}
 	if result.Run.BuildID != "" {
-		result.Run.URL = "https://dev.azure.com/dnceng/internal/_build/results?buildId=" + result.Run.BuildID
+		result.Run.URL = goImagesBuildURL(result.Run.BuildID)
 		result.Run.LinkLabel = "Open Azure DevOps run " + result.Run.BuildID
 	}
 	if !result.Enabled {

--- a/cmd/releaseagent/internal/releaseui/go_images_execution.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_execution.go
@@ -30,7 +30,7 @@ func (s *Server) goImagesExecutionResponseLocked() executionResponse {
 	}
 	state := s.goImages.document.State
 	result.Run = pipelineRun{
-		BuildID: state.BuildID, Complete: state.Complete,
+		BuildID: state.BuildID, Result: state.Result, Complete: state.Complete,
 	}
 	if result.Run.BuildID != "" {
 		result.Run.URL = "https://dev.azure.com/dnceng/internal/_build/results?buildId=" + result.Run.BuildID

--- a/cmd/releaseagent/internal/releaseui/go_images_plan.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_plan.go
@@ -160,9 +160,9 @@ func (s *Server) goImagesPlanResponseLocked(restored bool) planResponse {
 	if s.goImages.document != nil {
 		state := s.goImages.document.State
 		if state.Complete {
-			for i := range steps {
-				steps[i].Status = "succeeded"
-			}
+			setPlanStepStatus(steps, "Verify go-images commit is mirrored internally", "succeeded")
+			setPlanStepStatus(steps, "🚀 Queue go-images release", "succeeded")
+			setPlanStepStatus(steps, "⌚ Wait for go-images release", state.Result)
 		} else if state.BuildID != "" {
 			setPlanStepStatus(steps, "Verify go-images commit is mirrored internally", "succeeded")
 			setPlanStepStatus(steps, "🚀 Queue go-images release", "succeeded")

--- a/cmd/releaseagent/internal/releaseui/go_images_store.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_store.go
@@ -1,12 +1,10 @@
 package releaseui
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -174,14 +172,9 @@ func goImagesSessionRecord(workItem *azdoworkitem.WorkItem) (*GoImagesSessionRec
 	if workItem == nil || workItem.Snapshot == nil {
 		return nil, errors.New("release work item is empty")
 	}
-	decoder := json.NewDecoder(bytes.NewReader(workItem.Snapshot.Payload))
-	decoder.DisallowUnknownFields()
-	var document goimagessession.Document
-	if err := decoder.Decode(&document); err != nil {
+	document, err := decodeStrictJSON[goimagessession.Document](workItem.Snapshot.Payload)
+	if err != nil {
 		return nil, fmt.Errorf("decode go-images session: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, errors.New("decode go-images session: trailing JSON content")
 	}
 	if err := document.Validate(); err != nil {
 		return nil, fmt.Errorf("validate go-images session: %w", err)

--- a/cmd/releaseagent/internal/releaseui/go_images_store.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_store.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagessession"
@@ -110,7 +112,62 @@ func goImagesSnapshot(document *goimagessession.Document) (*azdoworkitem.Snapsho
 		Test:          document.Input.Mode == goimagesworkflow.ModeTest,
 		IntentDigest:  document.ExecutionDigest,
 		Payload:       payload,
+		Description:   goImagesDescription(document),
 	}, nil
+}
+
+func goImagesDescription(document *goimagessession.Document) *azdoworkitem.DescriptionSummary {
+	publication := "public/"
+	if document.Input.Mode == goimagesworkflow.ModeTest {
+		publication = "dev/"
+	}
+	fields := []azdoworkitem.DescriptionField{
+		{Label: "Mode", Value: goImagesModeName(document.Input.Mode)},
+		{Label: "Versions", Value: strings.Join(document.Input.Versions, ", ")},
+		{Label: "Publication", Value: publication},
+		{
+			Label: "Source commit", Value: document.Input.SourceVersion,
+			URL: "https://dev.azure.com/dnceng/internal/_git/microsoft-go-images/commit/" + url.PathEscape(document.Input.SourceVersion),
+		},
+	}
+	if document.Input.SourceBuildID != "" {
+		fields = append(fields, azdoworkitem.DescriptionField{
+			Label: "Source build", Value: document.Input.SourceBuildID,
+			URL: goImagesBuildURL(document.Input.SourceBuildID),
+		})
+	}
+	if document.State.BuildID != "" {
+		fields = append(fields, azdoworkitem.DescriptionField{
+			Label: "Azure build", Value: document.State.BuildID,
+			URL: goImagesBuildURL(document.State.BuildID),
+		})
+	}
+	fields = append(fields,
+		azdoworkitem.DescriptionField{Label: "Created", Value: formatWorkItemTime(document.CreatedAt)},
+		azdoworkitem.DescriptionField{Label: "Last checkpoint", Value: formatWorkItemTime(document.UpdatedAt)},
+	)
+	return &azdoworkitem.DescriptionSummary{ProcessName: "Go images", Fields: fields}
+}
+
+func goImagesModeName(mode goimagesworkflow.Mode) string {
+	switch mode {
+	case goimagesworkflow.ModeNormal:
+		return "Normal"
+	case goimagesworkflow.ModeRollback:
+		return "Rollback / republish"
+	case goimagesworkflow.ModeTest:
+		return "Test"
+	default:
+		return string(mode)
+	}
+}
+
+func goImagesBuildURL(buildID string) string {
+	return "https://dev.azure.com/dnceng/internal/_build/results?buildId=" + url.QueryEscape(buildID)
+}
+
+func formatWorkItemTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02 15:04:05 UTC")
 }
 
 func goImagesSessionRecord(workItem *azdoworkitem.WorkItem) (*GoImagesSessionRecord, error) {

--- a/cmd/releaseagent/internal/releaseui/go_images_store_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_store_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
-	"github.com/microsoft/go-infra/cmd/releaseagent/internal/coordinator"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagessession"
 	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagesworkflow"
 )
@@ -123,12 +122,11 @@ func testGoImagesDocumentMode(t *testing.T, mode goimagesworkflow.Mode) *goimage
 	if mode == goimagesworkflow.ModeRollback {
 		input.SourceBuildID = "3019035"
 	}
-	state, err := goimagesworkflow.NewState(input)
+	steps, state, err := goimagesworkflow.NewGraphWithCheckpoint(input, nil, disabledGoImagesService{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	step := coordinator.NewRootStep("Test release", time.Minute, func(context.Context) error { return nil })
-	document, err := goimagessession.NewDocument(input, state, []*coordinator.Step{step}, time.Now())
+	document, err := goimagessession.NewDocument(input, state, steps, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/releaseagent/internal/releaseui/go_images_store_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_images_store_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -84,6 +85,25 @@ func TestGoImagesWorkItemStoreRoundTrip(t *testing.T) {
 		client.item.Snapshot.Status != azdoworkitem.StatusSucceeded {
 
 		t.Fatalf("updated = %#v, snapshot = %#v", updated, client.item.Snapshot)
+	}
+	description, err := azdoworkitem.RenderDescription(client.item.Snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{
+		"<strong>Process</strong></td><td>Go images",
+		"<strong>Status</strong></td><td>Succeeded",
+		"<strong>Mode</strong></td><td>Normal",
+		"<strong>Versions</strong></td><td>1.26.5-2",
+		"<strong>Publication</strong></td><td>public/",
+		"microsoft-go-images/commit/" + testSourceCommit,
+		`_build/results?buildId=888">888</a>`,
+		"<strong>Created</strong>",
+		"<strong>Last checkpoint</strong>",
+	} {
+		if !strings.Contains(description, text) {
+			t.Fatalf("description does not contain %q: %s", text, description)
+		}
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/go_infra_process.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_process.go
@@ -4,12 +4,10 @@
 package releaseui
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"reflect"
 	"strconv"
 )
@@ -320,17 +318,4 @@ func goInfraProcessView(payload goInfraProcessPayload) ProcessPlanView {
 		}
 	}
 	return view
-}
-
-func decodeStrictJSON[T any](data json.RawMessage) (T, error) {
-	var value T
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&value); err != nil {
-		return value, fmt.Errorf("decode process data: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return value, errors.New("process data must contain exactly one JSON value")
-	}
-	return value, nil
 }

--- a/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
+++ b/cmd/releaseagent/internal/releaseui/go_infra_recovery_test.go
@@ -34,7 +34,8 @@ func TestInterruptedGoInfraRunRestoresUncertain(t *testing.T) {
 	var restored processRunResponse
 	decodeResponse(t, response, &restored)
 	if response.StatusCode != http.StatusOK || !restored.Execution.Run.Complete || len(restored.Steps) != 1 ||
-		restored.Steps[0].Status != "failed" {
+		restored.Steps[0].Status != "failed" || restored.Execution.WorkItem == nil ||
+		restored.Execution.WorkItem.ID != workItemID {
 
 		t.Fatalf("restored = %#v", restored)
 	}

--- a/cmd/releaseagent/internal/releaseui/process_execution.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution.go
@@ -485,6 +485,9 @@ func (s *Server) processRunResponseLocked() processRunResponse {
 	execution := executionResponse{
 		Enabled: true, Eligible: run.Digest != "", PlanDigest: run.Digest,
 	}
+	if s.processRunRecord != nil {
+		execution.WorkItem = &workItemReference{ID: s.processRunRecord.WorkItemID, URL: s.processRunRecord.URL}
+	}
 	if run.Started {
 		reference := run.Target
 		if run.External != nil {

--- a/cmd/releaseagent/internal/releaseui/process_execution.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution.go
@@ -495,7 +495,7 @@ func (s *Server) processRunResponseLocked() processRunResponse {
 		}
 		execution.Run = pipelineRun{
 			BuildID: reference.ID, URL: reference.URL, LinkLabel: reference.LinkLabel,
-			Complete: run.Complete,
+			Result: run.Result, Complete: run.Complete,
 		}
 	}
 	return processRunResponse{

--- a/cmd/releaseagent/internal/releaseui/process_execution.go
+++ b/cmd/releaseagent/internal/releaseui/process_execution.go
@@ -424,6 +424,10 @@ func (s *Server) restoreProcessRun() error {
 	if err != nil {
 		return fmt.Errorf("load release work item %d: %w", s.processRunItemID, err)
 	}
+	return s.restoreProcessRunRecord(record)
+}
+
+func (s *Server) restoreProcessRunRecord(record *ProcessRunRecord) error {
 	run := record.Run
 	executor, ok := s.processExecutors[run.ProcessID]
 	if !ok {
@@ -435,10 +439,11 @@ func (s *Server) restoreProcessRun() error {
 	if run.Started && !run.Complete && len(run.Checkpoint) == 0 {
 		run.Complete = true
 		run.Result = "uncertain"
-		record, err = s.processRunStore.Update(s.ctx, record, run)
+		updated, err := s.processRunStore.Update(s.ctx, record, run)
 		if err != nil {
 			return fmt.Errorf("mark interrupted process run uncertain: %w", err)
 		}
+		record = updated
 		run = record.Run
 	}
 	s.processRun = run

--- a/cmd/releaseagent/internal/releaseui/process_input.go
+++ b/cmd/releaseagent/internal/releaseui/process_input.go
@@ -84,3 +84,16 @@ func normalizeProcessInputs(inputs []ProcessInput, data json.RawMessage) (json.R
 	}
 	return result, nil
 }
+
+func decodeStrictJSON[T any](data json.RawMessage) (T, error) {
+	var value T
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return value, fmt.Errorf("decode process data: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return value, errors.New("process data must contain exactly one JSON value")
+	}
+	return value, nil
+}

--- a/cmd/releaseagent/internal/releaseui/process_run_store.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store.go
@@ -159,7 +159,39 @@ func processRunSnapshot(run *ProcessRun) (*azdoworkitem.Snapshot, error) {
 		Test:          run.Test,
 		IntentDigest:  run.Digest,
 		Payload:       payload,
+		Description:   processRunDescription(run),
 	}, nil
+}
+
+func processRunDescription(run *ProcessRun) *azdoworkitem.DescriptionSummary {
+	processName := run.ProcessID
+	if run.ProcessID == "go-infra" {
+		processName = "Go infrastructure"
+	}
+	fields := []azdoworkitem.DescriptionField{
+		{Label: "Intent", Value: run.View.IntentTitle},
+		{Label: "Action", Value: run.Step.Name},
+	}
+	for _, fact := range run.View.Facts {
+		value := fact.Value
+		if fact.Detail != "" {
+			value += " · " + fact.Detail
+		}
+		fields = append(fields, azdoworkitem.DescriptionField{Label: fact.Label, Value: value, URL: fact.Href})
+	}
+	fields = append(fields, azdoworkitem.DescriptionField{
+		Label: "Target", Value: strings.TrimPrefix(run.Target.LinkLabel, "Open "), URL: run.Target.URL,
+	})
+	if run.External != nil {
+		value := strings.TrimPrefix(run.External.LinkLabel, "Open ")
+		if run.External.Status != "" {
+			value += " · " + run.External.Status
+		}
+		fields = append(fields, azdoworkitem.DescriptionField{
+			Label: "External run", Value: value, URL: run.External.URL,
+		})
+	}
+	return &azdoworkitem.DescriptionSummary{ProcessName: processName, Fields: fields}
 }
 
 func processRunRecord(workItem *azdoworkitem.WorkItem) (*ProcessRunRecord, error) {

--- a/cmd/releaseagent/internal/releaseui/process_run_store.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store.go
@@ -4,13 +4,11 @@
 package releaseui
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -198,14 +196,9 @@ func processRunRecord(workItem *azdoworkitem.WorkItem) (*ProcessRunRecord, error
 	if workItem == nil || workItem.Snapshot == nil {
 		return nil, errors.New("release work item is empty")
 	}
-	decoder := json.NewDecoder(bytes.NewReader(workItem.Snapshot.Payload))
-	decoder.DisallowUnknownFields()
-	var run ProcessRun
-	if err := decoder.Decode(&run); err != nil {
+	run, err := decodeStrictJSON[ProcessRun](workItem.Snapshot.Payload)
+	if err != nil {
 		return nil, fmt.Errorf("decode process run: %w", err)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, errors.New("decode process run: trailing JSON content")
 	}
 	if err := validateProcessRun(&run); err != nil {
 		return nil, fmt.Errorf("validate process run: %w", err)

--- a/cmd/releaseagent/internal/releaseui/process_run_store_test.go
+++ b/cmd/releaseagent/internal/releaseui/process_run_store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -76,6 +77,11 @@ func TestProcessRunWorkItemStoreRoundTrip(t *testing.T) {
 
 	run.Complete = true
 	run.Result = "succeeded"
+	run.Checkpoint = json.RawMessage(`{"status":"completed"}`)
+	run.External = &ProcessRunReference{
+		ID: "7", URL: "https://example.com/runs/7", LinkLabel: "Open example run 7",
+		Status: "completed", Terminal: true, Succeeded: true,
+	}
 	updated, err := store.Update(context.Background(), record, run)
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +90,22 @@ func TestProcessRunWorkItemStoreRoundTrip(t *testing.T) {
 		client.item.Snapshot.Status != azdoworkitem.StatusSucceeded {
 
 		t.Fatalf("updated = %#v, snapshot = %#v", updated, client.item.Snapshot)
+	}
+	description, err := azdoworkitem.RenderDescription(client.item.Snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, text := range []string{
+		"<strong>Status</strong></td><td>Succeeded",
+		"<strong>Intent</strong></td><td>Run example",
+		"<strong>Action</strong></td><td>Run example",
+		`href="https://example.com/docs">Fixed input</a>`,
+		`href="https://example.com/runs">example runs</a>`,
+		`href="https://example.com/runs/7">example run 7 · completed</a>`,
+	} {
+		if !strings.Contains(description, text) {
+			t.Fatalf("description does not contain %q: %s", text, description)
+		}
 	}
 }
 
@@ -106,6 +128,7 @@ func testProcessRun(t *testing.T) *ProcessRun {
 		View: ProcessPlanView{
 			IntentTitle: "Run example", ExecutionConfirmation: "Confirm example.",
 			ExecutionButtonLabel: "Run example",
+			Facts:                []ProcessPlanFact{{Label: "Input", Value: "Fixed input", Href: "https://example.com/docs"}},
 		},
 		Target: ProcessRunReference{ID: "example", URL: "https://example.com/runs", LinkLabel: "Open example runs"},
 	})

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -51,7 +51,7 @@ type goImagesRuntime struct {
 	restored       bool
 }
 
-// Server hosts a single local release session.
+// Server hosts one local release UI instance.
 type Server struct {
 	ctx              context.Context
 	token            string
@@ -61,12 +61,14 @@ type Server struct {
 	processExecutors map[string]ProcessExecutor
 	processRunStore  ProcessRunStore
 	processRunItemID int
+	workItems        releaseWorkItemService
 
 	sessionStore       GoImagesSessionStore
 	goImagesWorkItemID int
 	readOnly           *GoImagesReadOnlyIntegration
 	execution          *GoImagesExecutionIntegration
 
+	selectionMu       sync.Mutex
 	mu                sync.Mutex
 	goImages          goImagesRuntime
 	steps             []*coordinator.Step
@@ -286,6 +288,9 @@ func (s *Server) Handler() http.Handler {
 	}
 	mux.Handle("GET /assets/", http.StripPrefix("/assets/", http.FileServer(http.FS(assets))))
 	mux.HandleFunc("GET /api/dashboard", s.handleDashboard)
+	mux.HandleFunc("POST /api/release-work-items/{id}/select", s.handleSelectWorkItem)
+	mux.HandleFunc("GET /api/release-work-items/{id}/export", s.handleExportWorkItem)
+	mux.HandleFunc("POST /api/release-work-items/{id}/import", s.handleImportWorkItem)
 	mux.HandleFunc("GET /api/processes/{id}", s.handleProcess)
 	return s.withSecurityHeaders(s.authenticate(mux))
 }
@@ -440,20 +445,23 @@ type executionResponse struct {
 }
 
 type dashboardResponse struct {
-	Ongoing   []releaseSummary `json:"ongoing"`
-	Recent    []releaseSummary `json:"recent"`
-	Processes []processSummary `json:"processes"`
+	Ongoing       []releaseSummary `json:"ongoing"`
+	Recent        []releaseSummary `json:"recent"`
+	Processes     []processSummary `json:"processes"`
+	TrackingError string           `json:"trackingError,omitempty"`
 }
 
 type releaseSummary struct {
-	Mark      string    `json:"mark"`
-	Name      string    `json:"name"`
-	Mode      string    `json:"mode,omitempty"`
-	Status    string    `json:"status"`
-	RunID     string    `json:"runId,omitempty"`
-	RunLabel  string    `json:"runLabel,omitempty"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	Href      string    `json:"href"`
+	Mark        string    `json:"mark"`
+	Name        string    `json:"name"`
+	Mode        string    `json:"mode,omitempty"`
+	Status      string    `json:"status"`
+	RunID       string    `json:"runId,omitempty"`
+	RunLabel    string    `json:"runLabel,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	Href        string    `json:"href"`
+	WorkItemID  int       `json:"workItemId,omitempty"`
+	WorkItemURL string    `json:"workItemUrl,omitempty"`
 }
 
 type processSummary struct {
@@ -500,7 +508,11 @@ func (s *Server) handleProcess(response http.ResponseWriter, request *http.Reque
 	writeJSON(response, http.StatusOK, detail)
 }
 
-func (s *Server) handleDashboard(response http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleDashboard(response http.ResponseWriter, request *http.Request) {
+	if s.workItems != nil {
+		writeJSON(response, http.StatusOK, s.workItemDashboard(request.Context()))
+		return
+	}
 	s.mu.Lock()
 	result := dashboardResponse{
 		Ongoing:   make([]releaseSummary, 0),
@@ -775,7 +787,11 @@ func secureEqual(left, right string) bool {
 }
 
 func decodeJSON(response http.ResponseWriter, request *http.Request, target any) error {
-	request.Body = http.MaxBytesReader(response, request.Body, 64<<10)
+	return decodeJSONLimit(response, request, target, 64<<10)
+}
+
+func decodeJSONLimit(response http.ResponseWriter, request *http.Request, target any, limit int64) error {
+	request.Body = http.MaxBytesReader(response, request.Body, limit)
 	decoder := json.NewDecoder(request.Body)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -433,6 +433,7 @@ type pipelineRun struct {
 	BuildID   string `json:"buildId,omitempty"`
 	URL       string `json:"url,omitempty"`
 	LinkLabel string `json:"linkLabel,omitempty"`
+	Result    string `json:"result,omitempty"`
 	Complete  bool   `json:"complete"`
 }
 
@@ -451,10 +452,11 @@ type executionResponse struct {
 }
 
 type dashboardResponse struct {
-	Ongoing       []releaseSummary `json:"ongoing"`
-	Recent        []releaseSummary `json:"recent"`
-	Processes     []processSummary `json:"processes"`
-	TrackingError string           `json:"trackingError,omitempty"`
+	Ongoing        []releaseSummary `json:"ongoing"`
+	NeedsAttention []releaseSummary `json:"needsAttention"`
+	Recent         []releaseSummary `json:"recent"`
+	Processes      []processSummary `json:"processes"`
+	TrackingError  string           `json:"trackingError,omitempty"`
 }
 
 type releaseSummary struct {
@@ -521,28 +523,30 @@ func (s *Server) handleDashboard(response http.ResponseWriter, request *http.Req
 	}
 	s.mu.Lock()
 	result := dashboardResponse{
-		Ongoing:   make([]releaseSummary, 0),
-		Recent:    make([]releaseSummary, 0),
-		Processes: s.processes.summaries(),
+		Ongoing:        make([]releaseSummary, 0),
+		NeedsAttention: make([]releaseSummary, 0),
+		Recent:         make([]releaseSummary, 0),
+		Processes:      s.processes.summaries(),
 	}
 	if s.goImages.document != nil {
-		summary := s.releaseSummaryLocked()
-		if s.goImages.document.State.Complete {
-			result.Recent = append(result.Recent, summary)
-		} else {
-			result.Ongoing = append(result.Ongoing, summary)
-		}
+		addDashboardRelease(&result, s.releaseSummaryLocked())
 	}
 	if s.processRun != nil {
-		summary := s.processRunSummaryLocked()
-		if s.processRun.Complete {
-			result.Recent = append(result.Recent, summary)
-		} else {
-			result.Ongoing = append(result.Ongoing, summary)
-		}
+		addDashboardRelease(&result, s.processRunSummaryLocked())
 	}
 	s.mu.Unlock()
 	writeJSON(response, http.StatusOK, result)
+}
+
+func addDashboardRelease(result *dashboardResponse, summary releaseSummary) {
+	switch summary.Status {
+	case "succeeded":
+		result.Recent = append(result.Recent, summary)
+	case "failed", "canceled", "uncertain":
+		result.NeedsAttention = append(result.NeedsAttention, summary)
+	default:
+		result.Ongoing = append(result.Ongoing, summary)
+	}
 }
 
 func (s *Server) releaseSummaryLocked() releaseSummary {

--- a/cmd/releaseagent/internal/releaseui/server.go
+++ b/cmd/releaseagent/internal/releaseui/server.go
@@ -436,12 +436,18 @@ type pipelineRun struct {
 	Complete  bool   `json:"complete"`
 }
 
+type workItemReference struct {
+	ID  int    `json:"id"`
+	URL string `json:"url"`
+}
+
 type executionResponse struct {
-	Enabled           bool        `json:"enabled"`
-	Eligible          bool        `json:"eligible"`
-	PlanDigest        string      `json:"planDigest,omitempty"`
-	UnavailableReason string      `json:"unavailableReason,omitempty"`
-	Run               pipelineRun `json:"run"`
+	Enabled           bool               `json:"enabled"`
+	Eligible          bool               `json:"eligible"`
+	PlanDigest        string             `json:"planDigest,omitempty"`
+	UnavailableReason string             `json:"unavailableReason,omitempty"`
+	Run               pipelineRun        `json:"run"`
+	WorkItem          *workItemReference `json:"workItem,omitempty"`
 }
 
 type dashboardResponse struct {

--- a/cmd/releaseagent/internal/releaseui/server_test.go
+++ b/cmd/releaseagent/internal/releaseui/server_test.go
@@ -420,6 +420,7 @@ type fakeExecutionService struct {
 	mode        goimagesworkflow.Mode
 	sourceBuild string
 	mirrorErr   error
+	pollErr     error
 	beforeQueue func()
 }
 
@@ -451,7 +452,7 @@ func (s *fakeExecutionService) PollPipeline(_ context.Context, buildID string) e
 	if buildID != "888" {
 		return errors.New("unexpected build ID")
 	}
-	return nil
+	return s.pollErr
 }
 
 func TestRealReleaseRequiresExactIntent(t *testing.T) {
@@ -533,6 +534,70 @@ func TestRealReleaseRequiresExactIntent(t *testing.T) {
 	decodeResponse(t, response, &dashboard)
 	if len(dashboard.Recent) != 1 || len(dashboard.Ongoing) != 0 {
 		t.Fatalf("dashboard = %#v", dashboard)
+	}
+}
+
+func TestCanceledReleaseMovesToNeedsAttention(t *testing.T) {
+	store := newMemoryGoImagesSessionStore()
+	source := GoImagesSource{Branch: testSourceBranch, Commit: testSourceCommit, Versions: []string{"1.26.5-2"}}
+	service := &fakeExecutionService{
+		mode: goimagesworkflow.ModeTest,
+		pollErr: &goimagesworkflow.PipelineResultError{
+			Result: "canceled", Err: errors.New("pipeline canceled"),
+		},
+	}
+	ui := newTestUI(t,
+		WithSessionStore(store),
+		WithGoImagesReadOnlyIntegration(testReadOnly(&source, nil)),
+		WithGoImagesExecutionIntegration(GoImagesExecutionIntegration{
+			NewService: func(GoImagesExecutionRequest) (goimagesworkflow.Service, error) {
+				return service, nil
+			},
+		}),
+	)
+	plan := createTestPlan(t, ui, `{"mode":"test"}`)
+	body, err := json.Marshal(releaseStartRequest{PlanDigest: plan.Execution.PlanDigest, Confirmed: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := postJSON(t, ui, testGoImagesAPI+"/start", string(body))
+	response.Body.Close()
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("start status = %d", response.StatusCode)
+	}
+	waitForRelease(t, ui)
+
+	persisted := store.latest(t)
+	if !persisted.State.Complete || persisted.State.Result != "canceled" {
+		t.Fatalf("persisted state = %#v", persisted.State)
+	}
+	response, err = ui.client.Get(ui.http.URL + "/api/dashboard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dashboard dashboardResponse
+	decodeResponse(t, response, &dashboard)
+	if len(dashboard.Ongoing) != 0 || len(dashboard.NeedsAttention) != 1 ||
+		dashboard.NeedsAttention[0].Status != "canceled" {
+
+		t.Fatalf("dashboard = %#v", dashboard)
+	}
+	response, err = ui.client.Get(ui.http.URL + testGoImagesAPI + "/plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored planResponse
+	decodeResponse(t, response, &restored)
+	statuses := make(map[string]string)
+	for _, step := range restored.Steps {
+		statuses[step.Name] = step.Status
+	}
+	if statuses["Verify go-images commit is mirrored internally"] != "succeeded" ||
+		statuses["🚀 Queue go-images release"] != "succeeded" ||
+		statuses["⌚ Wait for go-images release"] != "canceled" ||
+		!restored.Execution.Run.Complete || restored.Execution.Run.Result != "canceled" {
+
+		t.Fatalf("restored plan = %#v", restored)
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -4,15 +4,30 @@ const ongoingReleases = document.querySelector("#ongoing-releases");
 const recentSection = document.querySelector("#recent-section");
 const recentReleases = document.querySelector("#recent-releases");
 const processGrid = document.querySelector("#process-grid");
+const trackingError = document.querySelector("#tracking-error");
+const jsonDialog = document.querySelector("#json-dialog");
+const jsonDialogTitle = document.querySelector("#json-dialog-title");
+const jsonEditor = document.querySelector("#json-editor");
+const jsonError = document.querySelector("#json-error");
+const jsonClose = document.querySelector("#json-close");
+const jsonCopy = document.querySelector("#json-copy");
+const jsonSave = document.querySelector("#json-save");
+
+let editingWorkItem = 0;
 
 loadDashboard();
+jsonClose.addEventListener("click", () => jsonDialog.close());
+jsonCopy.addEventListener("click", copyJSON);
+jsonSave.addEventListener("click", saveJSON);
 
 async function loadDashboard() {
   const dashboardState = await requestJSON("/api/dashboard");
-  renderReleases(ongoingReleases, dashboardState.ongoing, "No release work item is currently selected.");
+  renderReleases(ongoingReleases, dashboardState.ongoing, "No active release work items.");
   processGrid.replaceChildren(...dashboardState.processes.map(createProcessCard));
   recentSection.hidden = dashboardState.recent.length === 0;
   renderReleases(recentReleases, dashboardState.recent, "");
+  trackingError.hidden = !dashboardState.trackingError;
+  trackingError.textContent = dashboardState.trackingError || "";
 }
 
 function renderReleases(container, releases, emptyText) {
@@ -51,18 +66,117 @@ function createReleaseCard(release) {
   details.textContent = `Updated ${new Date(release.updatedAt).toLocaleString()}${run}`;
   body.append(top, details);
 
-  const link = document.createElement("a");
-  link.className = "button button-secondary compact-button";
-  link.href = release.href;
-  if (/^https?:/.test(release.href)) {
-    link.target = "_blank";
-    link.rel = "noreferrer";
-    link.textContent = "Open Azure run";
+  const actions = document.createElement("div");
+  actions.className = "release-card-actions";
+  if (release.workItemId) {
+    const workItemLink = document.createElement("a");
+    workItemLink.className = "button button-secondary compact-button";
+    workItemLink.href = release.workItemUrl;
+    workItemLink.target = "_blank";
+    workItemLink.rel = "noreferrer";
+    workItemLink.textContent = `Work item ${release.workItemId}`;
+
+    const edit = document.createElement("button");
+    edit.className = "button button-secondary compact-button";
+    edit.type = "button";
+    edit.textContent = "View JSON";
+    edit.addEventListener("click", () => openJSON(release));
+
+    const resume = document.createElement("button");
+    resume.className = "button button-secondary compact-button";
+    resume.type = "button";
+    const selectLabel = release.status === "succeeded" ? "Inspect" : "Resume";
+    resume.textContent = selectLabel;
+    resume.addEventListener("click", () => selectWorkItem(release, resume, selectLabel));
+    actions.append(workItemLink, edit, resume);
   } else {
+    const link = document.createElement("a");
+    link.className = "button button-secondary compact-button";
+    link.href = release.href;
     link.textContent = "Track release";
+    actions.append(link);
   }
-  card.append(icon, body, link);
+  card.append(icon, body, actions);
   return card;
+}
+
+async function selectWorkItem(release, button, label) {
+  setButtonBusy(button, true, "Opening…");
+  try {
+    const selected = await requestJSON(`/api/release-work-items/${release.workItemId}/select`, {
+      method: "POST",
+      body: "{}",
+    });
+    location.assign(selected.href);
+  } catch (error) {
+    showTrackingError(error.message);
+    setButtonBusy(button, false, label);
+  }
+}
+
+async function openJSON(release) {
+  try {
+    const exported = await requestJSON(`/api/release-work-items/${release.workItemId}/export`);
+    editingWorkItem = release.workItemId;
+    jsonDialogTitle.textContent = `Work item ${release.workItemId} state`;
+    jsonEditor.value = JSON.stringify(exported, null, 2);
+    jsonError.hidden = true;
+    jsonDialog.showModal();
+  } catch (error) {
+    showTrackingError(error.message);
+  }
+}
+
+async function copyJSON() {
+  try {
+    await navigator.clipboard.writeText(jsonEditor.value);
+    setButtonBusy(jsonCopy, true, "Copied");
+    setTimeout(() => setButtonBusy(jsonCopy, false, "Copy JSON"), 900);
+  } catch (error) {
+    showJSONError(error.message);
+  }
+}
+
+async function saveJSON() {
+  let value;
+  try {
+    value = JSON.parse(jsonEditor.value);
+  } catch (error) {
+    showJSONError(`Invalid JSON: ${error.message}`);
+    return;
+  }
+  if (!confirm(`Replace the stored state for work item ${editingWorkItem}?`)) return;
+
+  setButtonBusy(jsonSave, true, "Saving…");
+  try {
+    const updated = await requestJSON(`/api/release-work-items/${editingWorkItem}/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(value),
+    });
+    jsonEditor.value = JSON.stringify(updated, null, 2);
+    jsonDialog.close();
+    await loadDashboard();
+  } catch (error) {
+    showJSONError(error.message);
+  } finally {
+    setButtonBusy(jsonSave, false, "Save repaired state");
+  }
+}
+
+function setButtonBusy(button, busy, text) {
+  button.disabled = busy;
+  button.textContent = text;
+}
+
+function showTrackingError(message) {
+  trackingError.textContent = message;
+  trackingError.hidden = false;
+}
+
+function showJSONError(message) {
+  jsonError.textContent = message;
+  jsonError.hidden = false;
 }
 
 function createProcessCard(process) {
@@ -94,8 +208,8 @@ function statusText(status) {
   return status === "running" ? "in progress" : status;
 }
 
-async function requestJSON(path) {
-  const response = await fetch(path);
+async function requestJSON(path, options = {}) {
+  const response = await fetch(path, options);
   const data = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(data.error || `${response.status} ${response.statusText}`);
   return data;

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const ongoingReleases = document.querySelector("#ongoing-releases");
+const attentionSection = document.querySelector("#attention-section");
+const attentionReleases = document.querySelector("#attention-releases");
 const recentSection = document.querySelector("#recent-section");
 const recentReleases = document.querySelector("#recent-releases");
 const processGrid = document.querySelector("#process-grid");
@@ -22,7 +24,9 @@ jsonSave.addEventListener("click", saveJSON);
 
 async function loadDashboard() {
   const dashboardState = await requestJSON("/api/dashboard");
-  renderReleases(ongoingReleases, dashboardState.ongoing, "No active release work items.");
+  renderReleases(ongoingReleases, dashboardState.ongoing, "No releases are currently in progress.");
+  attentionSection.hidden = dashboardState.needsAttention.length === 0;
+  renderReleases(attentionReleases, dashboardState.needsAttention, "");
   processGrid.replaceChildren(...dashboardState.processes.map(createProcessCard));
   recentSection.hidden = dashboardState.recent.length === 0;
   renderReleases(recentReleases, dashboardState.recent, "");

--- a/cmd/releaseagent/internal/releaseui/web/dashboard.js
+++ b/cmd/releaseagent/internal/releaseui/web/dashboard.js
@@ -82,13 +82,25 @@ function createReleaseCard(release) {
     edit.textContent = "View JSON";
     edit.addEventListener("click", () => openJSON(release));
 
-    const resume = document.createElement("button");
-    resume.className = "button button-secondary compact-button";
-    resume.type = "button";
-    const selectLabel = release.status === "succeeded" ? "Inspect" : "Resume";
-    resume.textContent = selectLabel;
-    resume.addEventListener("click", () => selectWorkItem(release, resume, selectLabel));
-    actions.append(workItemLink, edit, resume);
+    const open = document.createElement("button");
+    open.className = "button button-secondary compact-button";
+    open.type = "button";
+    open.textContent = "Open";
+    const openRelease = () => {
+      if (!open.disabled) selectWorkItem(release, open, "Open");
+    };
+    open.addEventListener("click", openRelease);
+    card.classList.add("release-card-selectable");
+    card.tabIndex = 0;
+    card.addEventListener("click", (event) => {
+      if (!(event.target instanceof Element) || !event.target.closest("a, button")) openRelease();
+    });
+    card.addEventListener("keydown", (event) => {
+      if (event.target !== card || event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      openRelease();
+    });
+    actions.append(workItemLink, edit, open);
   } else {
     const link = document.createElement("a");
     link.className = "button button-secondary compact-button";

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -51,6 +51,17 @@
       <p id="tracking-error" class="tracking-error" hidden></p>
     </section>
 
+    <section id="attention-section" class="dashboard-section" aria-labelledby="attention-title" hidden>
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Operator action</p>
+          <h2 id="attention-title">Needs attention</h2>
+          <p>Inspect a stopped release before deciding what to do next.</p>
+        </div>
+      </div>
+      <div id="attention-releases" class="release-list" aria-live="polite"></div>
+    </section>
+
     <section class="dashboard-section" aria-labelledby="processes-title">
       <div class="section-heading">
         <div>

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -42,12 +42,13 @@
         <div>
           <p class="eyebrow">Live work</p>
           <h2 id="ongoing-title">Ongoing releases</h2>
-          <p>Reopen the currently selected release work item.</p>
+          <p>Select a release work item to inspect or resume.</p>
         </div>
       </div>
       <div id="ongoing-releases" class="release-list" aria-live="polite">
-        <article class="release-empty loading-card">Checking the selected work item…</article>
+        <article class="release-empty loading-card">Loading release work items…</article>
       </div>
+      <p id="tracking-error" class="tracking-error" hidden></p>
     </section>
 
     <section class="dashboard-section" aria-labelledby="processes-title">
@@ -64,7 +65,7 @@
     <section id="recent-section" class="dashboard-section" aria-labelledby="recent-title" hidden>
       <div class="section-heading">
         <div>
-          <p class="eyebrow">This session</p>
+          <p class="eyebrow">Release history</p>
           <h2 id="recent-title">Recently completed</h2>
         </div>
       </div>
@@ -72,5 +73,22 @@
     </section>
 
   </main>
+
+  <dialog id="json-dialog" class="json-dialog">
+    <div class="json-dialog-heading">
+      <div>
+        <p class="eyebrow">Manual repair</p>
+        <h2 id="json-dialog-title">Release state JSON</h2>
+      </div>
+      <button id="json-close" class="dialog-close" type="button" aria-label="Close JSON editor">×</button>
+    </div>
+    <label for="json-editor">Work item export</label>
+    <textarea id="json-editor" spellcheck="false"></textarea>
+    <p id="json-error" class="tracking-error" hidden></p>
+    <div class="json-dialog-actions">
+      <button id="json-copy" class="button button-secondary" type="button">Copy JSON</button>
+      <button id="json-save" class="button button-danger" type="button">Save repaired state</button>
+    </div>
+  </dialog>
 </body>
 </html>

--- a/cmd/releaseagent/internal/releaseui/web/index.html
+++ b/cmd/releaseagent/internal/releaseui/web/index.html
@@ -42,7 +42,7 @@
         <div>
           <p class="eyebrow">Live work</p>
           <h2 id="ongoing-title">Ongoing releases</h2>
-          <p>Select a release work item to inspect or resume.</p>
+          <p>Select a release work item to open its release page.</p>
         </div>
       </div>
       <div id="ongoing-releases" class="release-list" aria-live="polite">

--- a/cmd/releaseagent/internal/releaseui/web/process.html
+++ b/cmd/releaseagent/internal/releaseui/web/process.html
@@ -111,7 +111,10 @@
             <svg id="step-edges" class="step-graph-edges" aria-hidden="true"></svg>
             <div id="step-list" class="step-graph-list" role="list"></div>
           </div>
-          <a id="pipeline-run-link" class="pipeline-run-link" target="_blank" rel="noreferrer" hidden></a>
+          <div id="execution-links" class="execution-links" hidden>
+            <a id="work-item-link" class="execution-link" target="_blank" rel="noreferrer" hidden></a>
+            <a id="pipeline-run-link" class="execution-link" target="_blank" rel="noreferrer" hidden></a>
+          </div>
 
           <section id="execution-controls" class="execution-controls" hidden>
             <p class="eyebrow">External execution</p>

--- a/cmd/releaseagent/internal/releaseui/web/styles.css
+++ b/cmd/releaseagent/internal/releaseui/web/styles.css
@@ -212,8 +212,9 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .pipeline-parameters dt { color: #8cabc5; background: rgb(18 42 64 / 72%); }
 .pipeline-parameters dd { color: var(--text); background: rgb(6 17 30 / 65%); }
 .pipeline-parameters > :nth-last-child(-n+2) { border-bottom: 0; }
-.pipeline-run-link { display: flex; align-items: center; justify-content: center; min-height: 52px; margin-top: 16px; padding: 0 18px; border: 1px solid rgb(57 213 255 / 45%); border-radius: 11px; background: rgb(57 213 255 / 12%); color: var(--cyan); font-size: 14px; font-weight: 800; text-align: center; text-decoration: none; }
-.pipeline-run-link:hover { background: rgb(57 213 255 / 18%); border-color: var(--cyan); }
+.execution-links { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr)); gap: 10px; margin-top: 16px; }
+.execution-link { display: flex; align-items: center; justify-content: center; min-height: 52px; padding: 0 18px; border: 1px solid rgb(57 213 255 / 45%); border-radius: 11px; background: rgb(57 213 255 / 12%); color: var(--cyan); font-size: 14px; font-weight: 800; text-align: center; text-decoration: none; }
+.execution-link:hover { background: rgb(57 213 255 / 18%); border-color: var(--cyan); }
 .demo-unavailable { margin: 14px 0; padding: 11px 13px; border: 1px solid rgb(255 197 92 / 34%); border-radius: 10px; background: rgb(255 197 92 / 8%); color: var(--yellow); font-size: 10px; line-height: 1.5; }
 
 .step-graph-viewport { position: relative; min-height: 210px; max-height: 760px; margin: 0; overflow: auto; border: 1px solid var(--border); border-radius: 14px; background: radial-gradient(circle at 50% 50%, rgb(31 66 91 / 18%), transparent 70%), rgb(5 16 29 / 42%); }
@@ -264,6 +265,9 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .release-empty { padding: 23px; border: 1px dashed var(--border); border-radius: 14px; color: var(--muted); background: rgb(5 16 29 / 32%); font-size: 14px; text-align: center; }
 .loading-card { animation: gentle-pulse 1.6s ease-in-out infinite; }
 .release-card { display: flex; align-items: center; gap: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 14px; background: rgb(6 18 32 / 58%); }
+.release-card-selectable { cursor: pointer; }
+.release-card-selectable:hover { border-color: var(--cyan); }
+.release-card-selectable:focus-visible { outline: 2px solid var(--cyan); outline-offset: 2px; }
 .release-icon, .process-mark, .release-product-mark { display: grid; flex: 0 0 auto; place-items: center; border-radius: 12px; background: linear-gradient(145deg, var(--cyan), #2588f2); color: #03101b; font-weight: 900; }
 .release-icon { width: 42px; height: 42px; font-size: 11px; }
 .release-card-body { min-width: 0; flex: 1; }

--- a/cmd/releaseagent/internal/releaseui/web/styles.css
+++ b/cmd/releaseagent/internal/releaseui/web/styles.css
@@ -32,7 +32,7 @@ body {
   min-height: 100vh;
 }
 
-button, input, textarea { font: inherit; }
+button, input, textarea, dialog { font: inherit; }
 button { color: inherit; }
 
 .topbar {
@@ -271,6 +271,15 @@ input:focus, textarea:focus { border-color: var(--cyan-deep); box-shadow: 0 0 0 
 .release-card-title strong { font-size: 15px; }
 .release-card-body p { margin: 6px 0 0; color: var(--muted); font-size: 13px; }
 .compact-button { min-height: 34px; padding: 0 12px; text-decoration: none; }
+.release-card-actions { display: flex; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+.tracking-error { margin: 12px 0 0; padding: 11px 13px; border: 1px solid rgb(255 123 135 / 34%); border-radius: 8px; background: rgb(255 123 135 / 8%); color: #ffd1d6; font-size: 12px; line-height: 1.5; }
+.json-dialog { width: min(880px, calc(100vw - 32px)); max-height: calc(100vh - 48px); padding: 22px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); box-shadow: var(--shadow); }
+.json-dialog::backdrop { background: rgb(0 0 0 / 68%); }
+.json-dialog-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
+.json-dialog-heading h2 { margin: 0; font-size: 20px; }
+.dialog-close { width: 36px; height: 36px; padding: 0; border: 1px solid var(--border); border-radius: 6px; background: var(--surface-soft); color: var(--muted); cursor: pointer; font-size: 22px; }
+.json-dialog textarea { min-height: min(52vh, 540px); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; tab-size: 2; }
+.json-dialog-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 14px; }
 .process-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
 .process-card { position: relative; min-height: 236px; padding: 21px; overflow: hidden; border: 1px solid var(--border); border-radius: 17px; background: linear-gradient(145deg, rgb(13 35 55 / 84%), rgb(6 19 33 / 78%)); color: inherit; text-decoration: none; transition: border-color .18s, transform .18s, background .18s; }
 a.process-card:hover { transform: translateY(-3px); border-color: rgb(57 213 255 / 46%); background: linear-gradient(145deg, rgb(19 51 73 / 90%), rgb(7 23 40 / 84%)); }
@@ -364,7 +373,10 @@ label.mode-card { position: relative; display: grid; grid-template-columns: auto
   .section-heading { align-items: flex-start; flex-direction: column; }
   .section-heading .button { width: 100%; }
   .release-card { align-items: flex-start; flex-wrap: wrap; }
-  .release-card .compact-button { width: 100%; }
+  .release-card-actions { width: 100%; }
+  .release-card .compact-button { flex: 1; }
+  .json-dialog-actions { flex-direction: column; }
+  .json-dialog-actions .button { width: 100%; }
   .release-hero { grid-template-columns: 1fr; }
   .release-product-mark { width: 52px; height: 52px; }
   .source-grid { grid-template-columns: 1fr; }

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -32,6 +32,8 @@
   const stepGraph = document.querySelector("#step-graph");
   const stepEdges = document.querySelector("#step-edges");
   const stepList = document.querySelector("#step-list");
+  const executionLinks = document.querySelector("#execution-links");
+  const workItemLink = document.querySelector("#work-item-link");
   const pipelineRunLink = document.querySelector("#pipeline-run-link");
   const executionControls = document.querySelector("#execution-controls");
   const executionUnavailable = document.querySelector("#execution-unavailable");
@@ -301,7 +303,7 @@
     executionActive = snapshot.active;
     updateSteps(snapshot);
     updateProgress(snapshot);
-    renderRun(nextPlan.execution?.run);
+    renderLinks(nextPlan.execution);
     renderExecution(nextPlan.execution, view);
     updateActionButtons();
   }
@@ -598,15 +600,26 @@
     return status === "running" ? "in progress" : status;
   }
 
-  function renderRun(run) {
+  function renderLinks(execution) {
+    const workItem = execution?.workItem;
+    workItemLink.hidden = !workItem?.id;
+    if (workItem?.id) {
+      workItemLink.href = workItem.url;
+      workItemLink.textContent = `Open work item ${workItem.id} ↗`;
+    } else {
+      workItemLink.removeAttribute("href");
+    }
+
+    const run = execution?.run;
     if (!run?.buildId) {
       pipelineRunLink.hidden = true;
       pipelineRunLink.removeAttribute("href");
-      return;
+    } else {
+      pipelineRunLink.href = run.url;
+      pipelineRunLink.textContent = `${run.linkLabel || `Open external run ${run.buildId}`} ↗ · ${run.complete ? "Completed" : "In progress"}`;
+      pipelineRunLink.hidden = false;
     }
-    pipelineRunLink.href = run.url;
-    pipelineRunLink.textContent = `${run.linkLabel || `Open external run ${run.buildId}`} ↗ · ${run.complete ? "Completed" : "In progress"}`;
-    pipelineRunLink.hidden = false;
+    executionLinks.hidden = workItemLink.hidden && pipelineRunLink.hidden;
   }
 
   function updateActionButtons() {
@@ -666,7 +679,7 @@
       if (!response.ok) throw new Error(latest.error || `${response.status} ${response.statusText}`);
       if (!plan || latest.sessionId !== plan.sessionId) return;
       plan = latest;
-      renderRun(latest.execution?.run);
+      renderLinks(latest.execution);
       renderExecution(latest.execution, latest.view || {});
       updateActionButtons();
     } finally {

--- a/cmd/releaseagent/internal/releaseui/web/workflow.js
+++ b/cmd/releaseagent/internal/releaseui/web/workflow.js
@@ -616,7 +616,12 @@
       pipelineRunLink.removeAttribute("href");
     } else {
       pipelineRunLink.href = run.url;
-      pipelineRunLink.textContent = `${run.linkLabel || `Open external run ${run.buildId}`} ↗ · ${run.complete ? "Completed" : "In progress"}`;
+      const outcome = run.complete
+        ? run.result === "failed" ? "Failed"
+          : run.result === "canceled" ? "Canceled"
+            : run.result === "uncertain" ? "Needs attention" : "Completed"
+        : "In progress";
+      pipelineRunLink.textContent = `${run.linkLabel || `Open external run ${run.buildId}`} ↗ · ${outcome}`;
       pipelineRunLink.hidden = false;
     }
     executionLinks.hidden = workItemLink.hidden && pipelineRunLink.hidden;

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -1,0 +1,318 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package releaseui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/coordinator"
+)
+
+const (
+	dashboardActiveLimit = 50
+	dashboardRecentLimit = 10
+)
+
+type releaseWorkItemService interface {
+	releaseWorkItemClient
+	Query(context.Context, bool, int) ([]*azdoworkitem.WorkItem, error)
+}
+
+// WithReleaseWorkItems enables shared discovery, selection, and JSON repair routes.
+func WithReleaseWorkItems(workItems releaseWorkItemService) Option {
+	return func(server *Server) {
+		server.workItems = workItems
+	}
+}
+
+type workItemExport struct {
+	ID       int                    `json:"id"`
+	Revision int                    `json:"revision"`
+	URL      string                 `json:"url"`
+	Snapshot *azdoworkitem.Snapshot `json:"snapshot"`
+}
+
+func (s *Server) workItemDashboard(ctx context.Context) dashboardResponse {
+	result := dashboardResponse{
+		Ongoing:   make([]releaseSummary, 0),
+		Recent:    make([]releaseSummary, 0),
+		Processes: s.processes.summaries(),
+	}
+	active, err := s.workItems.Query(ctx, false, dashboardActiveLimit)
+	if err != nil {
+		result.TrackingError = err.Error()
+		return result
+	}
+	recent, err := s.workItems.Query(ctx, true, dashboardRecentLimit)
+	if err != nil {
+		result.TrackingError = err.Error()
+	}
+	items := append(active, recent...)
+	for _, item := range items {
+		summary, err := s.workItemSummary(item)
+		if err != nil {
+			if result.TrackingError == "" {
+				result.TrackingError = err.Error()
+			}
+			continue
+		}
+		if item.Snapshot.Status == azdoworkitem.StatusSucceeded {
+			result.Recent = append(result.Recent, summary)
+		} else {
+			result.Ongoing = append(result.Ongoing, summary)
+		}
+	}
+	return result
+}
+
+func (s *Server) workItemSummary(item *azdoworkitem.WorkItem) (releaseSummary, error) {
+	if item == nil || item.Snapshot == nil {
+		return releaseSummary{}, errors.New("release work item is empty")
+	}
+	summary := releaseSummary{
+		Status:      string(item.Snapshot.Status),
+		UpdatedAt:   item.ChangedAt,
+		WorkItemID:  item.ID,
+		WorkItemURL: item.URL,
+	}
+	if item.Snapshot.ProcessID == goImagesProcessID {
+		record, err := goImagesSessionRecord(item)
+		if err != nil {
+			return releaseSummary{}, err
+		}
+		summary.Mark = "GI"
+		summary.Name = "Go images"
+		summary.Mode = string(record.Document.Input.Mode)
+		summary.RunID = record.Document.State.BuildID
+		summary.RunLabel = "Azure build"
+		summary.Href = processPath(goImagesProcessID)
+		return summary, nil
+	}
+	record, err := processRunRecord(item)
+	if err != nil {
+		return releaseSummary{}, err
+	}
+	definition, ok := s.processes.process(record.Run.ProcessID)
+	if !ok {
+		return releaseSummary{}, fmt.Errorf("release work item %d has unknown process %q", item.ID, record.Run.ProcessID)
+	}
+	summary.Mark = definition.Mark
+	summary.Name = definition.Name
+	summary.Href = processPath(record.Run.ProcessID)
+	summary.RunLabel = "Target"
+	summary.RunID = record.Run.Target.ID
+	if record.Run.External != nil {
+		summary.RunID = record.Run.External.ID
+	}
+	return summary, nil
+}
+
+func (s *Server) handleSelectWorkItem(response http.ResponseWriter, request *http.Request) {
+	if !sameOrigin(request) {
+		writeError(response, http.StatusForbidden, "request origin does not match the release UI")
+		return
+	}
+	id, ok := workItemID(response, request)
+	if !ok {
+		return
+	}
+	if s.workItems == nil {
+		writeError(response, http.StatusServiceUnavailable, "release work item discovery is unavailable")
+		return
+	}
+
+	s.selectionMu.Lock()
+	defer s.selectionMu.Unlock()
+	s.mu.Lock()
+	if s.hasSelectedOrPreparedReleaseLocked() {
+		s.mu.Unlock()
+		writeError(response, http.StatusConflict, "restart without a selected or prepared release before selecting another work item")
+		return
+	}
+	s.mu.Unlock()
+	item, err := s.workItems.Get(request.Context(), id)
+	if err != nil {
+		writeError(response, http.StatusBadGateway, fmt.Sprintf("load release work item: %v", err))
+		return
+	}
+	if item == nil || item.Snapshot == nil {
+		writeError(response, http.StatusBadGateway, "release work item is empty")
+		return
+	}
+	s.mu.Lock()
+	if s.hasSelectedOrPreparedReleaseLocked() {
+		s.mu.Unlock()
+		writeError(response, http.StatusConflict, "a release was prepared while the work item was loading")
+		return
+	}
+	var href string
+	if item.Snapshot.ProcessID == goImagesProcessID {
+		s.goImagesWorkItemID = id
+		var record *GoImagesSessionRecord
+		record, err = goImagesSessionRecord(item)
+		if err == nil {
+			err = s.restoreGoImagesSession(record)
+		}
+		if err == nil {
+			err = s.resumeRestoredMonitoring()
+		}
+		href = processPath(goImagesProcessID)
+	} else {
+		s.processRunItemID = id
+		var record *ProcessRunRecord
+		record, err = processRunRecord(item)
+		if err == nil {
+			err = s.restoreProcessRunRecord(record)
+		}
+		href = processPath(item.Snapshot.ProcessID)
+	}
+	if err != nil {
+		s.clearSelectedReleaseLocked()
+		s.mu.Unlock()
+		writeError(response, http.StatusConflict, fmt.Sprintf("restore release work item: %v", err))
+		return
+	}
+	s.mu.Unlock()
+	writeJSON(response, http.StatusOK, map[string]string{"href": href})
+}
+
+func (s *Server) hasSelectedOrPreparedReleaseLocked() bool {
+	return s.simulationRunning || s.releaseRunning || s.processRunning || len(s.steps) != 0 ||
+		s.goImages.document != nil || s.processRun != nil
+}
+
+func (s *Server) clearSelectedReleaseLocked() {
+	s.activeProcessID = ""
+	s.steps = nil
+	s.runner = &coordinator.StepRunner{}
+	s.goImages = goImagesRuntime{}
+	s.goImagesWorkItemID = 0
+	s.processRun = nil
+	s.processRunRecord = nil
+	s.processRunItemID = 0
+}
+
+func (s *Server) handleExportWorkItem(response http.ResponseWriter, request *http.Request) {
+	id, ok := workItemID(response, request)
+	if !ok {
+		return
+	}
+	if s.workItems == nil {
+		writeError(response, http.StatusServiceUnavailable, "release work item discovery is unavailable")
+		return
+	}
+	item, err := s.workItems.Get(request.Context(), id)
+	if err != nil {
+		writeError(response, http.StatusBadGateway, fmt.Sprintf("load release work item: %v", err))
+		return
+	}
+	writeJSON(response, http.StatusOK, exportWorkItem(item))
+}
+
+func (s *Server) handleImportWorkItem(response http.ResponseWriter, request *http.Request) {
+	if !sameOrigin(request) {
+		writeError(response, http.StatusForbidden, "request origin does not match the release UI")
+		return
+	}
+	id, ok := workItemID(response, request)
+	if !ok {
+		return
+	}
+	if s.workItems == nil {
+		writeError(response, http.StatusServiceUnavailable, "release work item discovery is unavailable")
+		return
+	}
+	var imported workItemExport
+	if err := decodeJSONLimit(response, request, &imported, 2*azdoworkitem.MaxSnapshotSize); err != nil {
+		writeError(response, http.StatusBadRequest, err.Error())
+		return
+	}
+	if imported.ID != id || imported.Revision <= 0 || imported.Snapshot == nil {
+		writeError(response, http.StatusBadRequest, "imported work item identity is invalid")
+		return
+	}
+	if err := imported.Snapshot.Validate(); err != nil {
+		writeError(response, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	s.selectionMu.Lock()
+	defer s.selectionMu.Unlock()
+	s.mu.Lock()
+	selected := s.goImages.record != nil && s.goImages.record.WorkItemID == id ||
+		s.processRunRecord != nil && s.processRunRecord.WorkItemID == id
+	running := s.simulationRunning || s.releaseRunning || s.processRunning
+	s.mu.Unlock()
+	if selected || running {
+		writeError(response, http.StatusConflict, "restart without selecting this work item before importing repaired state")
+		return
+	}
+
+	current, err := s.workItems.Get(request.Context(), id)
+	if err != nil {
+		writeError(response, http.StatusBadGateway, fmt.Sprintf("load release work item: %v", err))
+		return
+	}
+	if current.Revision != imported.Revision {
+		writeError(response, http.StatusConflict, "release work item changed; export it again before importing")
+		return
+	}
+	if current.Snapshot.ProcessID != imported.Snapshot.ProcessID ||
+		current.Snapshot.IntentDigest != imported.Snapshot.IntentDigest {
+
+		writeError(response, http.StatusBadRequest, "import cannot change the release process or immutable intent")
+		return
+	}
+	if err := validateImportedSnapshot(current, imported.Snapshot); err != nil {
+		writeError(response, http.StatusBadRequest, err.Error())
+		return
+	}
+	updated, err := s.workItems.Update(request.Context(), current, imported.Snapshot)
+	if errors.Is(err, azdoworkitem.ErrRevisionConflict) {
+		writeError(response, http.StatusConflict, "release work item changed; export it again before importing")
+		return
+	}
+	if err != nil {
+		writeError(response, http.StatusBadGateway, fmt.Sprintf("update release work item: %v", err))
+		return
+	}
+	writeJSON(response, http.StatusOK, exportWorkItem(updated))
+}
+
+func validateImportedSnapshot(current *azdoworkitem.WorkItem, snapshot *azdoworkitem.Snapshot) error {
+	candidate := *current
+	candidate.State = workItemStateForStatus(snapshot.Status)
+	candidate.Snapshot = snapshot
+	if snapshot.ProcessID == goImagesProcessID {
+		_, err := goImagesSessionRecord(&candidate)
+		return err
+	}
+	_, err := processRunRecord(&candidate)
+	return err
+}
+
+func workItemStateForStatus(status azdoworkitem.Status) string {
+	if status == azdoworkitem.StatusSucceeded {
+		return "Closed"
+	}
+	return "Active"
+}
+
+func exportWorkItem(item *azdoworkitem.WorkItem) workItemExport {
+	return workItemExport{ID: item.ID, Revision: item.Revision, URL: item.URL, Snapshot: item.Snapshot}
+}
+
+func workItemID(response http.ResponseWriter, request *http.Request) (int, bool) {
+	id, err := strconv.Atoi(request.PathValue("id"))
+	if err != nil || id <= 0 {
+		writeError(response, http.StatusBadRequest, "release work item ID must be a positive integer")
+		return 0, false
+	}
+	return id, true
+}

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -63,7 +63,11 @@ func (s *Server) workItemDashboard(ctx context.Context) dashboardResponse {
 			}
 			continue
 		}
-		addDashboardRelease(&result, summary)
+		if item.State == "Closed" {
+			result.Recent = append(result.Recent, summary)
+		} else {
+			addDashboardRelease(&result, summary)
+		}
 	}
 	return result
 }

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -287,10 +287,16 @@ func validateImportedSnapshot(current *azdoworkitem.WorkItem, snapshot *azdowork
 	candidate.State = workItemStateForStatus(snapshot.Status)
 	candidate.Snapshot = snapshot
 	if snapshot.ProcessID == goImagesProcessID {
-		_, err := goImagesSessionRecord(&candidate)
+		record, err := goImagesSessionRecord(&candidate)
+		if err == nil {
+			snapshot.Description = goImagesDescription(record.Document)
+		}
 		return err
 	}
-	_, err := processRunRecord(&candidate)
+	record, err := processRunRecord(&candidate)
+	if err == nil {
+		snapshot.Description = processRunDescription(record.Run)
+	}
 	return err
 }
 

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -127,9 +127,14 @@ func (s *Server) handleSelectWorkItem(response http.ResponseWriter, request *htt
 	s.selectionMu.Lock()
 	defer s.selectionMu.Unlock()
 	s.mu.Lock()
+	if href, selected := s.selectedWorkItemHrefLocked(id); selected {
+		s.mu.Unlock()
+		writeJSON(response, http.StatusOK, map[string]string{"href": href})
+		return
+	}
 	if s.hasSelectedOrPreparedReleaseLocked() {
 		s.mu.Unlock()
-		writeError(response, http.StatusConflict, "restart without a selected or prepared release before selecting another work item")
+		writeError(response, http.StatusConflict, "restart without a selected or prepared release before selecting a different work item")
 		return
 	}
 	s.mu.Unlock()
@@ -143,6 +148,11 @@ func (s *Server) handleSelectWorkItem(response http.ResponseWriter, request *htt
 		return
 	}
 	s.mu.Lock()
+	if href, selected := s.selectedWorkItemHrefLocked(id); selected {
+		s.mu.Unlock()
+		writeJSON(response, http.StatusOK, map[string]string{"href": href})
+		return
+	}
 	if s.hasSelectedOrPreparedReleaseLocked() {
 		s.mu.Unlock()
 		writeError(response, http.StatusConflict, "a release was prepared while the work item was loading")
@@ -177,6 +187,16 @@ func (s *Server) handleSelectWorkItem(response http.ResponseWriter, request *htt
 	}
 	s.mu.Unlock()
 	writeJSON(response, http.StatusOK, map[string]string{"href": href})
+}
+
+func (s *Server) selectedWorkItemHrefLocked(id int) (string, bool) {
+	if s.goImages.record != nil && s.goImages.record.WorkItemID == id {
+		return processPath(goImagesProcessID), true
+	}
+	if s.processRunRecord != nil && s.processRunRecord.WorkItemID == id {
+		return processPath(s.processRunRecord.Run.ProcessID), true
+	}
+	return "", false
 }
 
 func (s *Server) hasSelectedOrPreparedReleaseLocked() bool {

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -308,7 +308,6 @@ func (s *Server) handleImportWorkItem(response http.ResponseWriter, request *htt
 
 func validateImportedSnapshot(current *azdoworkitem.WorkItem, snapshot *azdoworkitem.Snapshot) error {
 	candidate := *current
-	candidate.State = workItemStateForStatus(snapshot.Status)
 	candidate.Snapshot = snapshot
 	if snapshot.ProcessID == goImagesProcessID {
 		record, err := goImagesSessionRecord(&candidate)
@@ -322,13 +321,6 @@ func validateImportedSnapshot(current *azdoworkitem.WorkItem, snapshot *azdowork
 		snapshot.Description = processRunDescription(record.Run)
 	}
 	return err
-}
-
-func workItemStateForStatus(status azdoworkitem.Status) string {
-	if status == azdoworkitem.StatusSucceeded {
-		return "Closed"
-	}
-	return "Active"
 }
 
 func exportWorkItem(item *azdoworkitem.WorkItem) workItemExport {

--- a/cmd/releaseagent/internal/releaseui/work_items.go
+++ b/cmd/releaseagent/internal/releaseui/work_items.go
@@ -40,9 +40,10 @@ type workItemExport struct {
 
 func (s *Server) workItemDashboard(ctx context.Context) dashboardResponse {
 	result := dashboardResponse{
-		Ongoing:   make([]releaseSummary, 0),
-		Recent:    make([]releaseSummary, 0),
-		Processes: s.processes.summaries(),
+		Ongoing:        make([]releaseSummary, 0),
+		NeedsAttention: make([]releaseSummary, 0),
+		Recent:         make([]releaseSummary, 0),
+		Processes:      s.processes.summaries(),
 	}
 	active, err := s.workItems.Query(ctx, false, dashboardActiveLimit)
 	if err != nil {
@@ -62,11 +63,7 @@ func (s *Server) workItemDashboard(ctx context.Context) dashboardResponse {
 			}
 			continue
 		}
-		if item.Snapshot.Status == azdoworkitem.StatusSucceeded {
-			result.Recent = append(result.Recent, summary)
-		} else {
-			result.Ongoing = append(result.Ongoing, summary)
-		}
+		addDashboardRelease(&result, summary)
 	}
 	return result
 }

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -1,0 +1,275 @@
+package releaseui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/azdoworkitem"
+	"github.com/microsoft/go-infra/cmd/releaseagent/internal/goimagessession"
+)
+
+type memoryReleaseWorkItemService struct {
+	mu    sync.Mutex
+	items map[int]*azdoworkitem.WorkItem
+	order []int
+}
+
+func newMemoryReleaseWorkItemService(items ...*azdoworkitem.WorkItem) *memoryReleaseWorkItemService {
+	service := &memoryReleaseWorkItemService{items: make(map[int]*azdoworkitem.WorkItem)}
+	for _, item := range items {
+		service.items[item.ID] = cloneReleaseWorkItem(item)
+		service.order = append(service.order, item.ID)
+	}
+	return service
+}
+
+func (s *memoryReleaseWorkItemService) Create(
+	context.Context,
+	string,
+	string,
+	*azdoworkitem.Snapshot,
+) (*azdoworkitem.WorkItem, error) {
+	return nil, errors.New("unexpected Create call")
+}
+
+func (s *memoryReleaseWorkItemService) Get(_ context.Context, id int) (*azdoworkitem.WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.items[id]
+	if !ok {
+		return nil, fmt.Errorf("work item %d not found", id)
+	}
+	return cloneReleaseWorkItem(item), nil
+}
+
+func (s *memoryReleaseWorkItemService) Update(
+	_ context.Context,
+	current *azdoworkitem.WorkItem,
+	snapshot *azdoworkitem.Snapshot,
+) (*azdoworkitem.WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, ok := s.items[current.ID]
+	if !ok || item.Revision != current.Revision {
+		return nil, azdoworkitem.ErrRevisionConflict
+	}
+	item.Revision++
+	item.ChangedAt = item.ChangedAt.Add(time.Minute)
+	item.State = workItemStateForStatus(snapshot.Status)
+	item.Snapshot = cloneReleaseSnapshot(snapshot)
+	return cloneReleaseWorkItem(item), nil
+}
+
+func (s *memoryReleaseWorkItemService) Query(_ context.Context, closed bool, limit int) ([]*azdoworkitem.WorkItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := make([]*azdoworkitem.WorkItem, 0, len(s.order))
+	for _, id := range s.order {
+		item := s.items[id]
+		if (item.State == "Closed") != closed {
+			continue
+		}
+		items = append(items, cloneReleaseWorkItem(item))
+		if len(items) == limit {
+			break
+		}
+	}
+	return items, nil
+}
+
+func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
+	goImagesDocument := testGoImagesDocument(t)
+	goImagesState := goImagesDocument.State
+	goImagesState.Complete = true
+	goImagesState.Result = "succeeded"
+	var err error
+	goImagesDocument, err = goImagesDocument.WithState(&goImagesState, goImagesDocument.UpdatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	goImagesSnapshot, err := goImagesSnapshot(goImagesDocument)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processRun := testStoredGoInfraRun(
+		t,
+		goInfraPlanInput{Action: goInfraActionManualDispatch, DispatchMode: goInfraDispatchModeDryRun},
+		nil,
+	)
+	processRun.Started = true
+	processSnapshot, err := processRunSnapshot(processRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := newMemoryReleaseWorkItemService(
+		testReleaseWorkItem(2, processSnapshot, time.Date(2026, 9, 9, 13, 0, 0, 0, time.UTC)),
+		testReleaseWorkItem(1, goImagesSnapshot, time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)),
+	)
+	ui := newTestUI(t, WithReleaseWorkItems(service))
+	response, err := ui.client.Get(ui.http.URL + "/api/dashboard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dashboard dashboardResponse
+	decodeResponse(t, response, &dashboard)
+	if response.StatusCode != http.StatusOK || dashboard.TrackingError != "" ||
+		len(dashboard.Ongoing) != 1 || len(dashboard.Recent) != 1 {
+
+		t.Fatalf("dashboard = %#v", dashboard)
+	}
+	if dashboard.Ongoing[0].WorkItemID != 2 || dashboard.Ongoing[0].Status != "starting" ||
+		dashboard.Recent[0].WorkItemID != 1 || dashboard.Recent[0].Status != "succeeded" {
+
+		t.Fatalf("ongoing = %#v, recent = %#v", dashboard.Ongoing, dashboard.Recent)
+	}
+}
+
+func TestSelectReleaseWorkItemRestoresProcess(t *testing.T) {
+	document := testGoImagesDocument(t)
+	snapshot, err := goImagesSnapshot(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := newMemoryReleaseWorkItemService(testReleaseWorkItem(42, snapshot, time.Now().UTC()))
+	store, err := NewGoImagesWorkItemStore(service, "Release Operator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ui := newTestUI(t, WithReleaseWorkItems(service), WithSessionStore(store))
+	response := postJSON(t, ui, "/api/release-work-items/42/select", `{}`)
+	var selected map[string]string
+	decodeResponse(t, response, &selected)
+	if response.StatusCode != http.StatusOK || selected["href"] != "/go-images" {
+		t.Fatalf("status = %d, selected = %#v", response.StatusCode, selected)
+	}
+	response, err = ui.client.Get(ui.http.URL + testGoImagesAPI + "/plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plan planResponse
+	decodeResponse(t, response, &plan)
+	if response.StatusCode != http.StatusOK || plan.SessionID != document.ID {
+		t.Fatalf("status = %d, plan = %#v", response.StatusCode, plan)
+	}
+}
+
+func TestExportImportReleaseWorkItem(t *testing.T) {
+	document := testGoImagesDocument(t)
+	snapshot, err := goImagesSnapshot(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := newMemoryReleaseWorkItemService(testReleaseWorkItem(42, snapshot, time.Now().UTC()))
+	ui := newTestUI(t, WithReleaseWorkItems(service))
+
+	response, err := ui.client.Get(ui.http.URL + "/api/release-work-items/42/export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exported workItemExport
+	decodeResponse(t, response, &exported)
+	if response.StatusCode != http.StatusOK || exported.ID != 42 || exported.Revision != 1 {
+		t.Fatalf("status = %d, export = %#v", response.StatusCode, exported)
+	}
+
+	var repairedDocument goimagessession.Document
+	if err := json.Unmarshal(exported.Snapshot.Payload, &repairedDocument); err != nil {
+		t.Fatal(err)
+	}
+	repairedState := repairedDocument.State
+	repairedState.QueueAttempted = true
+	repaired, err := repairedDocument.WithState(&repairedState, repairedDocument.UpdatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exported.Snapshot.Payload, err = json.Marshal(repaired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response = postJSONValue(t, ui, "/api/release-work-items/42/import", exported)
+	var updated workItemExport
+	decodeResponse(t, response, &updated)
+	if response.StatusCode != http.StatusOK || updated.Revision != 2 {
+		t.Fatalf("status = %d, update = %#v", response.StatusCode, updated)
+	}
+
+	response = postJSONValue(t, ui, "/api/release-work-items/42/import", exported)
+	response.Body.Close()
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("stale import status = %d, want %d", response.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestImportRejectsChangedIntentAndInconsistentStatus(t *testing.T) {
+	document := testGoImagesDocument(t)
+	snapshot, err := goImagesSnapshot(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := newMemoryReleaseWorkItemService(testReleaseWorkItem(42, snapshot, time.Now().UTC()))
+	ui := newTestUI(t, WithReleaseWorkItems(service))
+
+	for _, test := range []struct {
+		name   string
+		change func(*workItemExport)
+	}{
+		{name: "intent", change: func(exported *workItemExport) {
+			exported.Snapshot.IntentDigest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		}},
+		{name: "status", change: func(exported *workItemExport) {
+			exported.Snapshot.Status = azdoworkitem.StatusSucceeded
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			item, err := service.Get(context.Background(), 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			exported := exportWorkItem(item)
+			test.change(&exported)
+			response := postJSONValue(t, ui, "/api/release-work-items/42/import", exported)
+			response.Body.Close()
+			if response.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func postJSONValue(t *testing.T, ui *testUI, path string, value any) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return postJSON(t, ui, path, string(data))
+}
+
+func testReleaseWorkItem(id int, snapshot *azdoworkitem.Snapshot, changedAt time.Time) *azdoworkitem.WorkItem {
+	return &azdoworkitem.WorkItem{
+		ID: id, Revision: 1, URL: fmt.Sprintf("https://example.invalid/workitems/%d", id),
+		Title: fmt.Sprintf("Release %d", id), State: workItemStateForStatus(snapshot.Status),
+		ChangedAt: changedAt, Snapshot: cloneReleaseSnapshot(snapshot),
+	}
+}
+
+func cloneReleaseWorkItem(item *azdoworkitem.WorkItem) *azdoworkitem.WorkItem {
+	clone := *item
+	clone.Snapshot = cloneReleaseSnapshot(item.Snapshot)
+	return &clone
+}
+
+func cloneReleaseSnapshot(snapshot *azdoworkitem.Snapshot) *azdoworkitem.Snapshot {
+	clone := *snapshot
+	clone.Payload = slices.Clone(snapshot.Payload)
+	return &clone
+}
+
+var _ releaseWorkItemService = (*memoryReleaseWorkItemService)(nil)

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -154,7 +154,10 @@ func TestSelectReleaseWorkItemRestoresProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := newMemoryReleaseWorkItemService(testReleaseWorkItem(42, snapshot, time.Now().UTC()))
+	service := newMemoryReleaseWorkItemService(
+		testReleaseWorkItem(42, snapshot, time.Now().UTC()),
+		testReleaseWorkItem(43, snapshot, time.Now().UTC()),
+	)
 	store, err := NewGoImagesWorkItemStore(service, "Release Operator")
 	if err != nil {
 		t.Fatal(err)
@@ -176,6 +179,40 @@ func TestSelectReleaseWorkItemRestoresProcess(t *testing.T) {
 		plan.Execution.WorkItem.ID != 42 || plan.Execution.WorkItem.URL != "https://example.invalid/workitems/42" {
 
 		t.Fatalf("status = %d, plan = %#v", response.StatusCode, plan)
+	}
+	response = postJSON(t, ui, "/api/release-work-items/42/select", `{}`)
+	decodeResponse(t, response, &selected)
+	if response.StatusCode != http.StatusOK || selected["href"] != "/go-images" {
+		t.Fatalf("reopen status = %d, selected = %#v", response.StatusCode, selected)
+	}
+	response = postJSON(t, ui, "/api/release-work-items/43/select", `{}`)
+	response.Body.Close()
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("different work item status = %d, want %d", response.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestSelectedWorkItemHrefLocked(t *testing.T) {
+	server := &Server{
+		goImages: goImagesRuntime{record: &GoImagesSessionRecord{WorkItemID: 42}},
+		processRunRecord: &ProcessRunRecord{
+			WorkItemID: 43,
+			Run:        &ProcessRun{ProcessID: "go-infra"},
+		},
+	}
+	for _, test := range []struct {
+		id   int
+		href string
+		ok   bool
+	}{
+		{id: 42, href: "/go-images", ok: true},
+		{id: 43, href: "/go-infra", ok: true},
+		{id: 44},
+	} {
+		href, ok := server.selectedWorkItemHrefLocked(test.id)
+		if href != test.href || ok != test.ok {
+			t.Fatalf("selectedWorkItemHrefLocked(%d) = %q, %v; want %q, %v", test.id, href, ok, test.href, test.ok)
+		}
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -63,7 +63,7 @@ func (s *memoryReleaseWorkItemService) Update(
 	}
 	item.Revision++
 	item.ChangedAt = item.ChangedAt.Add(time.Minute)
-	item.State = workItemStateForStatus(snapshot.Status)
+	item.State = testWorkItemState(snapshot.Status)
 	item.Snapshot = cloneReleaseSnapshot(snapshot)
 	return cloneReleaseWorkItem(item), nil
 }
@@ -327,9 +327,16 @@ func postJSONValue(t *testing.T, ui *testUI, path string, value any) *http.Respo
 func testReleaseWorkItem(id int, snapshot *azdoworkitem.Snapshot, changedAt time.Time) *azdoworkitem.WorkItem {
 	return &azdoworkitem.WorkItem{
 		ID: id, Revision: 1, URL: fmt.Sprintf("https://example.invalid/workitems/%d", id),
-		Title: fmt.Sprintf("Release %d", id), State: workItemStateForStatus(snapshot.Status),
+		Title: fmt.Sprintf("Release %d", id), State: testWorkItemState(snapshot.Status),
 		ChangedAt: changedAt, Snapshot: cloneReleaseSnapshot(snapshot),
 	}
+}
+
+func testWorkItemState(status azdoworkitem.Status) string {
+	if status == azdoworkitem.StatusSucceeded {
+		return "Closed"
+	}
+	return "Active"
 }
 
 func cloneReleaseWorkItem(item *azdoworkitem.WorkItem) *azdoworkitem.WorkItem {

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,6 +217,20 @@ func TestExportImportReleaseWorkItem(t *testing.T) {
 	decodeResponse(t, response, &updated)
 	if response.StatusCode != http.StatusOK || updated.Revision != 2 {
 		t.Fatalf("status = %d, update = %#v", response.StatusCode, updated)
+	}
+	item, err := service.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Snapshot.Description == nil {
+		t.Fatal("import did not regenerate work item description")
+	}
+	description, err := azdoworkitem.RenderDescription(item.Snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(description, "<strong>Last checkpoint</strong>") {
+		t.Fatalf("description = %s", description)
 	}
 
 	response = postJSONValue(t, ui, "/api/release-work-items/42/import", exported)

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -101,6 +101,8 @@ func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	canceledItem := testReleaseWorkItem(3, canceledSnapshot, time.Date(2026, 9, 9, 14, 0, 0, 0, time.UTC))
+	canceledItem.State = "Closed"
 	goImagesDocument := testGoImagesDocument(t)
 	goImagesState := goImagesDocument.State
 	goImagesState.Complete = true
@@ -124,7 +126,7 @@ func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := newMemoryReleaseWorkItemService(
-		testReleaseWorkItem(3, canceledSnapshot, time.Date(2026, 9, 9, 14, 0, 0, 0, time.UTC)),
+		canceledItem,
 		testReleaseWorkItem(2, processSnapshot, time.Date(2026, 9, 9, 13, 0, 0, 0, time.UTC)),
 		testReleaseWorkItem(1, goImagesSnapshot, time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)),
 	)
@@ -136,13 +138,13 @@ func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
 	var dashboard dashboardResponse
 	decodeResponse(t, response, &dashboard)
 	if response.StatusCode != http.StatusOK || dashboard.TrackingError != "" ||
-		len(dashboard.Ongoing) != 1 || len(dashboard.NeedsAttention) != 1 || len(dashboard.Recent) != 1 {
+		len(dashboard.Ongoing) != 1 || len(dashboard.NeedsAttention) != 0 || len(dashboard.Recent) != 2 {
 
 		t.Fatalf("dashboard = %#v", dashboard)
 	}
 	if dashboard.Ongoing[0].WorkItemID != 2 || dashboard.Ongoing[0].Status != "starting" ||
-		dashboard.NeedsAttention[0].WorkItemID != 3 || dashboard.NeedsAttention[0].Status != "canceled" ||
-		dashboard.Recent[0].WorkItemID != 1 || dashboard.Recent[0].Status != "succeeded" {
+		dashboard.Recent[0].WorkItemID != 3 || dashboard.Recent[0].Status != "canceled" ||
+		dashboard.Recent[1].WorkItemID != 1 || dashboard.Recent[1].Status != "succeeded" {
 
 		t.Fatalf("ongoing = %#v, attention = %#v, recent = %#v", dashboard.Ongoing, dashboard.NeedsAttention, dashboard.Recent)
 	}

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -85,11 +85,25 @@ func (s *memoryReleaseWorkItemService) Query(_ context.Context, closed bool, lim
 }
 
 func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
+	canceledDocument := testGoImagesDocument(t)
+	canceledState := canceledDocument.State
+	canceledState.QueueAttempted = true
+	canceledState.BuildID = "888"
+	canceledState.Complete = true
+	canceledState.Result = "canceled"
+	var err error
+	canceledDocument, err = canceledDocument.WithState(&canceledState, canceledDocument.UpdatedAt.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canceledSnapshot, err := goImagesSnapshot(canceledDocument)
+	if err != nil {
+		t.Fatal(err)
+	}
 	goImagesDocument := testGoImagesDocument(t)
 	goImagesState := goImagesDocument.State
 	goImagesState.Complete = true
 	goImagesState.Result = "succeeded"
-	var err error
 	goImagesDocument, err = goImagesDocument.WithState(&goImagesState, goImagesDocument.UpdatedAt.Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +123,7 @@ func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
 		t.Fatal(err)
 	}
 	service := newMemoryReleaseWorkItemService(
+		testReleaseWorkItem(3, canceledSnapshot, time.Date(2026, 9, 9, 14, 0, 0, 0, time.UTC)),
 		testReleaseWorkItem(2, processSnapshot, time.Date(2026, 9, 9, 13, 0, 0, 0, time.UTC)),
 		testReleaseWorkItem(1, goImagesSnapshot, time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)),
 	)
@@ -120,14 +135,15 @@ func TestDashboardQueriesReleaseWorkItems(t *testing.T) {
 	var dashboard dashboardResponse
 	decodeResponse(t, response, &dashboard)
 	if response.StatusCode != http.StatusOK || dashboard.TrackingError != "" ||
-		len(dashboard.Ongoing) != 1 || len(dashboard.Recent) != 1 {
+		len(dashboard.Ongoing) != 1 || len(dashboard.NeedsAttention) != 1 || len(dashboard.Recent) != 1 {
 
 		t.Fatalf("dashboard = %#v", dashboard)
 	}
 	if dashboard.Ongoing[0].WorkItemID != 2 || dashboard.Ongoing[0].Status != "starting" ||
+		dashboard.NeedsAttention[0].WorkItemID != 3 || dashboard.NeedsAttention[0].Status != "canceled" ||
 		dashboard.Recent[0].WorkItemID != 1 || dashboard.Recent[0].Status != "succeeded" {
 
-		t.Fatalf("ongoing = %#v, recent = %#v", dashboard.Ongoing, dashboard.Recent)
+		t.Fatalf("ongoing = %#v, attention = %#v, recent = %#v", dashboard.Ongoing, dashboard.NeedsAttention, dashboard.Recent)
 	}
 }
 

--- a/cmd/releaseagent/internal/releaseui/work_items_test.go
+++ b/cmd/releaseagent/internal/releaseui/work_items_test.go
@@ -155,7 +155,9 @@ func TestSelectReleaseWorkItemRestoresProcess(t *testing.T) {
 	}
 	var plan planResponse
 	decodeResponse(t, response, &plan)
-	if response.StatusCode != http.StatusOK || plan.SessionID != document.ID {
+	if response.StatusCode != http.StatusOK || plan.SessionID != document.ID || plan.Execution.WorkItem == nil ||
+		plan.Execution.WorkItem.ID != 42 || plan.Execution.WorkItem.URL != "https://example.invalid/workitems/42" {
+
 		t.Fatalf("status = %d, plan = %#v", response.StatusCode, plan)
 	}
 }

--- a/cmd/releaseagent/serve.go
+++ b/cmd/releaseagent/serve.go
@@ -81,6 +81,7 @@ func handleServe(parse subcmd.ParseFunc) error {
 		return err
 	}
 	options := []releaseui.Option{
+		releaseui.WithReleaseWorkItems(workItems),
 		releaseui.WithSessionStore(goImagesStore),
 		releaseui.WithProcessRunStore(processRunStore),
 		releaseui.WithGoInfraGitHubIntegration(releaseui.GoInfraGitHubIntegration{


### PR DESCRIPTION
## Summary

- build the release dashboard from bounded Azure DevOps work-item queries, with ongoing, needs-attention, and recent-history groups
- let operators open or restore an item, follow work-item and external-run links, and export or revision-check repair JSON
- persist failed and canceled pipeline outcomes, accept manually closed terminal items, and keep same-item reopening idempotent
- add useful work-item descriptions plus composable `releaseagent`, conditional `test`, and process tags while reading legacy test tags during migration

The dashboard remains read-only until an item is selected. JSON repair preserves immutable process identity and intent, and every write begins with the expected Azure DevOps revision.

## Stack

4 of 4. Stacked on #600.

## Testing

- `go test -count=1 -race ./cmd/releaseagent/...`
- `go vet ./cmd/releaseagent/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.0 run ./cmd/releaseagent/...`
- desktop and mobile browser checks for dashboard grouping, card navigation, work-item links, selected-release links, terminal outcomes, and JSON repair